### PR TITLE
Upgrade eslint-plugin-amo

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.7.1",
     "eslint-config-amo": "^1.11.0",
-    "eslint-plugin-amo": "^1.10.0",
+    "eslint-plugin-amo": "^1.10.1",
     "jest-enzyme": "^7.0.1",
     "jest-fetch-mock": "^2.1.0",
     "prettier": "1.16.3",

--- a/src/@types/react-diff-view/index.d.ts
+++ b/src/@types/react-diff-view/index.d.ts
@@ -1,5 +1,3 @@
-/* eslint amo/only-tsx-files: 0 */
-
 declare module 'react-diff-view' {
   type ChangeType = 'delete' | 'insert' | 'normal';
 

--- a/src/@types/universal-cookie-express/index.d.ts
+++ b/src/@types/universal-cookie-express/index.d.ts
@@ -1,4 +1,3 @@
-/* eslint amo/only-tsx-files: 0 */
 import { Request } from 'express';
 import Cookies from 'universal-cookie';
 

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,2 +1,2 @@
-/* eslint amo/only-tsx-files: 0, spaced-comment: 0 */
+/* eslint spaced-comment: 0 */
 /// <reference types="react-scripts" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -5262,10 +5262,10 @@ eslint-module-utils@^2.2.0, eslint-module-utils@^2.3.0:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
-eslint-plugin-amo@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-amo/-/eslint-plugin-amo-1.10.0.tgz#5aa76cb207e1bc6df8bdd2cf62d2af07fbe5ebb9"
-  integrity sha512-IkNBSWQUN0jESOhaqXtZj47YX5oI3fjCO5fo6QyxkhGRu9Dz+voKpdx3nDjL36h2jPSdG7Ib/kNbupZxrEtdRQ==
+eslint-plugin-amo@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-amo/-/eslint-plugin-amo-1.10.1.tgz#bba2b8d7a334877761db62b1cadbbab38a717121"
+  integrity sha512-7/wG0ATsOLxOq4sw/9QtR0r/P/Cdi7IktnYZMdQoeGyN+i/LNEsRvSwwN5WfLZ/voJbXOkT5eV/YxIVb/XjNSA==
   dependencies:
     requireindex "~1.1.0"
     string-natural-compare "^2.0.2"


### PR DESCRIPTION
Nothing fancy, just upgrading the eslint-plugin-amo to latest version,
which contains a fix for the `only-tsx-files` rule (to ignore `.d.ts`
files).