### PR TITLE
Fix dev proxy to inject the auth token all the time

### DIFF
--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -132,7 +132,9 @@ export const createServer = ({
           req: http.IncomingMessage & RequestWithCookies,
           res: http.ServerResponse,
         ) => {
-          if (req.url === '/') {
+          const contentType = proxyResponse.headers['content-type'] || '';
+
+          if (contentType.includes('text/html')) {
             // eslint-disable-next-line no-param-reassign
             proxyResponse.headers['cache-control'] = 'private, no-store';
 


### PR DESCRIPTION
Fixes #131 

---

This is required for #130. I cannot find a way to test this part of the server code yet, because the `proxy` call depends on another service. I'll try to get back to that in #133.