### PR TITLE
Add ESLint reporter for jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "stmux": "stmux -nM -t addons-code-manager -e 'error,!0 errors'",
     "storybook": "start-storybook -p 9001 -c stories/setup",
     "storybook-smoke-test": "yarn storybook --smoke-test",
-    "test": "react-scripts test",
+    "test": "react-scripts test --reporters=default --reporters=`pwd`/src/jest-reporters/eslint-check.js",
     "test-ci": "yarn test --coverage && codecov",
     "type-coverage": "type-coverage",
     "typecheck": "tsc"

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "start-local-dev": "yarn build-local-dev-config && yarn start",
     "start-local-prod": "cat .env.common-local > .env.local && yarn start",
     "start-local-stage": "cat .env.common-local .env.stage > .env.local && yarn start",
-    "stmux": "stmux -nM -t addons-code-manager -e 'error,!0 errors'",
+    "stmux": "stmux -nM -t addons-code-manager -e 'error,!0 errors,!no errors'",
     "storybook": "start-storybook -p 9001 -c stories/setup",
     "storybook-smoke-test": "yarn storybook --smoke-test",
     "test": "react-scripts test --reporters=default --reporters=`pwd`/src/jest-reporters/eslint-check.js",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "stmux": "stmux -nM -t addons-code-manager -e 'error,!0 errors,!no errors'",
     "storybook": "start-storybook -p 9001 -c stories/setup",
     "storybook-smoke-test": "yarn storybook --smoke-test",
-    "test": "react-scripts test --reporters=default --reporters=`pwd`/src/jest-reporters/eslint-check.js",
+    "test": "react-scripts test --reporters=default --reporters='<rootDir>/src/jest-reporters/eslint-check.js'",
     "test-ci": "yarn test --coverage && codecov",
     "type-coverage": "type-coverage",
     "typecheck": "tsc"

--- a/src/jest-reporters/eslint-check.js
+++ b/src/jest-reporters/eslint-check.js
@@ -1,0 +1,61 @@
+/* eslint-disable no-console */
+/* eslint-disable amo/only-tsx-files */
+/* eslint-disable @typescript-eslint/no-var-requires */
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { CLIEngine } = require('eslint');
+
+const { getChangedFiles } = require('./utils');
+
+const NO_ESLINT_ENV_VAR = 'NO_ESLINT';
+
+class EslintCheckReporter {
+  constructor() {
+    this.eslint = new CLIEngine();
+    this.eslintOutput = null;
+  }
+
+  isDisabled() {
+    return process.env[NO_ESLINT_ENV_VAR] === '1';
+  }
+
+  async onRunStart() {
+    if (this.isDisabled()) {
+      return;
+    }
+
+    const files = await getChangedFiles();
+
+    if (!files) {
+      throw new Error(`Failed to retrieve files in the eslint check reporter.`);
+    }
+
+    const report = this.eslint.executeOnFiles(files);
+
+    if (report.errorCount === 0 && report.warningCount === 0) {
+      // All good.
+      this.eslintOutput = null;
+    } else {
+      this.eslintOutput = CLIEngine.getFormatter()(report.results);
+    }
+  }
+
+  getLastError() {
+    if (this.isDisabled()) {
+      return undefined;
+    }
+
+    console.log('');
+    if (this.eslintOutput) {
+      console.log(this.eslintOutput);
+      console.log(
+        `Set ${NO_ESLINT_ENV_VAR}=1 in the environment to disable eslint checks`,
+      );
+      return new Error('eslint errors');
+    }
+    console.log('Eslint: no errors 💄 ✨');
+
+    return undefined;
+  }
+}
+
+module.exports = EslintCheckReporter;

--- a/src/jest-reporters/utils.js
+++ b/src/jest-reporters/utils.js
@@ -1,0 +1,47 @@
+/* eslint-disable amo/only-tsx-files */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+const filterFileNamesFromGitStatusOutput = (output) => {
+  const files = output
+    .split('\n')
+    .map((line) => line.trim())
+    // Make sure we ignore deleted files.
+    .filter((line) => !line.startsWith('D'))
+    .map((line) => {
+      // Return the new name of a renamed file.
+      if (line.startsWith('RM')) {
+        return line.substring(line.indexOf('->'));
+      }
+
+      return line;
+    })
+    .map((line) => line.split(' '))
+    // .flatMap()
+    .reduce((chunks, chunk) => chunks.concat(chunk), [])
+    // We assume no filename can be smaller than 3 to filter the short format
+    // statuses: https://git-scm.com/docs/git-status#_short_format.
+    .filter((chunk) => chunk.length > 3)
+    // Allow directories OR JS/JSX/TS/TSX files
+    .filter((filename) => /(\/|\.[tj]sx?)$/.test(filename));
+
+  return files;
+};
+
+const getChangedFiles = async () => {
+  // We use the Porcelain Format Version 1,
+  // See: https://git-scm.com/docs/git-status#_porcelain_format_version_1
+  const { stdout, stderr } = await exec('git status --porcelain=1');
+
+  if (stderr) {
+    return null;
+  }
+
+  return filterFileNamesFromGitStatusOutput(stdout);
+};
+
+module.exports = {
+  filterFileNamesFromGitStatusOutput,
+  getChangedFiles,
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
     "stories"
   ],
   "exclude": [
-    "stories/setup/webpack.config.js"
+    "stories/setup/webpack.config.js",
+    "src/jest-reporters/"
   ]
 }


### PR DESCRIPTION
Fixes #140 

This is just an initial crack at getting this to work. I simply brought a couple of files over from addons-frontend, and added a new yarn command called `test-lint`, which runs the Jest tests and also the ESLint checks.

It's a bit hacky, but the only thing I could get to work, which I picked up from https://github.com/facebook/create-react-app/issues/2474#issuecomment-321837707.

The Jest reporter and utils files are still `js` files, as opposed to `tsx` files, and I guess we'll want to rewrite them as `tsx` files, as long as Jest allows that.

Just submitting this for initial thoughts and feedback.