### PR TITLE
Add loading state

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@types/classnames": "2.2.7",
     "@types/express": "4.16.1",
     "@types/http-proxy": "1.16.2",
     "@types/http-proxy-middleware": "0.19.2",
@@ -16,6 +17,7 @@
     "@types/react-router-dom": "4.3.1",
     "@types/redux-logger": "3.0.6",
     "bootstrap": "4.2.1",
+    "classnames": "2.2.6",
     "express": "4.16.4",
     "history": "4.7.2",
     "http-proxy-middleware": "0.19.1",

--- a/src/components/App/index.spec.tsx
+++ b/src/components/App/index.spec.tsx
@@ -12,6 +12,7 @@ import {
   fakeUser,
   shallowUntilTarget,
 } from '../../test-helpers';
+import Navbar from '../Navbar';
 
 import App, { AppBase } from '.';
 
@@ -42,10 +43,11 @@ describe(__filename, () => {
   };
 
   it('renders without an authentication token', () => {
-    const root = render({ authToken: '' });
+    const root = render({ authToken: null });
 
     expect(root.find(Container)).toHaveClassName(styles.container);
     expect(root.find(`.${styles.content}`)).toHaveLength(1);
+    expect(root.find(Navbar)).toHaveLength(1);
   });
 
   it('renders with an empty authentication token', () => {
@@ -53,12 +55,14 @@ describe(__filename, () => {
 
     expect(root.find(Container)).toHaveClassName(styles.container);
     expect(root.find(`.${styles.content}`)).toHaveLength(1);
+    expect(root.find(Navbar)).toHaveLength(1);
   });
 
   it('displays a loading message until the user profile gets loaded', () => {
     const root = render();
 
     expect(root).toIncludeText('Getting your workspace ready');
+    expect(root.find(Navbar)).toHaveLength(0);
   });
 
   it('dispatches setAuthToken on mount when authToken is valid', () => {

--- a/src/components/App/index.spec.tsx
+++ b/src/components/App/index.spec.tsx
@@ -41,11 +41,24 @@ describe(__filename, () => {
     return root;
   };
 
-  it('renders without crashing', () => {
-    const root = render();
+  it('renders without an authentication token', () => {
+    const root = render({ authToken: '' });
 
     expect(root.find(Container)).toHaveClassName(styles.container);
     expect(root.find(`.${styles.content}`)).toHaveLength(1);
+  });
+
+  it('renders with an empty authentication token', () => {
+    const root = render({ authToken: '' });
+
+    expect(root.find(Container)).toHaveClassName(styles.container);
+    expect(root.find(`.${styles.content}`)).toHaveLength(1);
+  });
+
+  it('displays a loading message until the user profile gets loaded', () => {
+    const root = render();
+
+    expect(root).toIncludeText('Getting your workspace ready');
   });
 
   it('dispatches setAuthToken on mount when authToken is valid', () => {
@@ -69,12 +82,10 @@ describe(__filename, () => {
     expect(dispatch).not.toHaveBeenCalled();
   });
 
-  it('configures 1 route when the user is not logged in', () => {
-    const store = configureStore();
+  it('configures no route when the user is not logged in', () => {
+    const root = render({ authToken: null });
 
-    const root = render({ store });
-
-    expect(root.find(Route)).toHaveLength(1);
+    expect(root.find(Route)).toHaveLength(0);
     expect(root.find(`.${styles.loginMessage}`)).toIncludeText('Please log in');
   });
 

--- a/src/components/App/styles.module.scss
+++ b/src/components/App/styles.module.scss
@@ -1,13 +1,22 @@
 .container {
-  text-align: center;
 }
 
 .content {
   background-color: #282c34;
-  flex-direction: column;
-  padding-top: 20px;
   min-height: 100vh;
+  padding: 15px;
 }
 
-.login-message {
+.isLoading {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  font-size: 1.2em;
+  font-weight: 500;
+  justify-content: center;
+  text-align: center;
+
+  p {
+    margin: 4px auto;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1522,6 +1522,11 @@
   resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.10.tgz#780d552467824be4a241b29510a7873a7432c4a6"
   integrity sha512-fOM/Jhv51iyugY7KOBZz2ThfT1gwvsGCfWxpLpZDgkGjpEO4Le9cld07OdskikLjDUQJ43dzDaVRSFwQlpdqVg==
 
+"@types/classnames@2.2.7":
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.7.tgz#fb68cc9be8487e6ea5b13700e759bfbab7e0fefd"
+  integrity sha512-rzOhiQ55WzAiFgXRtitP/ZUT8iVNyllEpylJ5zHzR4vArUvMB39GTk+Zon/uAM0JxEFAWnwsxC2gH8s+tZ3Myg==
+
 "@types/connect@*":
   version "3.4.32"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.32.tgz#aa0e9616b9435ccad02bc52b5b454ffc2c70ba28"
@@ -3729,7 +3734,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5, classnames@^2.2.6:
+classnames@2.2.6, classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==


### PR DESCRIPTION
Fixes #144

---

As discussed in #134, I added a loading state until the user profile gets loaded. It is only displayed when there is an authentication token, otherwise we see the "please log in" message.

For some reasons, the catch-all route was not working as intended (404). I fixed that but the behavior is different: the "please log in" message has precedence over the 404 (which is ok I believe).

Note: I decided to add this code in `App` so that it is done once for all.

## Screenshots

### Loading

![screen shot 2019-02-05 at 19 17 55](https://user-images.githubusercontent.com/217628/52294908-c33fd480-297a-11e9-9bad-343d623d80cf.png)


### 404

![screen shot 2019-02-05 at 19 15 02](https://user-images.githubusercontent.com/217628/52294757-67754b80-297a-11e9-910e-69b49f5ac3ff.png)

### Please log in

![screen shot 2019-02-05 at 19 14 52](https://user-images.githubusercontent.com/217628/52294759-680de200-297a-11e9-8da7-38d4def7978c.png)

### Browse page

![screen shot 2019-02-05 at 19 14 58](https://user-images.githubusercontent.com/217628/52294758-67754b80-297a-11e9-8ed1-fbfe1a868064.png)