### PR TITLE
Start playing with Treebeard

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-redux": "5.1.1",
     "react-router-dom": "4.3.1",
     "react-scripts": "2.1.3",
+    "react-treebeard": "3.1.0",
     "redux": "4.0.1",
     "redux-devtools-extension": "2.13.8",
     "redux-logger": "3.0.6",

--- a/src/@types/react-treebeard/index.d.ts
+++ b/src/@types/react-treebeard/index.d.ts
@@ -1,0 +1,11 @@
+declare module 'react-treebeard' {
+  type TreebeardProps = {
+    data: object;
+    style?: object;
+  };
+
+  // eslint-disable-next-line no-undef
+  export class Treebeard extends React.Component<TreebeardProps, {}> {}
+}
+
+declare module 'react-treebeard/lib/themes/default';

--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -1,0 +1,100 @@
+import { Entry, buildTreebeardData } from '.';
+
+describe(__filename, () => {
+  describe('buildTreebeardData', () => {
+    it('creates a root node', () => {
+      const name = 'some-name';
+      const entries: Entry[] = [];
+
+      const data = buildTreebeardData(name, entries);
+
+      expect(data).toEqual({
+        name,
+        toggled: true,
+        children: [],
+      });
+    });
+
+    it('converts a non-directory entry to a file node', () => {
+      const name = 'some-name';
+
+      const filename = 'some-filename';
+      const entries = [
+        {
+          depth: 0,
+          directory: false,
+          filename,
+          path: filename,
+        },
+      ];
+
+      const data = buildTreebeardData(name, entries);
+
+      expect(data.children).toEqual([
+        {
+          name: filename,
+        },
+      ]);
+    });
+
+    it('converts a directory entry to a directory node', () => {
+      const name = 'some-name';
+
+      const directory = 'some-directory';
+      const entries = [
+        {
+          depth: 0,
+          directory: true,
+          filename: directory,
+          path: directory,
+        },
+      ];
+
+      const data = buildTreebeardData(name, entries);
+
+      expect(data.children).toEqual([
+        {
+          name: directory,
+          toggled: true,
+          children: [],
+        },
+      ]);
+    });
+
+    it('finds the appropriate node to add a new entry to it', () => {
+      const name = 'some-name';
+
+      const directory = 'parent';
+      const file = 'child';
+
+      const entries = [
+        {
+          depth: 0,
+          directory: true,
+          filename: directory,
+          path: directory,
+        },
+        {
+          depth: 1,
+          directory: false,
+          filename: file,
+          path: `${directory}/${file},`,
+        },
+      ];
+
+      const data = buildTreebeardData(name, entries);
+
+      expect(data.children).toEqual([
+        {
+          name: directory,
+          toggled: true,
+          children: [
+            {
+              name: file,
+            },
+          ],
+        },
+      ]);
+    });
+  });
+});

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -1,0 +1,133 @@
+import * as React from 'react';
+import { Treebeard } from 'react-treebeard';
+
+import treebeardStyle from './treebeard-style';
+
+export type Entry = {
+  depth: number;
+  directory: boolean;
+  filename: string;
+  path: string;
+};
+
+type FileNode = {
+  name: string;
+};
+
+type DirectoryNode = {
+  name: string;
+  toggled: boolean;
+  children: TreeNode[];
+};
+
+type TreeNode = FileNode | DirectoryNode;
+
+export const buildTreebeardData = (
+  versionId: string,
+  entries: Entry[],
+): DirectoryNode => {
+  const root: DirectoryNode = {
+    name: versionId,
+    toggled: true,
+    children: [],
+  };
+
+  // We need to know how depth the tree is because we'll build the Treebeard
+  // tree depth by depth.
+  const maxDepth = entries.reduce((max, entry) => {
+    if (entry.depth > max) {
+      return entry.depth;
+    }
+
+    return max;
+  }, 0);
+
+  let currentDepth = 0;
+  while (currentDepth <= maxDepth) {
+    // We find the entries for the current depth.
+    const currentEntries = entries.filter(
+      // eslint-disable-next-line no-loop-func
+      (entry) => entry.depth === currentDepth,
+    );
+
+    // This is where we create new "nodes" for each entry.
+    // eslint-disable-next-line no-loop-func
+    currentEntries.forEach((entry) => {
+      let currentNode = root;
+
+      if (currentDepth > 0) {
+        // We need to find the current node (directory) to add the current
+        // entry in its children. We do this by splitting the `path` attribute
+        // and visit each node until we reach the desired node.
+        //
+        // This only applies when the current depth is not 0 (a.k.a. the root
+        // directory) because we already know `root`.
+        const parts = entry.path.split('/');
+        // Remove the filename
+        parts.pop();
+
+        for (let i = 0; i < parts.length; i++) {
+          const maybeNode = currentNode.children.find(
+            (child: TreeNode) => child.name === parts[i],
+          ) as DirectoryNode;
+
+          if (maybeNode) {
+            currentNode = maybeNode;
+          }
+
+          // TODO: this should not happen but what if we don't find a node?
+        }
+      }
+
+      // Create a new node.
+      let node: TreeNode = {
+        name: entry.filename,
+      };
+
+      // When the entry is a directory, we create a `DirectoryNode`.
+      if (entry.directory) {
+        node = {
+          ...node,
+          toggled: true,
+          children: [],
+        };
+      }
+
+      currentNode.children.push(node);
+    });
+
+    // To the next depth.
+    currentDepth++;
+  }
+
+  return root;
+};
+
+type PartialExternalVersion = {
+  id: string;
+  file: {
+    entries: Entry[];
+  };
+};
+
+type PublicProps = {
+  response: PartialExternalVersion;
+};
+
+export class FileTreeBase extends React.Component<PublicProps> {
+  render() {
+    const { response } = this.props;
+
+    return (
+      <Treebeard
+        data={buildTreebeardData(
+          response.id,
+          Object.values(response.file.entries),
+        )}
+        style={treebeardStyle}
+      />
+    );
+  }
+}
+
+export default FileTreeBase;

--- a/src/components/FileTree/treebeard-style.tsx
+++ b/src/components/FileTree/treebeard-style.tsx
@@ -1,0 +1,14 @@
+import defaultTheme from 'react-treebeard/lib/themes/default';
+
+export default {
+  ...defaultTheme,
+  tree: {
+    ...defaultTheme.tree,
+    node: {
+      ...defaultTheme.tree.node,
+      // This is required because of a bug in the upstream library, see:
+      // https://github.com/storybooks/react-treebeard/issues/148
+      container: {},
+    },
+  },
+};

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 
 import { createFakeHistory } from '../../test-helpers';
+import configureStore from '../../configureStore';
 
 import Browse from '.';
 
@@ -27,6 +28,7 @@ describe(__filename, () => {
   const render = ({ versionId = '123' } = {}) => {
     const props = {
       ...createFakeRouteComponentProps({ params: { versionId } }),
+      store: configureStore(),
     };
 
     return shallow(<Browse {...props} />);
@@ -37,6 +39,6 @@ describe(__filename, () => {
 
     const root = render({ versionId });
 
-    expect(root).toIncludeText(`Version ID: ${versionId}`);
+    expect(root.dive()).toIncludeText(`Version ID: ${versionId}`);
   });
 });

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -1,20 +1,72 @@
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
+import { connect } from 'react-redux';
+import { Col } from 'react-bootstrap';
+
+import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
+import { ApiState } from '../../reducers/api';
+import { callApi } from '../../api';
+import FileTree from '../../components/FileTree';
 
 type PropsFromRouter = {
   versionId: string;
 };
 
-export class BrowseBase extends React.Component<
-  RouteComponentProps<PropsFromRouter>
-> {
+type PropsFromState = {
+  apiState: ApiState;
+};
+
+/* eslint-disable @typescript-eslint/indent */
+type Props = RouteComponentProps<PropsFromRouter> &
+  PropsFromState &
+  ConnectedReduxProps;
+/* eslint-enable @typescript-eslint/indent */
+
+export class BrowseBase extends React.Component<Props> {
+  state = {
+    response: null,
+  };
+
+  async componentDidMount() {
+    const { apiState, match } = this.props;
+    const { versionId } = match.params;
+
+    const response = await callApi({
+      apiState,
+      endpoint: `/reviewers/browse/${versionId}`,
+    });
+
+    this.setState({ response });
+  }
+
   render() {
+    const { response } = this.state;
+
+    // @ts-ignore
+    const showFileTree = response && !response.error;
+
     return (
-      <div>
-        <p>Version ID: {this.props.match.params.versionId}</p>
-      </div>
+      <React.Fragment>
+        <Col md="3">
+          {showFileTree && (
+            <FileTree
+              // @ts-ignore
+              response={response}
+            />
+          )}
+        </Col>
+        <Col>
+          <p>Version ID: {this.props.match.params.versionId}</p>
+        </Col>
+      </React.Fragment>
     );
   }
 }
 
-export default BrowseBase;
+const mapStateToProps = (state: ApplicationState): PropsFromState => {
+  return {
+    apiState: state.api,
+  };
+};
+
+export default connect(mapStateToProps)(BrowseBase);

--- a/src/pages/Index/index.tsx
+++ b/src/pages/Index/index.tsx
@@ -9,8 +9,8 @@ export class IndexBase extends React.Component<PublicProps> {
       <div>
         <p>
           There is nothing you can do here, but try{' '}
-          <Link to="/en-US/firefox/files/browse/255464/">
-            browsing this Test Add-on 2.0 version.
+          <Link to="/en-US/firefox/files/browse/1541786/">
+            browsing this add-on version.
           </Link>
         </p>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11327,7 +11327,7 @@ react-transition-group@^2.0.0, react-transition-group@^2.5.1:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react-treebeard@^3.1.0:
+react-treebeard@3.1.0, react-treebeard@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/react-treebeard/-/react-treebeard-3.1.0.tgz#e380b9e75f900e538044280ac365d29092583642"
   integrity sha512-u4OEzwZk1Xcxp2s55Ny/Ofp8fHRwlabKOAeGbzQ7XUE9YXFbPj8ajl0FInbXEP4Ys9+E1vHCtgqJ6VBsgbCPVg==


### PR DESCRIPTION
Supports #39 

---

This PR adds:

- `react-treebeard`, the most "okay" react tree library: https://github.com/storybooks/react-treebeard
- a `FileTree` component that renders any tree coming from the browse API

Known limitations:

- the API types are partial
- API errors are not handled at all
- files are not sorted (we should have directories first, then files IMHO)
- I store the response in the component's state until we get a reducer for that (but that's not a lot of code anyway)
- the interface (public props) of the `FileTree` will likely change, in part because the reducer will likely allow this component to be connected (or at least to receive more precise props from the `Browse` component)
- it uses the default style + a fix, but we could make it prettier, later

Use these links to try this patch:

- http://localhost:3000/en-US/firefox/files/browse/1541786/
- http://localhost:3000/en-US/firefox/files/browse/1541520/

## Screenshots

![screen shot 2019-02-06 at 18 18 56](https://user-images.githubusercontent.com/217628/52360226-d1a1f500-2a3b-11e9-9f01-20d3ab82f602.png)
![screen shot 2019-02-06 at 18 18 53](https://user-images.githubusercontent.com/217628/52360227-d1a1f500-2a3b-11e9-9acf-9b2de379ffb5.png)
