### PR TITLE
Add support for query params in callApi

### DIFF
--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -132,6 +132,17 @@ describe(__filename, () => {
         new Error('Unexpected status for GET /: 400'),
       );
     });
+
+    it('accepts query parameters', async () => {
+      const query = { foo: '1', bar: 'abc' };
+
+      await callApiWithDefaultApiState({ endpoint: '/url', query });
+
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/url/?foo=1&bar=abc',
+        expect.any(Object),
+      );
+    });
   });
 
   describe('logOutFromServer', () => {

--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -139,7 +139,7 @@ describe(__filename, () => {
       await callApiWithDefaultApiState({ endpoint: '/url', query });
 
       expect(fetch).toHaveBeenCalledWith(
-        '/api/url/?foo=1&bar=abc',
+        '/api/v4/url/?foo=1&bar=abc',
         expect.any(Object),
       );
     });

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -15,6 +15,7 @@ type CallApiParams = {
   method?: HttpMethod;
   version?: string;
   apiState: ApiState;
+  query?: { [key: string]: string };
 };
 
 type CallApiResponse = object | { error: Error };
@@ -28,6 +29,7 @@ export const callApi = async ({
   endpoint,
   method = HttpMethod.GET,
   version = 'v4',
+  query = {},
 }: CallApiParams): Promise<CallApiResponse> => {
   let adjustedEndpoint = endpoint;
   if (!adjustedEndpoint.startsWith('/')) {
@@ -40,6 +42,14 @@ export const callApi = async ({
   const headers: Headers = {};
   if (apiState.authToken) {
     headers.Authorization = `Bearer ${apiState.authToken}`;
+  }
+
+  if (Object.keys(query).length) {
+    const queryString = Object.keys(query)
+      .map((k) => `${k}=${query[k]}`)
+      .join('&');
+
+    adjustedEndpoint = `${adjustedEndpoint}?${queryString}`;
   }
 
   try {


### PR DESCRIPTION
Fixes #157

---

This PR adds basic support for query parameters.