### PR TITLE
Start playing with Treefold

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-redux": "5.1.1",
     "react-router-dom": "4.3.1",
     "react-scripts": "2.1.4",
+    "react-treefold": "1.0.0",
     "redux": "4.0.1",
     "redux-devtools-extension": "2.13.8",
     "redux-logger": "3.0.6",

--- a/src/@types/react-treefold/index.d.ts
+++ b/src/@types/react-treefold/index.d.ts
@@ -10,7 +10,7 @@ declare module 'react-treefold' {
   };
 
   type TreefoldProps<NodeType> = {
-    nodes: object[];
+    nodes: NodeType[];
     render: (props: TreefoldRenderProps<NodeType>) => React.Node;
   };
 

--- a/src/@types/react-treefold/index.d.ts
+++ b/src/@types/react-treefold/index.d.ts
@@ -1,6 +1,14 @@
 declare module 'react-treefold' {
+  // Based on https://github.com/gnapse/react-treefold/blob/3ae905279010b00ccda727c307cecf65da3bdc0e/src/Node.js#L26-L44
+  type ToggleProps = {
+    onClick: () => void;
+    onKeyDown: () => void;
+    role: string;
+    tabIndex: number;
+  };
+
   export type TreefoldRenderProps<NodeType> = {
-    getToggleProps: () => object;
+    getToggleProps: () => ToggleProps;
     hasChildNodes: boolean;
     isExpanded: boolean;
     isFolder: boolean;

--- a/src/@types/react-treefold/index.d.ts
+++ b/src/@types/react-treefold/index.d.ts
@@ -1,0 +1,21 @@
+declare module 'react-treefold' {
+  export type TreefoldRenderProps<NodeType> = {
+    getToggleProps: () => object;
+    hasChildNodes: boolean;
+    isExpanded: boolean;
+    isFolder: boolean;
+    level: number;
+    node: NodeType;
+    renderChildNodes: () => React.Element;
+  };
+
+  type TreefoldProps<NodeType> = {
+    nodes: object[];
+    render: (props: TreefoldRenderProps<NodeType>) => React.Node;
+  };
+
+  // eslint-disable-next-line no-undef
+  export default class Treefold<NodeType> extends React.Component<
+    TreefoldProps<NodeType>
+  > {}
+}

--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -16,7 +16,7 @@ describe(__filename, () => {
     });
 
     it('converts a non-directory entry to a file node', () => {
-      const name = 'some-name';
+      const versionId = 'some-name';
 
       const filename = 'some-filename';
       const entries = [
@@ -28,7 +28,7 @@ describe(__filename, () => {
         },
       ];
 
-      const data = buildFileTree(name, entries);
+      const data = buildFileTree(versionId, entries);
 
       expect(data.children).toEqual([
         {
@@ -39,7 +39,7 @@ describe(__filename, () => {
     });
 
     it('converts a directory entry to a directory node', () => {
-      const name = 'some-name';
+      const versionId = 'some-name';
 
       const directory = 'some-directory';
       const entries = [
@@ -51,7 +51,7 @@ describe(__filename, () => {
         },
       ];
 
-      const data = buildFileTree(name, entries);
+      const data = buildFileTree(versionId, entries);
 
       expect(data.children).toEqual([
         {
@@ -63,7 +63,7 @@ describe(__filename, () => {
     });
 
     it('finds the appropriate node to add a new entry to it', () => {
-      const name = 'some-name';
+      const versionId = 'some-name';
 
       const directory = 'parent';
       const file = 'child';
@@ -79,11 +79,11 @@ describe(__filename, () => {
           depth: 1,
           directory: false,
           filename: file,
-          path: `${directory}/${file},`,
+          path: `${directory}/${file}`,
         },
       ];
 
-      const data = buildFileTree(name, entries);
+      const data = buildFileTree(versionId, entries);
 
       expect(data.children).toEqual([
         {
@@ -93,6 +93,55 @@ describe(__filename, () => {
             {
               id: entries[1].path,
               name: file,
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('traverses multiple levels to find the right directory', () => {
+      const versionId = 'some-name';
+
+      const directoryName = 'same-file';
+      const fileName = 'same-nfile';
+
+      const entries = [
+        {
+          depth: 0,
+          directory: true,
+          filename: directoryName,
+          path: directoryName,
+        },
+        {
+          depth: 1,
+          directory: true,
+          filename: directoryName,
+          path: `${directoryName}/${directoryName}`,
+        },
+        {
+          depth: 2,
+          directory: false,
+          filename: fileName,
+          path: `${directoryName}/${directoryName}/${fileName}`,
+        },
+      ];
+
+      const data = buildFileTree(versionId, entries);
+
+      expect(data.children).toEqual([
+        {
+          id: entries[0].path,
+          name: directoryName,
+          children: [
+            {
+              id: entries[1].path,
+              name: directoryName,
+              children: [
+                {
+                  id: entries[2].path,
+                  name: fileName,
+                },
+              ],
             },
           ],
         },

--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -1,0 +1,102 @@
+import { Entry, buildFileTree } from '.';
+
+describe(__filename, () => {
+  describe('buildFileTree', () => {
+    it('creates a root node', () => {
+      const versionId = '1234';
+      const entries: Entry[] = [];
+
+      const data = buildFileTree(versionId, entries);
+
+      expect(data).toEqual({
+        id: `root-${versionId}`,
+        name: versionId,
+        children: [],
+      });
+    });
+
+    it('converts a non-directory entry to a file node', () => {
+      const name = 'some-name';
+
+      const filename = 'some-filename';
+      const entries = [
+        {
+          depth: 0,
+          directory: false,
+          filename,
+          path: filename,
+        },
+      ];
+
+      const data = buildFileTree(name, entries);
+
+      expect(data.children).toEqual([
+        {
+          id: entries[0].path,
+          name: filename,
+        },
+      ]);
+    });
+
+    it('converts a directory entry to a directory node', () => {
+      const name = 'some-name';
+
+      const directory = 'some-directory';
+      const entries = [
+        {
+          depth: 0,
+          directory: true,
+          filename: directory,
+          path: directory,
+        },
+      ];
+
+      const data = buildFileTree(name, entries);
+
+      expect(data.children).toEqual([
+        {
+          id: entries[0].path,
+          name: directory,
+          children: [],
+        },
+      ]);
+    });
+
+    it('finds the appropriate node to add a new entry to it', () => {
+      const name = 'some-name';
+
+      const directory = 'parent';
+      const file = 'child';
+
+      const entries = [
+        {
+          depth: 0,
+          directory: true,
+          filename: directory,
+          path: directory,
+        },
+        {
+          depth: 1,
+          directory: false,
+          filename: file,
+          path: `${directory}/${file},`,
+        },
+      ];
+
+      const data = buildFileTree(name, entries);
+
+      expect(data.children).toEqual([
+        {
+          id: entries[0].path,
+          name: directory,
+          children: [
+            {
+              id: entries[1].path,
+              name: file,
+            },
+          ],
+        },
+      ]);
+    });
+  });
+});

--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -1,10 +1,12 @@
-import { Entry, buildFileTree } from '.';
+import { Version, VersionEntryType } from '../../reducers/versions';
+
+import { buildFileTree } from '.';
 
 describe(__filename, () => {
   describe('buildFileTree', () => {
     it('creates a root node', () => {
       const versionId = '1234';
-      const entries: Entry[] = [];
+      const entries: Version['entries'] = [];
 
       const data = buildFileTree(versionId, entries);
 
@@ -22,9 +24,10 @@ describe(__filename, () => {
       const entries = [
         {
           depth: 0,
-          directory: false,
+          type: VersionEntryType.text,
           filename,
           path: filename,
+          modified: '2019-01-01',
         },
       ];
 
@@ -45,9 +48,10 @@ describe(__filename, () => {
       const entries = [
         {
           depth: 0,
-          directory: true,
+          type: VersionEntryType.directory,
           filename: directory,
           path: directory,
+          modified: '2019-01-01',
         },
       ];
 
@@ -71,15 +75,17 @@ describe(__filename, () => {
       const entries = [
         {
           depth: 0,
-          directory: true,
+          type: VersionEntryType.directory,
           filename: directory,
           path: directory,
+          modified: '2019-01-01',
         },
         {
           depth: 1,
-          directory: false,
+          type: VersionEntryType.text,
           filename: file,
           path: `${directory}/${file}`,
+          modified: '2019-01-01',
         },
       ];
 
@@ -108,21 +114,24 @@ describe(__filename, () => {
       const entries = [
         {
           depth: 0,
-          directory: true,
+          type: VersionEntryType.directory,
           filename: directoryName,
           path: directoryName,
+          modified: '2019-01-01',
         },
         {
           depth: 1,
-          directory: true,
+          type: VersionEntryType.directory,
           filename: directoryName,
           path: `${directoryName}/${directoryName}`,
+          modified: '2019-01-01',
         },
         {
           depth: 2,
-          directory: false,
+          type: VersionEntryType.text,
           filename: fileName,
           path: `${directoryName}/${directoryName}/${fileName}`,
+          modified: '2019-01-01',
         },
       ];
 

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -3,13 +3,7 @@ import Treefold, { TreefoldRenderProps } from 'react-treefold';
 
 import { gettext } from '../../utils';
 import styles from './styles.module.scss';
-
-export type Entry = {
-  depth: number;
-  directory: boolean;
-  filename: string;
-  path: string;
-};
+import { Version, VersionEntryType } from '../../reducers/versions';
 
 type FileNode = {
   id: string;
@@ -26,7 +20,7 @@ type TreeNode = FileNode | DirectoryNode;
 
 export const buildFileTree = (
   versionId: string,
-  entries: Entry[],
+  entries: Version['entries'],
 ): DirectoryNode => {
   const root: DirectoryNode = {
     id: `root-${versionId}`,
@@ -88,7 +82,7 @@ export const buildFileTree = (
       };
 
       // When the entry is a directory, we create a `DirectoryNode`.
-      if (entry.directory) {
+      if (entry.type === VersionEntryType.directory) {
         node = {
           ...node,
           children: [],
@@ -105,15 +99,8 @@ export const buildFileTree = (
   return root;
 };
 
-export type PartialExternalVersion = {
-  id: string;
-  file: {
-    entries: Entry[];
-  };
-};
-
 type PublicProps = {
-  response: PartialExternalVersion;
+  version: Version;
 };
 
 export class FileTreeBase extends React.Component<PublicProps> {
@@ -156,12 +143,9 @@ export class FileTreeBase extends React.Component<PublicProps> {
   };
 
   render() {
-    const { response } = this.props;
+    const { version } = this.props;
 
-    const tree = buildFileTree(
-      response.id,
-      Object.values(response.file.entries),
-    );
+    const tree = buildFileTree(`${version.id}`, version.entries);
 
     // eslint-disable-next-line react/jsx-props-no-multi-space
     return <Treefold nodes={[tree]} render={this.renderNode} />;

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -1,0 +1,171 @@
+import * as React from 'react';
+import Treefold, { TreefoldRenderProps } from 'react-treefold';
+
+import { gettext } from '../../utils';
+import styles from './styles.module.scss';
+
+export type Entry = {
+  depth: number;
+  directory: boolean;
+  filename: string;
+  path: string;
+};
+
+type FileNode = {
+  id: string;
+  name: string;
+};
+
+type DirectoryNode = {
+  id: string;
+  name: string;
+  children: TreeNode[];
+};
+
+type TreeNode = FileNode | DirectoryNode;
+
+export const buildFileTree = (
+  versionId: string,
+  entries: Entry[],
+): DirectoryNode => {
+  const root: DirectoryNode = {
+    id: `root-${versionId}`,
+    name: versionId,
+    children: [],
+  };
+
+  // We need to know how depth the tree is because we'll build the Treebeard
+  // tree depth by depth.
+  const maxDepth = entries.reduce((max, entry) => {
+    if (entry.depth > max) {
+      return entry.depth;
+    }
+
+    return max;
+  }, 0);
+
+  let currentDepth = 0;
+  while (currentDepth <= maxDepth) {
+    // We find the entries for the current depth.
+    const currentEntries = entries.filter(
+      // eslint-disable-next-line no-loop-func
+      (entry) => entry.depth === currentDepth,
+    );
+
+    // This is where we create new "nodes" for each entry.
+    // eslint-disable-next-line no-loop-func
+    currentEntries.forEach((entry) => {
+      let currentNode = root;
+
+      if (currentDepth > 0) {
+        // We need to find the current node (directory) to add the current
+        // entry in its children. We do this by splitting the `path` attribute
+        // and visit each node until we reach the desired node.
+        //
+        // This only applies when the current depth is not 0 (a.k.a. the root
+        // directory) because we already know `root`.
+        const parts = entry.path.split('/');
+        // Remove the filename
+        parts.pop();
+
+        for (let i = 0; i < parts.length; i++) {
+          const maybeNode = currentNode.children.find(
+            (child: TreeNode) => child.name === parts[i],
+          ) as DirectoryNode;
+
+          if (maybeNode) {
+            currentNode = maybeNode;
+          }
+
+          // TODO: this should not happen but what if we don't find a node?
+        }
+      }
+
+      // Create a new node.
+      let node: TreeNode = {
+        id: entry.path,
+        name: entry.filename,
+      };
+
+      // When the entry is a directory, we create a `DirectoryNode`.
+      if (entry.directory) {
+        node = {
+          ...node,
+          children: [],
+        };
+      }
+
+      currentNode.children.push(node);
+    });
+
+    // To the next depth.
+    currentDepth++;
+  }
+
+  return root;
+};
+
+type PartialExternalVersion = {
+  id: string;
+  file: {
+    entries: Entry[];
+  };
+};
+
+type PublicProps = {
+  response: PartialExternalVersion;
+};
+
+export class FileTreeBase extends React.Component<PublicProps> {
+  renderNode = (props: TreefoldRenderProps<TreeNode>) => {
+    const {
+      node,
+      level,
+      isFolder,
+      isExpanded,
+      getToggleProps,
+      hasChildNodes,
+      renderChildNodes,
+    } = props;
+
+    return (
+      <React.Fragment>
+        <div className={styles.node} style={{ paddingLeft: `${level * 20}px` }}>
+          {isFolder ? (
+            <span {...getToggleProps()} className={styles.directoryNode}>
+              {node.name}&nbsp;/
+            </span>
+          ) : (
+            <span>{node.name}</span>
+          )}
+        </div>
+
+        {isExpanded &&
+          (hasChildNodes ? (
+            renderChildNodes()
+          ) : (
+            <div
+              className={styles.emptyNodeDirectory}
+              style={{ paddingLeft: `${(level + 1) * 20}px` }}
+            >
+              {gettext('This folder is empty')}
+            </div>
+          ))}
+      </React.Fragment>
+    );
+  };
+
+  render() {
+    const { response } = this.props;
+
+    const tree = buildFileTree(
+      response.id,
+      Object.values(response.file.entries),
+    );
+
+    // eslint-disable-next-line react/jsx-props-no-multi-space
+    return <Treefold nodes={[tree]} render={this.renderNode} />;
+  }
+}
+
+export default FileTreeBase;

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -69,12 +69,12 @@ export const buildFileTree = (
         parts.pop();
 
         for (let i = 0; i < parts.length; i++) {
-          const maybeNode = currentNode.children.find(
+          const foundNode = currentNode.children.find(
             (child: TreeNode) => child.name === parts[i],
           ) as DirectoryNode;
 
-          if (maybeNode) {
-            currentNode = maybeNode;
+          if (foundNode) {
+            currentNode = foundNode;
           }
 
           // TODO: this should not happen but what if we don't find a node?
@@ -105,7 +105,7 @@ export const buildFileTree = (
   return root;
 };
 
-type PartialExternalVersion = {
+export type PartialExternalVersion = {
   id: string;
   file: {
     entries: Entry[];

--- a/src/components/FileTree/styles.module.scss
+++ b/src/components/FileTree/styles.module.scss
@@ -1,0 +1,9 @@
+.node {
+  cursor: pointer;
+}
+
+.directoryNode {
+}
+
+.emptyNodeDirectory {
+}

--- a/src/components/FileTree/styles.module.scss
+++ b/src/components/FileTree/styles.module.scss
@@ -1,9 +1,3 @@
 .node {
   cursor: pointer;
 }
-
-.directoryNode {
-}
-
-.emptyNodeDirectory {
-}

--- a/src/configureStore.spec.tsx
+++ b/src/configureStore.spec.tsx
@@ -4,6 +4,6 @@ describe(__filename, () => {
   it('registers all the reducers', () => {
     const store = configureStore();
 
-    expect(Object.keys(store.getState())).toEqual(['api', 'users']);
+    expect(Object.keys(store.getState())).toEqual(['api', 'users', 'versions']);
   });
 });

--- a/src/configureStore.tsx
+++ b/src/configureStore.tsx
@@ -12,6 +12,7 @@ import { createLogger } from 'redux-logger';
 
 import api, { ApiState } from './reducers/api';
 import users, { UsersState } from './reducers/users';
+import versions, { VersionsState } from './reducers/versions';
 
 export type ConnectedReduxProps<A extends Action = AnyAction> = {
   dispatch: Dispatch<A>;
@@ -20,10 +21,11 @@ export type ConnectedReduxProps<A extends Action = AnyAction> = {
 export type ApplicationState = {
   api: ApiState;
   users: UsersState;
+  versions: VersionsState;
 };
 
 const createRootReducer = () => {
-  return combineReducers<ApplicationState>({ api, users });
+  return combineReducers<ApplicationState>({ api, users, versions });
 };
 
 const configureStore = (

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 
 import { createFakeHistory } from '../../test-helpers';
+import configureStore from '../../configureStore';
 
 import Browse from '.';
 
@@ -27,6 +28,7 @@ describe(__filename, () => {
   const render = ({ versionId = '123' } = {}) => {
     const props = {
       ...createFakeRouteComponentProps({ params: { versionId } }),
+      store: configureStore(),
     };
 
     return shallow(<Browse {...props} />);
@@ -37,6 +39,6 @@ describe(__filename, () => {
 
     const root = render({ versionId });
 
-    expect(root).toIncludeText(`Version ID: ${versionId}`);
+    expect(root.dive()).toIncludeText(`Version ID: ${versionId}`);
   });
 });

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -1,10 +1,19 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
 
-import { createFakeHistory } from '../../test-helpers';
+import {
+  createFakeHistory,
+  fakeVersion,
+  shallowUntilTarget,
+} from '../../test-helpers';
+import * as api from '../../api';
 import configureStore from '../../configureStore';
+import {
+  actions as versionActions,
+  createInternalVersion,
+} from '../../reducers/versions';
+import FileTree from '../../components/FileTree';
 
-import Browse from '.';
+import Browse, { BrowseBase } from '.';
 
 describe(__filename, () => {
   const createFakeRouteComponentProps = ({
@@ -25,20 +34,64 @@ describe(__filename, () => {
     };
   };
 
-  const render = ({ versionId = '123' } = {}) => {
+  const render = async ({
+    versionId = '123',
+    store = configureStore(),
+  } = {}) => {
     const props = {
       ...createFakeRouteComponentProps({ params: { versionId } }),
-      store: configureStore(),
     };
 
-    return shallow(<Browse {...props} />);
+    return shallowUntilTarget(<Browse {...props} />, BrowseBase, {
+      shallowOptions: {
+        context: { store },
+      },
+    });
   };
 
-  it('renders a page', () => {
+  it('renders a page', async () => {
     const versionId = '123456';
 
-    const root = render({ versionId });
+    const root = await render({ versionId });
 
-    expect(root.dive()).toIncludeText(`Version ID: ${versionId}`);
+    expect(root).toIncludeText(`Version ID: ${versionId}`);
+  });
+
+  it('renders a FileTree component', async () => {
+    const version = fakeVersion;
+
+    const store = configureStore();
+    store.dispatch(versionActions.loadVersionInfo({ version }));
+
+    const root = await render({ store, versionId: String(version.id) });
+
+    expect(root.find(FileTree)).toHaveLength(1);
+    expect(root.find(FileTree)).toHaveProp(
+      'version',
+      createInternalVersion(version),
+    );
+  });
+
+  it('calls the API to load the version info on mount', async () => {
+    const version = {
+      ...fakeVersion,
+      id: 999,
+    };
+
+    const mockApi = jest.spyOn(api, 'getVersionFile');
+    mockApi.mockReturnValue(Promise.resolve(version));
+
+    const store = configureStore();
+    const dispatch = jest.spyOn(store, 'dispatch');
+
+    await render({ store, versionId: String(version.id) });
+
+    expect(mockApi).toHaveBeenCalledWith({
+      apiState: store.getState().api,
+      versionId: version.id,
+    });
+    expect(dispatch).toHaveBeenCalledWith(
+      versionActions.loadVersionInfo({ version }),
+    );
   });
 });

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -1,20 +1,72 @@
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
+import { connect } from 'react-redux';
+import { Col } from 'react-bootstrap';
+
+import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
+import { ApiState } from '../../reducers/api';
+import { callApi } from '../../api';
+import FileTree from '../../components/FileTree';
 
 type PropsFromRouter = {
   versionId: string;
 };
 
-export class BrowseBase extends React.Component<
-  RouteComponentProps<PropsFromRouter>
-> {
+type PropsFromState = {
+  apiState: ApiState;
+};
+
+/* eslint-disable @typescript-eslint/indent */
+type Props = RouteComponentProps<PropsFromRouter> &
+  PropsFromState &
+  ConnectedReduxProps;
+/* eslint-enable @typescript-eslint/indent */
+
+export class BrowseBase extends React.Component<Props> {
+  state = {
+    response: null,
+  };
+
+  async componentDidMount() {
+    const { apiState, match } = this.props;
+    const { versionId } = match.params;
+
+    const response = await callApi({
+      apiState,
+      endpoint: `/reviewers/browse/${versionId}`,
+    });
+
+    this.setState({ response });
+  }
+
   render() {
+    const { response } = this.state;
+
+    // @ts-ignore
+    const showFileTree = response && !response.error;
+
     return (
-      <div>
-        <p>Version ID: {this.props.match.params.versionId}</p>
-      </div>
+      <React.Fragment>
+        <Col md="3">
+          {showFileTree && (
+            <FileTree
+              // @ts-ignore
+              response={response}
+            />
+          )}
+        </Col>
+        <Col>
+          <p>Version ID: {this.props.match.params.versionId}</p>
+        </Col>
+      </React.Fragment>
     );
   }
 }
 
-export default BrowseBase;
+const mapStateToProps = (state: ApplicationState): PropsFromState => {
+  return {
+    apiState: state.api,
+  };
+};
+
+export default connect(mapStateToProps)(BrowseBase);

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -8,7 +8,7 @@ import { ApiState } from '../../reducers/api';
 import { getVersionFile } from '../../api';
 import FileTree from '../../components/FileTree';
 import {
-  actions as userActions,
+  actions as versionActions,
   Version,
   ExternalVersion,
   getVersionInfo,
@@ -40,7 +40,7 @@ export class BrowseBase extends React.Component<Props> {
     })) as ExternalVersion;
 
     if (response && response.id) {
-      dispatch(userActions.loadVersionInfo({ version: response }));
+      dispatch(versionActions.loadVersionInfo({ version: response }));
     }
   }
 

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -6,7 +6,7 @@ import { Col } from 'react-bootstrap';
 import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
 import { ApiState } from '../../reducers/api';
 import { callApi } from '../../api';
-import FileTree from '../../components/FileTree';
+import FileTree, { PartialExternalVersion } from '../../components/FileTree';
 
 type PropsFromRouter = {
   versionId: string;
@@ -22,8 +22,12 @@ type Props = RouteComponentProps<PropsFromRouter> &
   ConnectedReduxProps;
 /* eslint-enable @typescript-eslint/indent */
 
-export class BrowseBase extends React.Component<Props> {
-  state = {
+type State = {
+  response: PartialExternalVersion | null;
+};
+
+export class BrowseBase extends React.Component<Props, State> {
+  state: State = {
     response: null,
   };
 
@@ -31,10 +35,10 @@ export class BrowseBase extends React.Component<Props> {
     const { apiState, match } = this.props;
     const { versionId } = match.params;
 
-    const response = await callApi({
+    const response = (await callApi({
       apiState,
       endpoint: `/reviewers/browse/${versionId}`,
-    });
+    })) as PartialExternalVersion;
 
     this.setState({ response });
   }
@@ -42,18 +46,10 @@ export class BrowseBase extends React.Component<Props> {
   render() {
     const { response } = this.state;
 
-    // @ts-ignore
-    const showFileTree = response && !response.error;
-
     return (
       <React.Fragment>
         <Col md="3">
-          {showFileTree && (
-            <FileTree
-              // @ts-ignore
-              response={response}
-            />
-          )}
+          {response && response.id && <FileTree response={response} />}
         </Col>
         <Col>
           <p>Version ID: {this.props.match.params.versionId}</p>

--- a/src/pages/Index/index.tsx
+++ b/src/pages/Index/index.tsx
@@ -9,8 +9,8 @@ export class IndexBase extends React.Component<PublicProps> {
       <div>
         <p>
           There is nothing you can do here, but try{' '}
-          <Link to="/en-US/firefox/files/browse/255464/">
-            browsing this Test Add-on 2.0 version.
+          <Link to="/en-US/firefox/files/browse/1541786/">
+            browsing this add-on version.
           </Link>
         </p>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11120,6 +11120,13 @@ react-treebeard@^3.1.0:
     shallowequal "^1.1.0"
     velocity-react "^1.4.1"
 
+react-treefold@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-treefold/-/react-treefold-1.0.0.tgz#a9110367e8330b4abfb23305d3a7c5e766141559"
+  integrity sha512-L1td2EY8H/bX2d0PrBEj/8wbJ2JbQGH9VE7Oi7Olhlo0BjRA9OamxiK6jb/dbkTZ1I0KPfxx4fcmdo0ZETaYXQ==
+  dependencies:
+    warning "^3.0.0"
+
 react@16.8.1:
   version "16.8.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.1.tgz#ae11831f6cb2a05d58603a976afc8a558e852c4a"


### PR DESCRIPTION
Supports #39 

---

This PR adds:

- `react-treefold`, a good react tree library that does not too much things at once, so we can customize everything: https://github.com/gnapse/react-treefold
- a `FileTree` component that renders any tree coming from the browse API

Known limitations:

- ~~the API types are partial~~
- API errors are not handled at all
- files are not sorted (we should have directories first, then files IMHO) => see #162 
- ~~I store the response in the component's state until we get a reducer for that (but that's not a lot of code anyway)~~
- ~~the interface (public props) of the `FileTree` will likely change, in part because the reducer will likely allow this component to be connected (or at least to receive more precise props from the `Browse` component)~~
- styling will be done later => see #168
- next iterations will provide more code coverage but it depends on how we want to style the UI and also on redux stuff => see #168

Use these links to try this patch:

- http://localhost:3000/en-US/firefox/files/browse/1541786/
- http://localhost:3000/en-US/firefox/files/browse/1541520/
- http://localhost:3000/en-US/firefox/files/browse/1541794/

## Screenshots/Gifs

![screen shot 2019-02-07 at 15 12 29](https://user-images.githubusercontent.com/217628/52416846-da053900-2aea-11e9-85a5-89a04c17575f.png)

![2019-02-07 15 12 39](https://user-images.githubusercontent.com/217628/52416855-de315680-2aea-11e9-80d9-967450fb56d8.gif)


