### PR TITLE
Use redux-thunk for side effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "redux": "4.0.1",
     "redux-devtools-extension": "2.13.8",
     "redux-logger": "3.0.6",
+    "redux-thunk": "2.3.0",
     "ts-node": "8.0.2",
     "typesafe-actions": "3.1.0",
     "typescript": "3.3.3",

--- a/src/components/Navbar/index.spec.tsx
+++ b/src/components/Navbar/index.spec.tsx
@@ -5,7 +5,7 @@ import { Store } from 'redux';
 import configureStore from '../../configureStore';
 import LoginButton from '../LoginButton';
 import styles from './styles.module.scss';
-import { fakeUser } from '../../test-helpers';
+import { createFakeThunk, fakeUser } from '../../test-helpers';
 import { actions as userActions, requestLogOut } from '../../reducers/users';
 
 import Navbar from '.';
@@ -79,19 +79,6 @@ describe(__filename, () => {
   });
 
   describe('Log out button', () => {
-    const createFakeThunk = () => {
-      // This is a placeholder for the dispatch callback function.
-      // In reality it would look like (dispatch, getState) => {}
-      // but here it gets set to a string for easy test assertions.
-      const dispatchCallback = '__dispatchCallbackReturnedByTheThunk__';
-
-      return {
-        // This is a function that creates the dispatch callback.
-        creator: jest.fn().mockReturnValue(dispatchCallback),
-        dispatchCallback,
-      };
-    };
-
     it('dispatches requestLogOut when clicked', () => {
       const store = storeWithUser();
       const dispatch = jest
@@ -101,7 +88,7 @@ describe(__filename, () => {
       const fakeThunk = createFakeThunk();
       const root = render({
         store,
-        _requestLogOut: fakeThunk.creator,
+        _requestLogOut: fakeThunk.createThunk,
       });
 
       root.find(`.${styles.logOut}`).simulate('click');

--- a/src/components/Navbar/index.spec.tsx
+++ b/src/components/Navbar/index.spec.tsx
@@ -92,7 +92,7 @@ describe(__filename, () => {
       });
 
       root.find(`.${styles.logOut}`).simulate('click');
-      expect(dispatch).toHaveBeenCalledWith(fakeThunk.dispatchCallback);
+      expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
     });
   });
 });

--- a/src/components/Navbar/index.spec.tsx
+++ b/src/components/Navbar/index.spec.tsx
@@ -8,7 +8,7 @@ import styles from './styles.module.scss';
 import { fakeUser } from '../../test-helpers';
 import { actions as userActions, requestLogOut } from '../../reducers/users';
 
-import Navbar, { NavbarBase } from '.';
+import Navbar from '.';
 
 describe(__filename, () => {
   type RenderParams = {

--- a/src/components/Navbar/index.spec.tsx
+++ b/src/components/Navbar/index.spec.tsx
@@ -82,7 +82,9 @@ describe(__filename, () => {
     const createFakeThunk = () => {
       // This is a placeholder for the dispatch callback function.
       // In reality it would look like (dispatch, getState) => {}
-      const dispatchCallback = '__dispatchCallback__';
+      // but here it gets set to a string for easy test assertions.
+      const dispatchCallback = '__dispatchCallbackReturnedByTheThunk__';
+
       return {
         // This is a function that creates the dispatch callback.
         creator: jest.fn().mockReturnValue(dispatchCallback),

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -2,12 +2,15 @@ import * as React from 'react';
 import { Button, Navbar } from 'react-bootstrap';
 import { AnyAction } from 'redux';
 import { connect } from 'react-redux';
-import { ThunkDispatch } from 'redux-thunk';
 
 import { gettext } from '../../utils';
 import LoginButton from '../LoginButton';
 import { logOutFromServer } from '../../api';
-import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
+import {
+  ApplicationState,
+  ConnectedReduxProps,
+  ThunkDispatch,
+} from '../../configureStore';
 import { ApiState } from '../../reducers/api';
 import {
   User,
@@ -35,10 +38,7 @@ export class NavbarBase extends React.Component<Props> {
 
   logOut = () => {
     const { _requestLogOut, apiState, dispatch } = this.props;
-    // dispatch(_requestLogOut());
-    (dispatch as ThunkDispatch<ApplicationState, undefined, AnyAction>)(
-      _requestLogOut(),
-    );
+    (dispatch as ThunkDispatch)(_requestLogOut());
   };
 
   render() {

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -1,20 +1,16 @@
 import * as React from 'react';
 import { Button, Navbar } from 'react-bootstrap';
-import { AnyAction } from 'redux';
 import { connect } from 'react-redux';
 
 import { gettext } from '../../utils';
 import LoginButton from '../LoginButton';
-import { logOutFromServer } from '../../api';
 import {
   ApplicationState,
   ConnectedReduxProps,
   ThunkDispatch,
 } from '../../configureStore';
-import { ApiState } from '../../reducers/api';
 import {
   User,
-  actions as userActions,
   getCurrentUser,
   requestLogOut,
 } from '../../reducers/users';
@@ -25,7 +21,6 @@ type PublicProps = {
 };
 
 type PropsFromState = {
-  apiState: ApiState;
   profile: User | null;
 };
 
@@ -37,7 +32,7 @@ export class NavbarBase extends React.Component<Props> {
   };
 
   logOut = () => {
-    const { _requestLogOut, apiState, dispatch } = this.props;
+    const { _requestLogOut, dispatch } = this.props;
     (dispatch as ThunkDispatch)(_requestLogOut());
   };
 
@@ -66,7 +61,6 @@ export class NavbarBase extends React.Component<Props> {
 
 const mapStateToProps = (state: ApplicationState): PropsFromState => {
   return {
-    apiState: state.api,
     profile: getCurrentUser(state.users),
   };
 };

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -4,11 +4,7 @@ import { connect } from 'react-redux';
 
 import { gettext } from '../../utils';
 import LoginButton from '../LoginButton';
-import {
-  ApplicationState,
-  ConnectedReduxProps,
-  ThunkDispatch,
-} from '../../configureStore';
+import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
 import { User, getCurrentUser, requestLogOut } from '../../reducers/users';
 import styles from './styles.module.scss';
 

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -35,7 +35,8 @@ export class NavbarBase extends React.Component<Props> {
 
   logOut = () => {
     const { _requestLogOut, apiState, dispatch } = this.props;
-    (dispatch as ThunkDispatch<ApplicationState, null, AnyAction>)(
+    // dispatch(_requestLogOut());
+    (dispatch as ThunkDispatch<ApplicationState, undefined, AnyAction>)(
       _requestLogOut(),
     );
   };

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -29,7 +29,7 @@ export class NavbarBase extends React.Component<Props> {
 
   logOut = () => {
     const { _requestLogOut, dispatch } = this.props;
-    (dispatch as ThunkDispatch)(_requestLogOut());
+    dispatch(_requestLogOut());
   };
 
   render() {

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Button, Navbar } from 'react-bootstrap';
+import { AnyAction } from 'redux';
 import { connect } from 'react-redux';
+import { ThunkDispatch } from 'redux-thunk';
 
 import { gettext } from '../../utils';
 import LoginButton from '../LoginButton';
@@ -11,11 +13,12 @@ import {
   User,
   actions as userActions,
   getCurrentUser,
+  requestLogOut,
 } from '../../reducers/users';
 import styles from './styles.module.scss';
 
 type PublicProps = {
-  _logOutFromServer: typeof logOutFromServer;
+  _requestLogOut: typeof requestLogOut;
 };
 
 type PropsFromState = {
@@ -27,14 +30,14 @@ type Props = PublicProps & PropsFromState & ConnectedReduxProps;
 
 export class NavbarBase extends React.Component<Props> {
   static defaultProps = {
-    _logOutFromServer: logOutFromServer,
+    _requestLogOut: requestLogOut,
   };
 
-  logOut = async () => {
-    const { _logOutFromServer, apiState, dispatch } = this.props;
-
-    await _logOutFromServer(apiState);
-    dispatch(userActions.logOut());
+  logOut = () => {
+    const { _requestLogOut, apiState, dispatch } = this.props;
+    (dispatch as ThunkDispatch<ApplicationState, null, AnyAction>)(
+      _requestLogOut(),
+    );
   };
 
   render() {

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -9,11 +9,7 @@ import {
   ConnectedReduxProps,
   ThunkDispatch,
 } from '../../configureStore';
-import {
-  User,
-  getCurrentUser,
-  requestLogOut,
-} from '../../reducers/users';
+import { User, getCurrentUser, requestLogOut } from '../../reducers/users';
 import styles from './styles.module.scss';
 
 type PublicProps = {

--- a/src/configureStore.tsx
+++ b/src/configureStore.tsx
@@ -20,10 +20,6 @@ import api, { ApiState } from './reducers/api';
 import users, { UsersState } from './reducers/users';
 import versions, { VersionsState } from './reducers/versions';
 
-export type ConnectedReduxProps<A extends Action = AnyAction> = {
-  dispatch: Dispatch<A>;
-};
-
 export type ApplicationState = {
   api: ApiState;
   users: UsersState;
@@ -37,11 +33,15 @@ export type ThunkActionCreator<PromiseResult = void> = ThunkAction<
   AnyAction
 >;
 
-export type ThunkDispatch = ReduxThunkDispatch<
+export type ThunkDispatch<A extends Action = AnyAction> = ReduxThunkDispatch<
   ApplicationState,
   undefined,
-  AnyAction
+  A
 >;
+
+export type ConnectedReduxProps<A extends Action = AnyAction> = {
+  dispatch: ThunkDispatch<A>;
+};
 
 const createRootReducer = () => {
   return combineReducers<ApplicationState>({ api, users, versions });

--- a/src/configureStore.tsx
+++ b/src/configureStore.tsx
@@ -41,7 +41,7 @@ const configureStore = (
   preloadedState?: ApplicationState,
 ): Store<ApplicationState> => {
   const allMiddleware: Middleware[] = [
-    thunk as ThunkMiddleware<ApplicationState, Action>,
+    thunk as ThunkMiddleware<ApplicationState, AnyAction>,
   ];
   let addDevTools = false;
 

--- a/src/configureStore.tsx
+++ b/src/configureStore.tsx
@@ -10,7 +10,7 @@ import {
 } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import { createLogger } from 'redux-logger';
-import thunk, { ThunkMiddleware } from 'redux-thunk';
+import thunk, { ThunkAction, ThunkMiddleware } from 'redux-thunk';
 
 import api, { ApiState } from './reducers/api';
 import users, { UsersState } from './reducers/users';
@@ -25,6 +25,13 @@ export type ApplicationState = {
   users: UsersState;
   versions: VersionsState;
 };
+
+export type ThunkActionCreator<PromiseResult = void> = ThunkAction<
+  Promise<PromiseResult>,
+  ApplicationState,
+  undefined,
+  AnyAction
+>;
 
 const createRootReducer = () => {
   return combineReducers<ApplicationState>({ api, users, versions });

--- a/src/configureStore.tsx
+++ b/src/configureStore.tsx
@@ -1,7 +1,6 @@
 import {
   Action,
   AnyAction,
-  Dispatch,
   Middleware,
   Store,
   applyMiddleware,

--- a/src/configureStore.tsx
+++ b/src/configureStore.tsx
@@ -2,6 +2,7 @@ import {
   Action,
   AnyAction,
   Dispatch,
+  Middleware,
   Store,
   applyMiddleware,
   combineReducers,
@@ -9,6 +10,7 @@ import {
 } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import { createLogger } from 'redux-logger';
+import thunk, { ThunkMiddleware } from 'redux-thunk';
 
 import api, { ApiState } from './reducers/api';
 import users, { UsersState } from './reducers/users';
@@ -31,10 +33,18 @@ const createRootReducer = () => {
 const configureStore = (
   preloadedState?: ApplicationState,
 ): Store<ApplicationState> => {
-  let middleware;
-  if (process.env.NODE_ENV === 'development') {
-    middleware = applyMiddleware(createLogger());
+  const allMiddleware: Middleware[] = [
+    thunk as ThunkMiddleware<ApplicationState, Action>,
+  ];
+  let addDevTools = false;
 
+  if (process.env.NODE_ENV === 'development') {
+    allMiddleware.push(createLogger());
+    addDevTools = true;
+  }
+
+  let middleware = applyMiddleware(...allMiddleware);
+  if (addDevTools) {
     const composeEnhancers = composeWithDevTools({});
     middleware = composeEnhancers(middleware);
   }

--- a/src/configureStore.tsx
+++ b/src/configureStore.tsx
@@ -10,7 +10,11 @@ import {
 } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import { createLogger } from 'redux-logger';
-import thunk, { ThunkAction, ThunkMiddleware } from 'redux-thunk';
+import thunk, {
+  ThunkAction,
+  ThunkDispatch as ReduxThunkDispatch,
+  ThunkMiddleware,
+} from 'redux-thunk';
 
 import api, { ApiState } from './reducers/api';
 import users, { UsersState } from './reducers/users';
@@ -28,6 +32,12 @@ export type ApplicationState = {
 
 export type ThunkActionCreator<PromiseResult = void> = ThunkAction<
   Promise<PromiseResult>,
+  ApplicationState,
+  undefined,
+  AnyAction
+>;
+
+export type ThunkDispatch = ReduxThunkDispatch<
   ApplicationState,
   undefined,
   AnyAction

--- a/src/reducers/users.spec.tsx
+++ b/src/reducers/users.spec.tsx
@@ -5,8 +5,7 @@ import reducer, {
   initialState,
   requestLogOut,
 } from './users';
-import configureStore from '../configureStore';
-import { fakeUser } from '../test-helpers';
+import { fakeUser, thunkTester } from '../test-helpers';
 
 describe(__filename, () => {
   describe('reducer', () => {
@@ -58,16 +57,12 @@ describe(__filename, () => {
 
   describe('requestLogOut', () => {
     const prepareRequestLogOut = (params = {}) => {
-      const thunk = requestLogOut({ _logOutFromServer: jest.fn(), ...params });
+      const { dispatch, thunk, store } = thunkTester({
+        createThunk: () =>
+          requestLogOut({ _logOutFromServer: jest.fn(), ...params }),
+      });
 
-      const store = configureStore();
-      const dispatch = jest.fn();
-
-      return {
-        dispatch,
-        thunk: () => thunk(dispatch, () => store.getState(), undefined),
-        store,
-      };
+      return { dispatch, thunk, store };
     };
 
     it('calls logOutFromServer', async () => {

--- a/src/reducers/users.spec.tsx
+++ b/src/reducers/users.spec.tsx
@@ -3,7 +3,9 @@ import reducer, {
   createInternalUser,
   getCurrentUser,
   initialState,
+  requestLogOut,
 } from './users';
+import configureStore from '../configureStore';
 import { fakeUser } from '../test-helpers';
 
 describe(__filename, () => {
@@ -51,6 +53,38 @@ describe(__filename, () => {
       const state = initialState;
 
       expect(getCurrentUser(state)).toEqual(null);
+    });
+  });
+
+  describe('requestLogOut', () => {
+    const prepareRequestLogOut = (params = {}) => {
+      const thunk = requestLogOut({ _logOutFromServer: jest.fn(), ...params });
+
+      const store = configureStore();
+      const dispatch = jest.fn();
+
+      return {
+        dispatch,
+        thunk: () => thunk(dispatch, () => store.getState(), null),
+        store,
+      };
+    };
+
+    it('calls logOutFromServer', async () => {
+      const _logOutFromServer = jest.fn();
+      const { store, thunk } = prepareRequestLogOut({ _logOutFromServer });
+
+      await thunk();
+
+      expect(_logOutFromServer).toHaveBeenCalledWith(store.getState().api);
+    });
+
+    it('dispatches logOut', async () => {
+      const { dispatch, thunk } = prepareRequestLogOut();
+
+      await thunk();
+
+      expect(dispatch).toHaveBeenCalledWith(actions.logOut());
     });
   });
 });

--- a/src/reducers/users.spec.tsx
+++ b/src/reducers/users.spec.tsx
@@ -56,18 +56,11 @@ describe(__filename, () => {
   });
 
   describe('requestLogOut', () => {
-    const prepareRequestLogOut = (params = {}) => {
-      const { dispatch, thunk, store } = thunkTester({
-        createThunk: () =>
-          requestLogOut({ _logOutFromServer: jest.fn(), ...params }),
-      });
-
-      return { dispatch, thunk, store };
-    };
-
     it('calls logOutFromServer', async () => {
       const _logOutFromServer = jest.fn();
-      const { store, thunk } = prepareRequestLogOut({ _logOutFromServer });
+      const { store, thunk } = thunkTester({
+        createThunk: () => requestLogOut({ _logOutFromServer }),
+      });
 
       await thunk();
 
@@ -75,7 +68,9 @@ describe(__filename, () => {
     });
 
     it('dispatches logOut', async () => {
-      const { dispatch, thunk } = prepareRequestLogOut();
+      const { dispatch, thunk } = thunkTester({
+        createThunk: () => requestLogOut({ _logOutFromServer: jest.fn() }),
+      });
 
       await thunk();
 

--- a/src/reducers/users.spec.tsx
+++ b/src/reducers/users.spec.tsx
@@ -65,7 +65,7 @@ describe(__filename, () => {
 
       return {
         dispatch,
-        thunk: () => thunk(dispatch, () => store.getState(), null),
+        thunk: () => thunk(dispatch, () => store.getState(), undefined),
         store,
       };
     };

--- a/src/reducers/users.tsx
+++ b/src/reducers/users.tsx
@@ -1,7 +1,7 @@
-import { AnyAction, Reducer } from 'redux';
+import { Reducer } from 'redux';
 import { ActionType, createAction, getType } from 'typesafe-actions';
 
-import { ApplicationState, ThunkActionCreator } from '../configureStore';
+import { ThunkActionCreator } from '../configureStore';
 import { logOutFromServer } from '../api';
 
 type UserId = number;

--- a/src/reducers/users.tsx
+++ b/src/reducers/users.tsx
@@ -1,8 +1,7 @@
 import { AnyAction, Reducer } from 'redux';
-import { ThunkAction } from 'redux-thunk';
 import { ActionType, createAction, getType } from 'typesafe-actions';
 
-import { ApplicationState } from '../configureStore';
+import { ApplicationState, ThunkActionCreator } from '../configureStore';
 import { logOutFromServer } from '../api';
 
 type UserId = number;
@@ -53,14 +52,11 @@ export const actions = {
 
 export const requestLogOut = ({
   _logOutFromServer = logOutFromServer,
-} = {}): ThunkAction<
-  Promise<void>,
-  ApplicationState,
-  null,
-  AnyAction
-> => async (dispatch, getState) => {
-  await _logOutFromServer(getState().api);
-  dispatch(actions.logOut());
+} = {}): ThunkActionCreator => {
+  return async (dispatch, getState) => {
+    await _logOutFromServer(getState().api);
+    dispatch(actions.logOut());
+  };
 };
 
 export type UsersState = {

--- a/src/reducers/users.tsx
+++ b/src/reducers/users.tsx
@@ -1,5 +1,9 @@
-import { Reducer } from 'redux';
+import { AnyAction, Reducer } from 'redux';
+import { ThunkAction } from 'redux-thunk';
 import { ActionType, createAction, getType } from 'typesafe-actions';
+
+import { ApplicationState } from '../configureStore';
+import { logOutFromServer } from '../api';
 
 type UserId = number;
 
@@ -45,6 +49,18 @@ export const actions = {
     return (payload: { user: ExternalUser }) => resolve(payload);
   }),
   logOut: createAction('LOG_OUT'),
+};
+
+export const requestLogOut = ({
+  _logOutFromServer = logOutFromServer,
+} = {}): ThunkAction<
+  Promise<void>,
+  ApplicationState,
+  null,
+  AnyAction
+> => async (dispatch, getState) => {
+  await _logOutFromServer(getState().api);
+  dispatch(actions.logOut());
 };
 
 export type UsersState = {

--- a/src/test-helpers.spec.tsx
+++ b/src/test-helpers.spec.tsx
@@ -11,6 +11,7 @@ describe(__filename, () => {
     };
 
     const wrapper = () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return (WrappedComponent: any) => {
         return (props: object) => {
           return <WrappedComponent {...props} />;

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -167,7 +167,9 @@ type ShallowUntilTargetOptions = {
 };
 
 export const shallowUntilTarget = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   componentInstance: React.ReactElement<any>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   targetComponent: React.JSXElementConstructor<any>,
   {
     maxTries = 10,

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -219,17 +219,18 @@ export const shallowUntilTarget = (
  *
  * You can make an assertion that it was called like:
  *
- * expect(dispatch).toHaveBeenCalledWith(fakeThunk.dispatchCallback);
+ * expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
  */
 export const createFakeThunk = () => {
-  // This is a placeholder for the dispatch callback function.
+  // This is a placeholder for the dispatch callback function,
+  // the thunk itself.
   // In reality it would look like (dispatch, getState) => {}
   // but here it gets set to a string for easy test assertions.
-  const dispatchCallback = '__dispatchCallbackReturnedByTheThunk__';
+  const dispatchCallback = '__thunkDispatchCallback__';
 
   return {
     // This is a function that creates the dispatch callback.
     createThunk: jest.fn().mockReturnValue(dispatchCallback),
-    dispatchCallback,
+    thunk: dispatchCallback,
   };
 };

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -199,3 +199,37 @@ export const shallowUntilTarget = (
      gave up after ${maxTries} tries`,
   );
 };
+
+/*
+ * Creates a fake thunk for testing.
+ *
+ * Let's say you had a real thunk like this:
+ *
+ * const doLogout = () => {
+ *   return (dispatch, getState) => {
+ *     // Make a request to the API...
+ *     dispatch({ type: 'LOG_OUT' });
+ *   };
+ * };
+ *
+ * You can replace this thunk for testing as:
+ *
+ * const fakeThunk = createFakeThunk();
+ * render({ _doLogout: fakeThunk.createThunk });
+ *
+ * You can make an assertion that it was called like:
+ *
+ * expect(dispatch).toHaveBeenCalledWith(fakeThunk.dispatchCallback);
+ */
+export const createFakeThunk = () => {
+  // This is a placeholder for the dispatch callback function.
+  // In reality it would look like (dispatch, getState) => {}
+  // but here it gets set to a string for easy test assertions.
+  const dispatchCallback = '__dispatchCallbackReturnedByTheThunk__';
+
+  return {
+    // This is a function that creates the dispatch callback.
+    createThunk: jest.fn().mockReturnValue(dispatchCallback),
+    dispatchCallback,
+  };
+};

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -1,7 +1,12 @@
 import PropTypes from 'prop-types';
 import { History, Location } from 'history';
 import { shallow } from 'enzyme';
+import { Store } from 'redux';
 
+import configureStore, {
+  ApplicationState,
+  ThunkActionCreator,
+} from './configureStore';
 import { ExternalUser } from './reducers/users';
 import {
   ExternalVersion,
@@ -232,5 +237,46 @@ export const createFakeThunk = () => {
     // This is a function that creates the dispatch callback.
     createThunk: jest.fn().mockReturnValue(dispatchCallback),
     thunk: dispatchCallback,
+  };
+};
+
+/*
+ * Sets up a thunk for testing.
+ *
+ * Let's say you had a real thunk like this:
+ *
+ * const doLogout = () => {
+ *   return (dispatch, getState) => {
+ *     // Make a request to the API...
+ *     dispatch({ type: 'LOG_OUT' });
+ *   };
+ * };
+ *
+ * You can set it up for testing like this:
+ *
+ * const { dispatch, thunk, store } = thunkTester({
+ *   createThunk: () => doLogout(),
+ * });
+ *
+ * await thunk();
+ *
+ * expect(dispatch).toHaveBeenCalledWith({ type: 'LOG_OUT' });
+ *
+ */
+export const thunkTester = ({
+  store = configureStore(),
+  createThunk,
+}: {
+  store?: Store<ApplicationState>;
+  createThunk: () => ThunkActionCreator;
+}) => {
+  const thunk = createThunk();
+  const dispatch = jest.fn();
+
+  return {
+    dispatch,
+    // This simulates how the middleware will run the thunk.
+    thunk: () => thunk(dispatch, () => store.getState(), undefined),
+    store,
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11696,6 +11696,11 @@ redux-logger@3.0.6:
   dependencies:
     deep-diff "^0.3.5"
 
+redux-thunk@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+
 redux@4.0.1, redux@^4.0.0, redux@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/12

After some consideration (see below), redux-thunk is a pretty good option. This adds redux-thunk for handling side effects.

<hr>

*Original PR description:*

As part of https://github.com/mozilla/addons-code-manager/issues/12, here's an example of using `redux-thunk` so we can assess it.

Here are some questions worth asking:
- How testable is this?
- Does it allow our application behavior to be traced through one place?
- [maybe more questions]

Known issues:
- ~~The `(dispatch as ThunkDispatch)` type hint seems like it should be unnecessary since we have types for our middleware (see https://github.com/reduxjs/redux-thunk/issues/103) but I couldn't get the error to go away without this type hint, even when doing the same module override.~~
- I don't like how the *execution* of `requestLogOut()` is not captured in action replay. When we used sagas, it was possible to replay the stack of actions and re-execute each saga. This reduces traceability. As an example, let's say we were given a stack of actions by someone who encountered an error thrown in a thunk. The stack of actions would not let us reproduce that error.