### PR TITLE
Add add-on info to the `versions` reducer

### DIFF
--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -82,7 +82,7 @@ describe(__filename, () => {
 
   describe('createInternalVersionAddon', () => {
     it('creates a VersionAddon', () => {
-      const addon = { ...fakeVersionAddon, id: 1234 };
+      const addon = fakeVersionAddon;
 
       expect(createInternalVersionAddon(addon)).toEqual({
         iconUrl: addon.icon_url,

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -2,6 +2,7 @@ import reducer, {
   VersionEntryType,
   actions,
   createInternalVersion,
+  createInternalVersionAddon,
   createInternalVersionEntry,
   createInternalVersionFile,
   getVersionEntryType,
@@ -12,6 +13,7 @@ import reducer, {
 } from './versions';
 import {
   fakeVersion,
+  fakeVersionAddon,
   fakeVersionEntry,
   fakeVersionFile,
 } from '../test-helpers';
@@ -78,6 +80,19 @@ describe(__filename, () => {
     });
   });
 
+  describe('createInternalVersionAddon', () => {
+    it('creates a VersionAddon', () => {
+      const addon = { ...fakeVersionAddon, id: 1234 };
+
+      expect(createInternalVersionAddon(addon)).toEqual({
+        iconUrl: addon.icon_url,
+        id: addon.id,
+        name: addon.name,
+        slug: addon.slug,
+      });
+    });
+  });
+
   describe('createInternalVersionEntry', () => {
     it('creates a VersionEntry', () => {
       const entry = { ...fakeVersionEntry, filename: 'entry' };
@@ -98,6 +113,7 @@ describe(__filename, () => {
       const entry = version.file.entries[Object.keys(version.file.entries)[0]];
 
       expect(createInternalVersion(version)).toEqual({
+        addon: createInternalVersionAddon(version.addon),
         entries: [createInternalVersionEntry(entry)],
         id: version.id,
         reviewed: version.reviewed,
@@ -119,6 +135,7 @@ describe(__filename, () => {
       const version = { ...fakeVersion, file };
 
       expect(createInternalVersion(version)).toEqual({
+        addon: createInternalVersionAddon(version.addon),
         entries: [
           createInternalVersionEntry(entry1),
           createInternalVersionEntry(entry2),

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -53,7 +53,15 @@ export type ExternalVersionFile = {
   url: string;
 };
 
+export type ExternalVersionAddon = {
+  icon_url: string;
+  id: number;
+  name: LocalizedString;
+  slug: string;
+};
+
 export type ExternalVersion = {
+  addon: ExternalVersionAddon;
   channel: string;
   compatibility: VersionCompatibility;
   edit_url: string;
@@ -92,7 +100,15 @@ type VersionEntry = {
   type: VersionEntryType;
 };
 
+type VersionAddon = {
+  iconUrl: string;
+  id: number;
+  name: LocalizedString;
+  slug: string;
+};
+
 export type Version = {
+  addon: VersionAddon;
   entries: VersionEntry[];
   id: VersionId;
   reviewed: string;
@@ -162,8 +178,20 @@ export const createInternalVersionEntry = (
   };
 };
 
+export const createInternalVersionAddon = (
+  addon: ExternalVersionAddon,
+): VersionAddon => {
+  return {
+    iconUrl: addon.icon_url,
+    id: addon.id,
+    name: addon.name,
+    slug: addon.slug,
+  };
+};
+
 export const createInternalVersion = (version: ExternalVersion): Version => {
   return {
+    addon: createInternalVersionAddon(version.addon),
     entries: Object.keys(version.file.entries).map((nodeName) => {
       return createInternalVersionEntry(version.file.entries[nodeName]);
     }),

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -10,6 +10,7 @@ import configureStore, {
 import { ExternalUser } from './reducers/users';
 import {
   ExternalVersion,
+  ExternalVersionAddon,
   ExternalVersionEntry,
   ExternalVersionFile,
 } from './reducers/versions';
@@ -47,7 +48,15 @@ export const fakeVersionFile: ExternalVersionFile = Object.freeze({
   url: 'http://example.com/edit/',
 });
 
+export const fakeVersionAddon: ExternalVersionAddon = Object.freeze({
+  icon_url: 'some-icon-url',
+  id: 111,
+  name: { 'en-US': 'addon name' },
+  slug: 'addon-slug',
+});
+
 export const fakeVersion: ExternalVersion = Object.freeze({
+  addon: fakeVersionAddon,
   channel: 'some channel',
   compatibility: {
     firefox: {


### PR DESCRIPTION
Fixes #180 

I'm wondering, though, what we want to do about localized strings. Making use of this new `VersionAddon` object will be the first time we have to deal with them (for the `name` property). The API returns localized strings to us, i.e., an object with a translation for different locales, but maybe that's not what we want?

I believe in addons-frontend we set up the API call so it would include a language and we'd only get the string back for the language we requested. Although we don't think we're going to support multiple languages in the app, it seems like this is probably the route we should go here. Otherwise our code is going to have to deal with these localized string objects.

What do people think?
