### PR TITLE
Send an explicit language with API requests

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,8 @@
+REACT_APP_API_HOST=https://addons.mozilla.org
 # This is the placeholder used in the `index.html` file to inject the
 # authentication token on runtime.
 REACT_APP_AUTH_TOKEN_PLACEHOLDER=__AUTH_TOKEN__
-
-REACT_APP_API_HOST=https://addons.mozilla.org
-REACT_APP_FXA_CONFIG=amo
 REACT_APP_AUTHENTICATION_COOKIE=frontend_auth_token
+# This is the language that will be sent with all API requests.
+REACT_APP_DEFAULT_API_LANG=en-US
+REACT_APP_FXA_CONFIG=amo

--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -8,8 +8,8 @@ import {
 import { HttpMethod, callApi, getVersion, logOutFromServer } from '.';
 
 describe(__filename, () => {
-  const defaultLang = process.env.REACT_APP_DEFAULT_API_LANG;
-  const defaultVersion = 'v4dev';
+  const defaultLang = process.env.REACT_APP_DEFAULT_API_LANG as string;
+  const defaultVersion = process.env.REACT_APP_DEFAULT_API_VERSION;
 
   const getApiState = ({ authToken = '12345' } = {}) => {
     const store = configureStore();

--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -8,6 +8,8 @@ import configureStore from '../configureStore';
 import { HttpMethod, callApi, getVersion, logOutFromServer } from '.';
 
 describe(__filename, () => {
+  const defaultQueryString = `?lang=${process.env.REACT_APP_DEFAULT_API_LANG}`;
+
   const getApiState = ({ authToken = '12345' } = {}) => {
     const store = configureStore();
 
@@ -22,10 +24,10 @@ describe(__filename, () => {
       return callApi({ apiState: defaultApiState, endpoint: '/', ...params });
     };
 
-    it('calls the API', async () => {
+    it('calls the API using the default language', async () => {
       await callApiWithDefaultApiState({ endpoint: '/foo/' });
 
-      expect(fetch).toHaveBeenCalledWith(`/api/v4/foo/`, {
+      expect(fetch).toHaveBeenCalledWith(`/api/v4/foo/${defaultQueryString}`, {
         headers: {},
         method: 'GET',
       });
@@ -34,13 +36,19 @@ describe(__filename, () => {
     it('adds a trailing slash to the endpoint if there is none', async () => {
       await callApiWithDefaultApiState({ endpoint: '/foo' });
 
-      expect(fetch).toHaveBeenCalledWith(`/api/v4/foo/`, expect.any(Object));
+      expect(fetch).toHaveBeenCalledWith(
+        `/api/v4/foo/${defaultQueryString}`,
+        expect.any(Object),
+      );
     });
 
     it('adds a leading slash to the endpoint if there is none', async () => {
       await callApiWithDefaultApiState({ endpoint: 'foo/' });
 
-      expect(fetch).toHaveBeenCalledWith(`/api/v4/foo/`, expect.any(Object));
+      expect(fetch).toHaveBeenCalledWith(
+        `/api/v4/foo/${defaultQueryString}`,
+        expect.any(Object),
+      );
     });
 
     it('accepts an HTTP method', async () => {
@@ -62,7 +70,18 @@ describe(__filename, () => {
       await callApiWithDefaultApiState({ endpoint: '/', version });
 
       expect(fetch).toHaveBeenCalledWith(
-        `/api/${version}/`,
+        `/api/${version}/${defaultQueryString}`,
+        expect.any(Object),
+      );
+    });
+
+    it('accepts an API lang', async () => {
+      const lang = 'en-CA';
+
+      await callApiWithDefaultApiState({ endpoint: '/', lang });
+
+      expect(fetch).toHaveBeenCalledWith(
+        `/api/v4/?lang=${lang}`,
         expect.any(Object),
       );
     });
@@ -129,7 +148,7 @@ describe(__filename, () => {
 
       expect(response).toHaveProperty(
         'error',
-        new Error('Unexpected status for GET /: 400'),
+        new Error(`Unexpected status for GET /${defaultQueryString}: 400`),
       );
     });
 
@@ -139,7 +158,7 @@ describe(__filename, () => {
       await callApiWithDefaultApiState({ endpoint: '/url', query });
 
       expect(fetch).toHaveBeenCalledWith(
-        '/api/v4/url/?foo=1&bar=abc',
+        `/api/v4/url/${defaultQueryString}&foo=1&bar=abc`,
         expect.any(Object),
       );
     });
@@ -153,7 +172,7 @@ describe(__filename, () => {
       await getVersion({ apiState: defaultApiState, addonId, versionId });
 
       expect(fetch).toHaveBeenCalledWith(
-        `/api/v4/reviewers/addon/${addonId}/versions/${versionId}/`,
+        `/api/v4/reviewers/addon/${addonId}/versions/${versionId}/${defaultQueryString}`,
         {
           headers: {},
           method: HttpMethod.GET,
@@ -174,7 +193,7 @@ describe(__filename, () => {
       });
 
       expect(fetch).toHaveBeenCalledWith(
-        `/api/v4/reviewers/addon/${addonId}/versions/${versionId}/?file=${path}`,
+        `/api/v4/reviewers/addon/${addonId}/versions/${versionId}/${defaultQueryString}&file=${path}`,
         {
           headers: {},
           method: HttpMethod.GET,
@@ -187,10 +206,13 @@ describe(__filename, () => {
     it(`calls the API to delete the user's session`, async () => {
       await logOutFromServer(defaultApiState);
 
-      expect(fetch).toHaveBeenCalledWith('/api/v4/accounts/session/', {
-        headers: {},
-        method: HttpMethod.DELETE,
-      });
+      expect(fetch).toHaveBeenCalledWith(
+        `/api/v4/accounts/session/${defaultQueryString}`,
+        {
+          headers: {},
+          method: HttpMethod.DELETE,
+        },
+      );
     });
   });
 });

--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -8,7 +8,7 @@ import {
 import { HttpMethod, callApi, getVersion, logOutFromServer } from '.';
 
 describe(__filename, () => {
-  const defaultLang = process.env.REACT_APP_DEFAULT_API_LANG as string;
+  const defaultLang = process.env.REACT_APP_DEFAULT_API_LANG;
   const defaultVersion = process.env.REACT_APP_DEFAULT_API_VERSION;
 
   const getApiState = ({ authToken = '12345' } = {}) => {

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -29,9 +29,9 @@ export const callApi = async ({
   apiState,
   endpoint,
   method = HttpMethod.GET,
-  version = 'v4dev',
+  version = process.env.REACT_APP_DEFAULT_API_VERSION,
   query = {},
-  lang = process.env.REACT_APP_DEFAULT_API_LANG,
+  lang = process.env.REACT_APP_DEFAULT_API_LANG as string,
 }: CallApiParams): Promise<CallApiResponse> => {
   let adjustedEndpoint = endpoint;
   if (!adjustedEndpoint.startsWith('/')) {
@@ -46,8 +46,12 @@ export const callApi = async ({
     headers.Authorization = `Bearer ${apiState.authToken}`;
   }
 
+  type QueryWithLang = {
+    [key: string]: string;
+  };
+
   // Add the lang parameter to the querystring
-  const queryWithLang = Object.assign({ lang }, query);
+  const queryWithLang: QueryWithLang = { ...query, lang };
 
   const queryString = Object.keys(queryWithLang)
     .map((k) => `${k}=${queryWithLang[k]}`)

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -29,7 +29,7 @@ export const callApi = async ({
   apiState,
   endpoint,
   method = HttpMethod.GET,
-  version = 'v4',
+  version = 'v4dev',
   query = {},
   lang = process.env.REACT_APP_DEFAULT_API_LANG,
 }: CallApiParams): Promise<CallApiResponse> => {
@@ -41,21 +41,19 @@ export const callApi = async ({
     adjustedEndpoint = `${adjustedEndpoint}/`;
   }
 
-  // Add the lang parameter to the querystring
-  adjustedEndpoint = `${adjustedEndpoint}?lang=${lang}`;
-
   const headers: Headers = {};
   if (apiState.authToken) {
     headers.Authorization = `Bearer ${apiState.authToken}`;
   }
 
-  if (Object.keys(query).length) {
-    const queryString = Object.keys(query)
-      .map((k) => `${k}=${query[k]}`)
-      .join('&');
+  // Add the lang parameter to the querystring
+  const queryWithLang = Object.assign({ lang }, query);
 
-    adjustedEndpoint = `${adjustedEndpoint}&${queryString}`;
-  }
+  const queryString = Object.keys(queryWithLang)
+    .map((k) => `${k}=${queryWithLang[k]}`)
+    .join('&');
+
+  adjustedEndpoint = `${adjustedEndpoint}?${queryString}`;
 
   try {
     const response = await fetch(`/api/${version}${adjustedEndpoint}`, {

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -16,6 +16,7 @@ type CallApiParams = {
   version?: string;
   apiState: ApiState;
   query?: { [key: string]: string };
+  lang?: string;
 };
 
 type CallApiResponse = object | { error: Error };
@@ -30,6 +31,7 @@ export const callApi = async ({
   method = HttpMethod.GET,
   version = 'v4',
   query = {},
+  lang = process.env.REACT_APP_DEFAULT_API_LANG,
 }: CallApiParams): Promise<CallApiResponse> => {
   let adjustedEndpoint = endpoint;
   if (!adjustedEndpoint.startsWith('/')) {
@@ -38,6 +40,9 @@ export const callApi = async ({
   if (!adjustedEndpoint.endsWith('/')) {
     adjustedEndpoint = `${adjustedEndpoint}/`;
   }
+
+  // Add the lang parameter to the querystring
+  adjustedEndpoint = `${adjustedEndpoint}?lang=${lang}`;
 
   const headers: Headers = {};
   if (apiState.authToken) {
@@ -49,7 +54,7 @@ export const callApi = async ({
       .map((k) => `${k}=${query[k]}`)
       .join('&');
 
-    adjustedEndpoint = `${adjustedEndpoint}?${queryString}`;
+    adjustedEndpoint = `${adjustedEndpoint}&${queryString}`;
   }
 
   try {

--- a/src/jest-matchers/index.spec.tsx
+++ b/src/jest-matchers/index.spec.tsx
@@ -72,3 +72,5 @@ describe(__filename, () => {
     });
   });
 });
+
+export {};

--- a/src/jest-matchers/index.spec.tsx
+++ b/src/jest-matchers/index.spec.tsx
@@ -1,70 +1,74 @@
-const baseUrl = 'http://example.com';
-const param1 = 'param1';
-const param2 = 'param2';
-const testParams = { param1, param2 };
+describe(__filename, () => {
+  const baseUrl = 'http://example.com';
+  const param1 = 'param1';
+  const param2 = 'param2';
+  const testParams = { param1, param2 };
 
-describe('.urlWithTheseParams', () => {
-  test('passes when URL includes all params', () => {
-    expect(`${baseUrl}?param1=${param1}&param2=${param2}`).urlWithTheseParams(
-      testParams,
-    );
+  describe('.urlWithTheseParams', () => {
+    it('passes when URL includes all params', () => {
+      expect(`${baseUrl}?param1=${param1}&param2=${param2}`).urlWithTheseParams(
+        testParams,
+      );
+    });
+
+    it('passes regardless of order of params', () => {
+      expect(`${baseUrl}?param2=${param2}&param1=${param1}`).urlWithTheseParams(
+        testParams,
+      );
+    });
+
+    it('provides a descriptive message when it fails', () => {
+      const testUrl = `${baseUrl}?param1=${param1}`;
+      expect(() => expect(testUrl).urlWithTheseParams(testParams)).toThrow(
+        `expected ${testUrl} to contain params ${JSON.stringify(testParams)}`,
+      );
+    });
+
+    it('fails when URL includes no params', () => {
+      expect(() => expect(baseUrl).urlWithTheseParams(testParams)).toThrow(
+        'expected',
+      );
+    });
+
+    it('fails when URL includes only some params', () => {
+      expect(() =>
+        expect(`${baseUrl}?param1=${param1}`).urlWithTheseParams(testParams),
+      ).toThrow('expected');
+    });
   });
 
-  test('passes regardless of order of params', () => {
-    expect(`${baseUrl}?param2=${param2}&param1=${param1}`).urlWithTheseParams(
-      testParams,
-    );
-  });
+  describe('.not.urlWithTheseParams', () => {
+    it('passes when URL includes no params', () => {
+      expect(baseUrl).not.urlWithTheseParams(testParams);
+    });
 
-  test('provides a descriptive message when it fails', () => {
-    const testUrl = `${baseUrl}?param1=${param1}`;
-    expect(() => expect(testUrl).urlWithTheseParams(testParams)).toThrow(
-      `expected ${testUrl} to contain params ${JSON.stringify(testParams)}`,
-    );
-  });
+    it('passes when URL includes only some params', () => {
+      expect(`${baseUrl}?param1=${param1}`).not.urlWithTheseParams(testParams);
+    });
 
-  test('fails when URL includes no params', () => {
-    expect(() => expect(baseUrl).urlWithTheseParams(testParams)).toThrow(
-      'expected',
-    );
-  });
+    it('provides a descriptive message when it fails', () => {
+      const testUrl = `${baseUrl}?param1=${param1}&param2=${param2}`;
+      expect(() => expect(testUrl).not.urlWithTheseParams(testParams)).toThrow(
+        `expected ${testUrl} to not contain params ${JSON.stringify(
+          testParams,
+        )}`,
+      );
+    });
 
-  test('fails when URL includes only some params', () => {
-    expect(() =>
-      expect(`${baseUrl}?param1=${param1}`).urlWithTheseParams(testParams),
-    ).toThrow('expected');
-  });
-});
+    it('fails when URL includes all params', () => {
+      expect(() =>
+        expect(
+          `${baseUrl}?param1=${param1}&param2=${param2}`,
+        ).not.urlWithTheseParams(testParams),
+      ).toThrow('expected');
+    });
 
-describe('.not.urlWithTheseParams', () => {
-  test('passes when URL includes no params', () => {
-    expect(baseUrl).not.urlWithTheseParams(testParams);
-  });
-
-  test('passes when URL includes only some params', () => {
-    expect(`${baseUrl}?param1=${param1}`).not.urlWithTheseParams(testParams);
-  });
-
-  test('provides a descriptive message when it fails', () => {
-    const testUrl = `${baseUrl}?param1=${param1}&param2=${param2}`;
-    expect(() => expect(testUrl).not.urlWithTheseParams(testParams)).toThrow(
-      `expected ${testUrl} to not contain params ${JSON.stringify(testParams)}`,
-    );
-  });
-
-  test('fails when URL includes all params', () => {
-    expect(() =>
-      expect(
-        `${baseUrl}?param1=${param1}&param2=${param2}`,
-      ).not.urlWithTheseParams(testParams),
-    ).toThrow('expected');
-  });
-
-  test('fails regardless of order of params', () => {
-    expect(() =>
-      expect(
-        `${baseUrl}?param2=${param2}&param1=${param1}`,
-      ).not.urlWithTheseParams(testParams),
-    ).toThrow('expected');
+    it('fails regardless of order of params', () => {
+      expect(() =>
+        expect(
+          `${baseUrl}?param2=${param2}&param1=${param1}`,
+        ).not.urlWithTheseParams(testParams),
+      ).toThrow('expected');
+    });
   });
 });

--- a/src/jest-matchers/index.spec.tsx
+++ b/src/jest-matchers/index.spec.tsx
@@ -73,4 +73,6 @@ describe(__filename, () => {
   });
 });
 
+// We need this empty export or `tsc` thinks this is a global module and
+// compilation fails.
 export {};

--- a/src/jest-matchers/index.spec.tsx
+++ b/src/jest-matchers/index.spec.tsx
@@ -1,0 +1,70 @@
+const baseUrl = 'http://example.com';
+const param1 = 'param1';
+const param2 = 'param2';
+const testParams = { param1, param2 };
+
+describe('.urlWithTheseParams', () => {
+  test('passes when URL includes all params', () => {
+    expect(`${baseUrl}?param1=${param1}&param2=${param2}`).urlWithTheseParams(
+      testParams,
+    );
+  });
+
+  test('passes regardless of order of params', () => {
+    expect(`${baseUrl}?param2=${param2}&param1=${param1}`).urlWithTheseParams(
+      testParams,
+    );
+  });
+
+  test('provides a descriptive message when it fails', () => {
+    const testUrl = `${baseUrl}?param1=${param1}`;
+    expect(() => expect(testUrl).urlWithTheseParams(testParams)).toThrow(
+      `expected ${testUrl} to contain params ${JSON.stringify(testParams)}`,
+    );
+  });
+
+  test('fails when URL includes no params', () => {
+    expect(() => expect(baseUrl).urlWithTheseParams(testParams)).toThrow(
+      'expected',
+    );
+  });
+
+  test('fails when URL includes only some params', () => {
+    expect(() =>
+      expect(`${baseUrl}?param1=${param1}`).urlWithTheseParams(testParams),
+    ).toThrow('expected');
+  });
+});
+
+describe('.not.urlWithTheseParams', () => {
+  test('passes when URL includes no params', () => {
+    expect(baseUrl).not.urlWithTheseParams(testParams);
+  });
+
+  test('passes when URL includes only some params', () => {
+    expect(`${baseUrl}?param1=${param1}`).not.urlWithTheseParams(testParams);
+  });
+
+  test('provides a descriptive message when it fails', () => {
+    const testUrl = `${baseUrl}?param1=${param1}&param2=${param2}`;
+    expect(() => expect(testUrl).not.urlWithTheseParams(testParams)).toThrow(
+      `expected ${testUrl} to not contain params ${JSON.stringify(testParams)}`,
+    );
+  });
+
+  test('fails when URL includes all params', () => {
+    expect(() =>
+      expect(
+        `${baseUrl}?param1=${param1}&param2=${param2}`,
+      ).not.urlWithTheseParams(testParams),
+    ).toThrow('expected');
+  });
+
+  test('fails regardless of order of params', () => {
+    expect(() =>
+      expect(
+        `${baseUrl}?param2=${param2}&param1=${param1}`,
+      ).not.urlWithTheseParams(testParams),
+    ).toThrow('expected');
+  });
+});

--- a/src/jest-matchers/index.tsx
+++ b/src/jest-matchers/index.tsx
@@ -1,0 +1,36 @@
+import url from 'url';
+
+expect.extend({
+  /*
+   * A jest matcher to check if the URL contains the declared params.
+   *
+   * Example:
+   *
+   * expect(fetch).toHaveBeenCalledWith(
+   *   expect.urlWithTheseParams({
+   *     page: 1,
+   *   }),
+   * )
+   */
+  urlWithTheseParams(urlString: string, params: { [key: string]: string }) {
+    const { query } = url.parse(urlString, true);
+
+    for (const param in params) {
+      if (
+        query[param] === undefined ||
+        query[param] !== params[param].toString()
+      ) {
+        return {
+          message: () =>
+            `expected ${urlString} to contain params ${JSON.stringify(params)}`,
+          pass: false,
+        };
+      }
+    }
+    return {
+      message: () =>
+        `expected ${urlString} to not contain params ${JSON.stringify(params)}`,
+      pass: true,
+    };
+  },
+});

--- a/src/jest-matchers/index.tsx
+++ b/src/jest-matchers/index.tsx
@@ -1,5 +1,22 @@
 import url from 'url';
 
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      urlWithTheseParams(params: {
+        [key: string]: string | void;
+      }): CustomMatcherResult;
+    }
+
+    interface Expect {
+      urlWithTheseParams(params: {
+        [key: string]: string | void;
+      }): CustomMatcherResult;
+    }
+  }
+}
+
 expect.extend({
   /*
    * A jest matcher to check if the URL contains the declared params.

--- a/src/jest.d.ts
+++ b/src/jest.d.ts
@@ -1,0 +1,5 @@
+declare namespace jest {
+  interface Matchers<R> {
+    urlWithTheseParams(params: { [key: string]: string }): CustomMatcherResult;
+  }
+}

--- a/src/jest.d.ts
+++ b/src/jest.d.ts
@@ -1,5 +1,0 @@
-declare namespace jest {
-  interface Matchers<R> {
-    urlWithTheseParams(params: { [key: string]: string }): CustomMatcherResult;
-  }
-}

--- a/src/setupTests.tsx
+++ b/src/setupTests.tsx
@@ -3,6 +3,8 @@ import Adapter from 'enzyme-adapter-react-16';
 import { GlobalWithFetchMock } from 'jest-fetch-mock';
 import 'jest-enzyme';
 
+import './jest-matchers';
+
 configure({ adapter: new Adapter() });
 
 // See: https://github.com/jefflau/jest-fetch-mock/tree/07cf149688b6738e0a45864626ba47793d04da23#typescript-guide


### PR DESCRIPTION
Fixes #192 

Note that after making this change, the data I am getting back from the API no longer contains localized strings. I believe this is because the `v4` API is currently configured to return simple strings, and not objects, in order to be backwards compatible with addons-frontend, and that there is a different endpoint we can use to get the localized strings (something like `dev4`, iirc). 

@eviljeff What is the endpoint we need to use to get localized strings back from the API, even if we pass in a `lang`, and is it currently configured to work with `addons-code-manager`?