### PR TITLE
Add better return types for the API functions

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,12 @@
 REACT_APP_API_HOST=https://addons.mozilla.org
+
 # This is the placeholder used in the `index.html` file to inject the
 # authentication token on runtime.
 REACT_APP_AUTH_TOKEN_PLACEHOLDER=__AUTH_TOKEN__
 REACT_APP_AUTHENTICATION_COOKIE=frontend_auth_token
+
 # This is the language that will be sent with all API requests.
 REACT_APP_DEFAULT_API_LANG=en-US
+REACT_APP_DEFAULT_API_VERSION=v4dev
+
 REACT_APP_FXA_CONFIG=amo

--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -5,7 +5,14 @@ import {
   initialState as defaultApiState,
 } from '../reducers/api';
 
-import { HttpMethod, callApi, getVersion, logOutFromServer } from '.';
+import {
+  HttpMethod,
+  callApi,
+  getCurrentUserProfile,
+  getVersion,
+  isErrorResponse,
+  logOutFromServer,
+} from '.';
 
 describe(__filename, () => {
   const defaultLang = process.env.REACT_APP_DEFAULT_API_LANG;
@@ -179,6 +186,20 @@ describe(__filename, () => {
     });
   });
 
+  describe('isErrorResponse', () => {
+    it('returns true if a response object is an error', () => {
+      const response = { error: 'this is an error' };
+
+      expect(isErrorResponse(response)).toEqual(true);
+    });
+
+    it('returns false if a response object is not an error', () => {
+      const response = { id: 123 };
+
+      expect(isErrorResponse(response)).toEqual(false);
+    });
+  });
+
   describe('getVersion', () => {
     it('calls the API to retrieve version information', async () => {
       const addonId = 999;
@@ -230,6 +251,17 @@ describe(__filename, () => {
           method: HttpMethod.DELETE,
         },
       );
+    });
+  });
+
+  describe('getCurrentUserProfile', () => {
+    it('calls the API to retrieve the current logged-in user profile', async () => {
+      await getCurrentUserProfile(defaultApiState);
+
+      expect(fetch).toHaveBeenCalledWith(`/api/v4/accounts/profile/`, {
+        headers: {},
+        method: HttpMethod.GET,
+      });
     });
   });
 });

--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -258,10 +258,13 @@ describe(__filename, () => {
     it('calls the API to retrieve the current logged-in user profile', async () => {
       await getCurrentUserProfile(defaultApiState);
 
-      expect(fetch).toHaveBeenCalledWith(`/api/v4/accounts/profile/`, {
-        headers: {},
-        method: HttpMethod.GET,
-      });
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(`/api/${defaultVersion}/accounts/profile/`),
+        {
+          headers: {},
+          method: HttpMethod.GET,
+        },
+      );
     });
   });
 });

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -1,6 +1,8 @@
 import log from 'loglevel';
 
 import { ApiState } from '../reducers/api';
+import { ExternalUser } from '../reducers/users';
+import { ExternalVersion } from '../reducers/versions';
 
 export enum HttpMethod {
   DELETE = 'DELETE',
@@ -19,20 +21,37 @@ type CallApiParams = {
   lang?: string;
 };
 
-type CallApiResponse = object | { error: Error };
+type ErrorResponseType = { error: Error };
+
+type CallApiResponse<SuccessResponseType> =
+  | SuccessResponseType
+  | ErrorResponseType;
+
+// This function below is a user-defined type guard that we use to check
+// whether a callApi response object is successful or unsuccessful. We use
+// `any` on purpose because we don't know the exact type for
+// `SuccessResponseType`.
+export const isErrorResponse = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  arg: CallApiResponse<any>,
+): arg is ErrorResponseType => {
+  return arg.error !== undefined;
+};
 
 type Headers = {
   [name: string]: string;
 };
 
-export const callApi = async ({
+// For the `extends {}` part, please see:
+// https://github.com/Microsoft/TypeScript/issues/4922
+export const callApi = async <SuccessResponseType extends {}>({
   apiState,
   endpoint,
   method = HttpMethod.GET,
   version = process.env.REACT_APP_DEFAULT_API_VERSION,
   query = {},
   lang = process.env.REACT_APP_DEFAULT_API_LANG as string,
-}: CallApiParams): Promise<CallApiResponse> => {
+}: CallApiParams): Promise<CallApiResponse<SuccessResponseType>> => {
   let adjustedEndpoint = endpoint;
   if (!adjustedEndpoint.startsWith('/')) {
     adjustedEndpoint = `/${adjustedEndpoint}`;
@@ -96,7 +115,7 @@ export const getVersion = async ({
   addonId,
   versionId,
 }: GetVersionParams) => {
-  return callApi({
+  return callApi<ExternalVersion>({
     apiState,
     endpoint: `reviewers/addon/${addonId}/versions/${versionId}`,
     query: path ? { file: path } : undefined,
@@ -104,9 +123,16 @@ export const getVersion = async ({
 };
 
 export const logOutFromServer = async (apiState: ApiState) => {
-  return callApi({
+  return callApi<{}>({
     apiState,
     endpoint: 'accounts/session',
     method: HttpMethod.DELETE,
+  });
+};
+
+export const getCurrentUserProfile = async (apiState: ApiState) => {
+  return callApi<ExternalUser>({
+    apiState,
+    endpoint: '/accounts/profile/',
   });
 };

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -50,7 +50,7 @@ export const callApi = async <SuccessResponseType extends {}>({
   method = HttpMethod.GET,
   version = process.env.REACT_APP_DEFAULT_API_VERSION,
   query = {},
-  lang = process.env.REACT_APP_DEFAULT_API_LANG as string,
+  lang = process.env.REACT_APP_DEFAULT_API_LANG,
 }: CallApiParams): Promise<CallApiResponse<SuccessResponseType>> => {
   let adjustedEndpoint = endpoint;
   if (!adjustedEndpoint.startsWith('/')) {
@@ -69,8 +69,8 @@ export const callApi = async <SuccessResponseType extends {}>({
     [key: string]: string;
   };
 
-  // Add the lang parameter to the querystring
-  const queryWithLang: QueryWithLang = { ...query, lang };
+  // Add the lang parameter to the query string.
+  const queryWithLang: QueryWithLang = lang ? { ...query, lang } : query;
 
   const queryString = Object.keys(queryWithLang)
     .map((k) => `${k}=${queryWithLang[k]}`)

--- a/src/components/App/index.spec.tsx
+++ b/src/components/App/index.spec.tsx
@@ -6,29 +6,27 @@ import { Route } from 'react-router-dom';
 import styles from './styles.module.scss';
 import configureStore from '../../configureStore';
 import { actions as apiActions } from '../../reducers/api';
-import {
-  actions as userActions,
-  fetchCurrentUserProfile,
-} from '../../reducers/users';
+import { actions as userActions } from '../../reducers/users';
 import {
   createContextWithFakeRouter,
   createFakeThunk,
   fakeUser,
   shallowUntilTarget,
+  spyOn,
 } from '../../test-helpers';
 import Navbar from '../Navbar';
 
-import App, { AppBase } from '.';
+import App, { AppBase, PublicProps } from '.';
 
 describe(__filename, () => {
   type RenderParams = {
-    _fetchCurrentUserProfile?: typeof fetchCurrentUserProfile;
+    _fetchCurrentUserProfile?: PublicProps['_fetchCurrentUserProfile'];
+    authToken?: PublicProps['authToken'];
     store?: Store;
-    authToken?: string | null;
   };
 
   const render = ({
-    _fetchCurrentUserProfile,
+    _fetchCurrentUserProfile = createFakeThunk().createThunk,
     authToken = 'some-token',
     store = configureStore(),
   }: RenderParams = {}) => {
@@ -79,7 +77,7 @@ describe(__filename, () => {
   it('dispatches setAuthToken on mount when authToken is valid', () => {
     const authToken = 'my-token';
     const store = configureStore();
-    const dispatch = jest.spyOn(store, 'dispatch');
+    const dispatch = spyOn(store, 'dispatch');
 
     render({ authToken, store });
 
@@ -90,7 +88,7 @@ describe(__filename, () => {
 
   it('does not dispatch setAuthToken on mount when authToken is null', () => {
     const store = configureStore();
-    const dispatch = jest.spyOn(store, 'dispatch');
+    const dispatch = spyOn(store, 'dispatch');
 
     render({ authToken: null, store });
 
@@ -126,10 +124,7 @@ describe(__filename, () => {
 
     store.dispatch(apiActions.setAuthToken({ authToken: 'some-token' }));
     const { api: apiState } = store.getState();
-
-    const dispatch = jest
-      .spyOn(store, 'dispatch')
-      .mockImplementation(jest.fn());
+    const dispatch = spyOn(store, 'dispatch');
 
     root.setProps({ apiState, dispatch });
 
@@ -138,19 +133,12 @@ describe(__filename, () => {
 
   it('does not fetch the current user profile on update when there is no loaded profile and authToken is the same', () => {
     const store = configureStore();
-    const fakeThunk = createFakeThunk();
     store.dispatch(apiActions.setAuthToken({ authToken: 'some-token' }));
 
-    const root = render({
-      _fetchCurrentUserProfile: fakeThunk.createThunk,
-      store,
-    });
+    const root = render({ store });
 
     const { api: apiState } = store.getState();
-
-    const dispatch = jest
-      .spyOn(store, 'dispatch')
-      .mockImplementation(jest.fn());
+    const dispatch = spyOn(store, 'dispatch');
 
     root.setProps({ apiState, dispatch });
 
@@ -160,20 +148,12 @@ describe(__filename, () => {
   it('does not fetch the current user profile on update when the profile has been already loaded', () => {
     const store = configureStore();
     store.dispatch(userActions.loadCurrentUser({ user: fakeUser }));
-    const fakeThunk = createFakeThunk();
 
-    const root = render({
-      _fetchCurrentUserProfile: fakeThunk.createThunk,
-      authToken: null,
-      store,
-    });
+    const root = render({ authToken: null, store });
 
     store.dispatch(apiActions.setAuthToken({ authToken: 'some-token' }));
     const { api: apiState } = store.getState();
-
-    const dispatch = jest
-      .spyOn(store, 'dispatch')
-      .mockImplementation(jest.fn());
+    const dispatch = spyOn(store, 'dispatch');
 
     root.setProps({ apiState, dispatch });
 

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -15,10 +15,9 @@ import styles from './styles.module.scss';
 import { ApiState, actions as apiActions } from '../../reducers/api';
 import {
   User,
-  actions as userActions,
+  fetchCurrentUserProfile,
   getCurrentUser,
 } from '../../reducers/users';
-import { isErrorResponse, getCurrentUserProfile } from '../../api';
 import Navbar from '../Navbar';
 import Browse from '../../pages/Browse';
 import Index from '../../pages/Index';
@@ -30,6 +29,7 @@ type PublicProps = {
 };
 
 export type DefaultProps = {
+  _fetchCurrentUserProfile: typeof fetchCurrentUserProfile;
   _log: typeof log;
 };
 
@@ -49,6 +49,7 @@ type Props = PublicProps &
 
 export class AppBase extends React.Component<Props> {
   static defaultProps = {
+    _fetchCurrentUserProfile: fetchCurrentUserProfile,
     _log: log,
   };
 
@@ -60,17 +61,13 @@ export class AppBase extends React.Component<Props> {
     }
   }
 
-  async componentDidUpdate(prevProps: Props) {
-    const { _log, apiState, dispatch, profile } = this.props;
+  componentDidUpdate(prevProps: Props) {
+    const { apiState, profile } = this.props;
 
     if (!profile && prevProps.apiState.authToken !== apiState.authToken) {
-      const response = await getCurrentUserProfile(apiState);
+      const { _fetchCurrentUserProfile, dispatch } = this.props;
 
-      if (isErrorResponse(response)) {
-        _log.error(`TODO: handle this error response: ${response.error}`);
-      } else {
-        dispatch(userActions.loadCurrentUser({ user: response }));
-      }
+      dispatch(_fetchCurrentUserProfile());
     }
   }
 

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -24,13 +24,10 @@ import Index from '../../pages/Index';
 import NotFound from '../../pages/NotFound';
 import { gettext } from '../../utils';
 
-type PublicProps = {
-  authToken: string | null;
-};
-
-export type DefaultProps = {
+export type PublicProps = {
   _fetchCurrentUserProfile: typeof fetchCurrentUserProfile;
   _log: typeof log;
+  authToken: string | null;
 };
 
 type PropsFromState = {
@@ -42,7 +39,6 @@ type PropsFromState = {
 /* eslint-disable @typescript-eslint/indent */
 type Props = PublicProps &
   PropsFromState &
-  DefaultProps &
   ConnectedReduxProps &
   RouteComponentProps<{}>;
 /* eslint-enable @typescript-eslint/indent */

--- a/src/components/Navbar/index.spec.tsx
+++ b/src/components/Navbar/index.spec.tsx
@@ -5,7 +5,7 @@ import { Store } from 'redux';
 import configureStore from '../../configureStore';
 import LoginButton from '../LoginButton';
 import styles from './styles.module.scss';
-import { createFakeThunk, fakeUser } from '../../test-helpers';
+import { createFakeThunk, fakeUser, spyOn } from '../../test-helpers';
 import { actions as userActions, requestLogOut } from '../../reducers/users';
 
 import Navbar from '.';
@@ -81,9 +81,7 @@ describe(__filename, () => {
   describe('Log out button', () => {
     it('dispatches requestLogOut when clicked', () => {
       const store = storeWithUser();
-      const dispatch = jest
-        .spyOn(store, 'dispatch')
-        .mockImplementation(jest.fn());
+      const dispatch = spyOn(store, 'dispatch');
 
       const fakeThunk = createFakeThunk();
       const root = render({

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -3,15 +3,15 @@ import { Store } from 'redux';
 
 import {
   createFakeHistory,
+  createFakeThunk,
   fakeVersion,
-  getFakeLogger,
   shallowUntilTarget,
 } from '../../test-helpers';
-import * as api from '../../api';
 import configureStore from '../../configureStore';
 import {
   actions as versionActions,
   createInternalVersion,
+  fetchVersion,
 } from '../../reducers/versions';
 import FileTree from '../../components/FileTree';
 
@@ -38,13 +38,15 @@ describe(__filename, () => {
   };
 
   type RenderParams = {
+    _fetchVersion?: typeof fetchVersion;
     _log?: DefaultProps['_log'];
     addonId?: string;
     versionId?: string;
     store?: Store;
   };
 
-  const render = async ({
+  const render = ({
+    _fetchVersion,
     _log,
     addonId = '999',
     versionId = '123',
@@ -52,6 +54,7 @@ describe(__filename, () => {
   }: RenderParams = {}) => {
     const props = {
       ...createFakeRouteComponentProps({ params: { addonId, versionId } }),
+      _fetchVersion,
       _log,
     };
 
@@ -62,21 +65,21 @@ describe(__filename, () => {
     });
   };
 
-  it('renders a page', async () => {
+  it('renders a page', () => {
     const versionId = '123456';
 
-    const root = await render({ versionId });
+    const root = render({ versionId });
 
     expect(root).toIncludeText(`Version ID: ${versionId}`);
   });
 
-  it('renders a FileTree component', async () => {
+  it('renders a FileTree component', () => {
     const version = fakeVersion;
 
     const store = configureStore();
     store.dispatch(versionActions.loadVersionInfo({ version }));
 
-    const root = await render({ store, versionId: String(version.id) });
+    const root = render({ store, versionId: String(version.id) });
 
     expect(root.find(FileTree)).toHaveLength(1);
     expect(root.find(FileTree)).toHaveProp(
@@ -85,44 +88,21 @@ describe(__filename, () => {
     );
   });
 
-  it('calls the API to load the version info on mount', async () => {
-    const addonId = 12345;
-    const version = {
-      ...fakeVersion,
-      id: 999,
-    };
-
-    const mockApi = jest.spyOn(api, 'getVersion');
-    mockApi.mockReturnValue(Promise.resolve(version));
+  it('dispatches fetchVersion() on mount', () => {
+    const version = fakeVersion;
 
     const store = configureStore();
-    const dispatch = jest.spyOn(store, 'dispatch');
+    const dispatch = jest
+      .spyOn(store, 'dispatch')
+      .mockImplementation(jest.fn());
+    const fakeThunk = createFakeThunk();
 
-    await render({
+    render({
+      _fetchVersion: fakeThunk.createThunk,
       store,
-      addonId: String(addonId),
       versionId: String(version.id),
     });
 
-    expect(mockApi).toHaveBeenCalledWith({
-      apiState: store.getState().api,
-      addonId,
-      versionId: version.id,
-    });
-    expect(dispatch).toHaveBeenCalledWith(
-      versionActions.loadVersionInfo({ version }),
-    );
-  });
-
-  it('logs an error when the API request to retrieve the current user profile has failed', async () => {
-    const _log = getFakeLogger();
-    const error = new Error('server error');
-
-    const mockApi = jest.spyOn(api, 'getVersion');
-    mockApi.mockReturnValue(Promise.resolve({ error }));
-
-    await render({ _log });
-
-    expect(_log.error).toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
   });
 });

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -6,16 +6,16 @@ import {
   createFakeThunk,
   fakeVersion,
   shallowUntilTarget,
+  spyOn,
 } from '../../test-helpers';
 import configureStore from '../../configureStore';
 import {
   actions as versionActions,
   createInternalVersion,
-  fetchVersion,
 } from '../../reducers/versions';
 import FileTree from '../../components/FileTree';
 
-import Browse, { BrowseBase, DefaultProps } from '.';
+import Browse, { BrowseBase, PublicProps } from '.';
 
 describe(__filename, () => {
   const createFakeRouteComponentProps = ({
@@ -38,8 +38,8 @@ describe(__filename, () => {
   };
 
   type RenderParams = {
-    _fetchVersion?: typeof fetchVersion;
-    _log?: DefaultProps['_log'];
+    _fetchVersion?: PublicProps['_fetchVersion'];
+    _log?: PublicProps['_log'];
     addonId?: string;
     versionId?: string;
     store?: Store;
@@ -92,9 +92,7 @@ describe(__filename, () => {
     const version = fakeVersion;
 
     const store = configureStore();
-    const dispatch = jest
-      .spyOn(store, 'dispatch')
-      .mockImplementation(jest.fn());
+    const dispatch = spyOn(store, 'dispatch');
     const fakeThunk = createFakeThunk();
 
     render({

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -9,14 +9,14 @@ import { ApiState } from '../../reducers/api';
 import FileTree from '../../components/FileTree';
 import { Version, fetchVersion, getVersionInfo } from '../../reducers/versions';
 
+export type PublicProps = {
+  _fetchVersion: typeof fetchVersion;
+  _log: typeof log;
+};
+
 type PropsFromRouter = {
   addonId: string;
   versionId: string;
-};
-
-export type DefaultProps = {
-  _fetchVersion: typeof fetchVersion;
-  _log: typeof log;
 };
 
 type PropsFromState = {
@@ -27,7 +27,7 @@ type PropsFromState = {
 /* eslint-disable @typescript-eslint/indent */
 type Props = RouteComponentProps<PropsFromRouter> &
   PropsFromState &
-  DefaultProps &
+  PublicProps &
   ConnectedReduxProps;
 /* eslint-enable @typescript-eslint/indent */
 
@@ -37,7 +37,7 @@ export class BrowseBase extends React.Component<Props> {
     _log: log,
   };
 
-  async componentDidMount() {
+  componentDidMount() {
     const { _fetchVersion, dispatch, match } = this.props;
     const { addonId, versionId } = match.params;
 

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -6,13 +6,8 @@ import log from 'loglevel';
 
 import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
 import { ApiState } from '../../reducers/api';
-import { isErrorResponse, getVersion } from '../../api';
 import FileTree from '../../components/FileTree';
-import {
-  actions as versionActions,
-  Version,
-  getVersionInfo,
-} from '../../reducers/versions';
+import { Version, fetchVersion, getVersionInfo } from '../../reducers/versions';
 
 type PropsFromRouter = {
   addonId: string;
@@ -20,6 +15,7 @@ type PropsFromRouter = {
 };
 
 export type DefaultProps = {
+  _fetchVersion: typeof fetchVersion;
   _log: typeof log;
 };
 
@@ -37,24 +33,20 @@ type Props = RouteComponentProps<PropsFromRouter> &
 
 export class BrowseBase extends React.Component<Props> {
   static defaultProps = {
+    _fetchVersion: fetchVersion,
     _log: log,
   };
 
   async componentDidMount() {
-    const { _log, apiState, dispatch, match } = this.props;
+    const { _fetchVersion, dispatch, match } = this.props;
     const { addonId, versionId } = match.params;
 
-    const response = await getVersion({
-      addonId: parseInt(addonId, 10),
-      apiState,
-      versionId: parseInt(versionId, 10),
-    });
-
-    if (isErrorResponse(response)) {
-      _log.error(`TODO: handle this error response: ${response.error}`);
-    } else {
-      dispatch(versionActions.loadVersionInfo({ version: response }));
-    }
+    dispatch(
+      _fetchVersion({
+        addonId: parseInt(addonId, 10),
+        versionId: parseInt(versionId, 10),
+      }),
+    );
   }
 
   render() {

--- a/src/reducers/users.spec.tsx
+++ b/src/reducers/users.spec.tsx
@@ -80,7 +80,7 @@ describe(__filename, () => {
   });
 
   describe('fetchCurrentUserProfile', () => {
-    it('calls getCurrentuserProfile', async () => {
+    it('calls getCurrentUserProfile', async () => {
       const _getCurrentUserProfile = jest
         .fn()
         .mockReturnValue(Promise.resolve(fakeUser));

--- a/src/reducers/users.spec.tsx
+++ b/src/reducers/users.spec.tsx
@@ -1,11 +1,12 @@
 import reducer, {
   actions,
   createInternalUser,
+  fetchCurrentUserProfile,
   getCurrentUser,
   initialState,
   requestLogOut,
 } from './users';
-import { fakeUser, thunkTester } from '../test-helpers';
+import { getFakeLogger, fakeUser, thunkTester } from '../test-helpers';
 
 describe(__filename, () => {
   describe('reducer', () => {
@@ -75,6 +76,57 @@ describe(__filename, () => {
       await thunk();
 
       expect(dispatch).toHaveBeenCalledWith(actions.logOut());
+    });
+  });
+
+  describe('fetchCurrentUserProfile', () => {
+    it('calls getCurrentuserProfile', async () => {
+      const _getCurrentUserProfile = jest
+        .fn()
+        .mockReturnValue(Promise.resolve(fakeUser));
+
+      const { store, thunk } = thunkTester({
+        createThunk: () => fetchCurrentUserProfile({ _getCurrentUserProfile }),
+      });
+
+      await thunk();
+
+      expect(_getCurrentUserProfile).toHaveBeenCalledWith(store.getState().api);
+    });
+
+    it('dispatches loadCurrentUser when API response is successful', async () => {
+      const user = fakeUser;
+      const _getCurrentUserProfile = jest
+        .fn()
+        .mockReturnValue(Promise.resolve(user));
+
+      const { dispatch, thunk } = thunkTester({
+        createThunk: () => fetchCurrentUserProfile({ _getCurrentUserProfile }),
+      });
+
+      await thunk();
+
+      expect(dispatch).toHaveBeenCalledWith(actions.loadCurrentUser({ user }));
+    });
+
+    it('logs an error when API response is not successful', async () => {
+      const _log = getFakeLogger();
+
+      const _getCurrentUserProfile = jest.fn().mockReturnValue(
+        Promise.resolve({
+          error: new Error('Bad Request'),
+        }),
+      );
+
+      const { dispatch, thunk } = thunkTester({
+        createThunk: () =>
+          fetchCurrentUserProfile({ _log, _getCurrentUserProfile }),
+      });
+
+      await thunk();
+
+      expect(_log.error).toHaveBeenCalled();
+      expect(dispatch).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/reducers/users.tsx
+++ b/src/reducers/users.tsx
@@ -1,8 +1,13 @@
 import { Reducer } from 'redux';
 import { ActionType, createAction, getType } from 'typesafe-actions';
+import log from 'loglevel';
 
 import { ThunkActionCreator } from '../configureStore';
-import { logOutFromServer } from '../api';
+import {
+  getCurrentUserProfile,
+  isErrorResponse,
+  logOutFromServer,
+} from '../api';
 
 type UserId = number;
 
@@ -78,6 +83,23 @@ export const createInternalUser = (user: ExternalUser): User => {
 
 export const getCurrentUser = (users: UsersState) => {
   return users.currentUser;
+};
+
+export const fetchCurrentUserProfile = ({
+  _getCurrentUserProfile = getCurrentUserProfile,
+  _log = log,
+} = {}): ThunkActionCreator => {
+  return async (dispatch, getState) => {
+    const { api: apiState } = getState();
+
+    const response = await _getCurrentUserProfile(apiState);
+
+    if (isErrorResponse(response)) {
+      _log.error(`TODO: handle this error response: ${response.error}`);
+    } else {
+      dispatch(actions.loadCurrentUser({ user: response }));
+    }
+  };
 };
 
 const reducer: Reducer<UsersState, ActionType<typeof actions>> = (

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -1,5 +1,9 @@
 import { Reducer } from 'redux';
 import { ActionType, createAction, getType } from 'typesafe-actions';
+import log from 'loglevel';
+
+import { ThunkActionCreator } from '../configureStore';
+import { getVersion, isErrorResponse } from '../api';
 
 type VersionId = number;
 
@@ -196,6 +200,36 @@ export const getVersionInfo = (
   versionId: VersionId,
 ) => {
   return versions.versionInfo[versionId];
+};
+
+type FetchVersionParams = {
+  _log?: typeof log;
+  _getVersion?: typeof getVersion;
+  addonId: number;
+  versionId: number;
+};
+
+export const fetchVersion = ({
+  _getVersion = getVersion,
+  _log = log,
+  addonId,
+  versionId,
+}: FetchVersionParams): ThunkActionCreator => {
+  return async (dispatch, getState) => {
+    const { api: apiState } = getState();
+
+    const response = await _getVersion({
+      addonId,
+      apiState,
+      versionId,
+    });
+
+    if (isErrorResponse(response)) {
+      _log.error(`TODO: handle this error response: ${response.error}`);
+    } else {
+      dispatch(actions.loadVersionInfo({ version: response }));
+    }
+  };
 };
 
 const reducer: Reducer<VersionsState, ActionType<typeof actions>> = (

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -291,3 +291,10 @@ export const getFakeLogger = () => {
     info: jest.fn(),
   };
 };
+
+export const spyOn = <T extends {}>(
+  object: T,
+  method: jest.FunctionPropertyNames<T>,
+) => {
+  return jest.spyOn(object, method).mockImplementation(jest.fn());
+};

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import { History, Location } from 'history';
 import { shallow } from 'enzyme';
 import { Store } from 'redux';
+import log from 'loglevel';
 
 import configureStore, {
   ApplicationState,
@@ -279,5 +280,14 @@ export const thunkTester = ({
     // This simulates how the middleware will run the thunk.
     thunk: () => thunk(dispatch, () => store.getState(), undefined),
     store,
+  };
+};
+
+export const getFakeLogger = () => {
+  return {
+    ...log,
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
   };
 };


### PR DESCRIPTION
Fixes #181 

---

This PR allows us to write code like this now: https://github.com/mozilla/addons-code-manager/pull/218/files#diff-eaeb6d1753d7786e20e90d2089ffe11e. In other words, we now have precise return types for our API calls.

The PR also adds new thunks and a bunch of test cases.