### PR TITLE
Ignore src/index.tsx from coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,8 @@
     "collectCoverageFrom": [
       "src/**/*.{js,jsx,ts,tsx}",
       "!<rootDir>/node_modules/",
-      "!src/jest-reporters/eslint-check.js"
+      "!src/jest-reporters/eslint-check.js",
+      "!src/index.tsx"
     ]
   }
 }


### PR DESCRIPTION
I don't think we can cover this file with tests, so let's ignore it to have a more accurate coverage report.