### PR TITLE
Add selected_file to versions reducer (as selectedPath)

### DIFF
--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -191,15 +191,20 @@ describe(__filename, () => {
 
   describe('getVersionFiles', () => {
     it('returns all the files for a given version', () => {
-      const path = 'test.js';
+      const path1 = 'test.js';
+      const path2 = 'function.js';
       const version = fakeVersion;
-      const state = reducer(
-        undefined,
-        actions.loadVersionFile({ path, version }),
-      );
 
+      let state = reducer(
+        undefined,
+        actions.loadVersionFile({ path: path1, version }),
+      );
+      state = reducer(state, actions.loadVersionFile({ path: path2, version }));
+
+      const internalVersionFile = createInternalVersionFile(version.file);
       expect(getVersionFiles(state, version.id)).toEqual({
-        [path]: createInternalVersionFile(version.file),
+        [path1]: internalVersionFile,
+        [path2]: internalVersionFile,
       });
     });
 

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -6,6 +6,7 @@ import reducer, {
   createInternalVersionFile,
   getVersionEntryType,
   getVersionFile,
+  getVersionFiles,
   getVersionInfo,
   initialState,
 } from './versions';
@@ -57,7 +58,7 @@ describe(__filename, () => {
       });
     });
 
-    it('loads version info', () => {
+    it('loads version info and the default file', () => {
       const version = fakeVersion;
       const state = reducer(undefined, actions.loadVersionInfo({ version }));
 
@@ -65,6 +66,13 @@ describe(__filename, () => {
         ...initialState,
         versionInfo: {
           [version.id]: createInternalVersion(version),
+        },
+        versionFiles: {
+          [version.id]: {
+            [version.file.selected_file]: createInternalVersionFile(
+              version.file,
+            ),
+          },
         },
       });
     });
@@ -94,6 +102,7 @@ describe(__filename, () => {
         id: version.id,
         reviewed: version.reviewed,
         version: version.version,
+        selectedPath: version.file.selected_file,
       });
     });
 
@@ -117,6 +126,7 @@ describe(__filename, () => {
         id: version.id,
         reviewed: version.reviewed,
         version: version.version,
+        selectedPath: version.file.selected_file,
       });
     });
   });
@@ -176,6 +186,25 @@ describe(__filename, () => {
       const state = initialState;
 
       expect(getVersionFile('some-file-name.js', state, 1)).toEqual(undefined);
+    });
+  });
+
+  describe('getVersionFiles', () => {
+    it('returns all the files for a given version', () => {
+      const path = 'test.js';
+      const version = fakeVersion;
+      const state = reducer(
+        undefined,
+        actions.loadVersionFile({ path, version }),
+      );
+
+      expect(getVersionFiles(state, version.id)).toEqual({
+        [path]: createInternalVersionFile(version.file),
+      });
+    });
+
+    it('returns undefined if there are no files found', () => {
+      expect(getVersionFiles(initialState, 1)).toEqual(undefined);
     });
   });
 

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -47,6 +47,7 @@ export type ExternalVersionFile = {
   is_webextension: boolean;
   permissions: string[];
   platform: string;
+  selected_file: string;
   size: number;
   status: string;
   url: string;
@@ -96,6 +97,7 @@ export type Version = {
   id: VersionId;
   reviewed: string;
   version: string;
+  selectedPath: string;
 };
 
 export const actions = {
@@ -168,7 +170,15 @@ export const createInternalVersion = (version: ExternalVersion): Version => {
     id: version.id,
     reviewed: version.reviewed,
     version: version.version,
+    selectedPath: version.file.selected_file,
   };
+};
+
+export const getVersionFiles = (
+  versions: VersionsState,
+  versionId: VersionId,
+) => {
+  return versions.versionFiles[versionId];
 };
 
 export const getVersionFile = (
@@ -176,7 +186,8 @@ export const getVersionFile = (
   versions: VersionsState,
   versionId: VersionId,
 ) => {
-  const filesForVersion = versions.versionFiles[versionId];
+  const filesForVersion = getVersionFiles(versions, versionId);
+
   return filesForVersion ? filesForVersion[path] : undefined;
 };
 
@@ -194,16 +205,26 @@ const reducer: Reducer<VersionsState, ActionType<typeof actions>> = (
   switch (action.type) {
     case getType(actions.loadVersionInfo): {
       const { version } = action.payload;
+
       return {
         ...state,
         versionInfo: {
           ...state.versionInfo,
           [version.id]: createInternalVersion(version),
         },
+        versionFiles: {
+          [version.id]: {
+            ...state.versionFiles[version.id],
+            [version.file.selected_file]: createInternalVersionFile(
+              version.file,
+            ),
+          },
+        },
       };
     }
     case getType(actions.loadVersionFile): {
       const { path, version } = action.payload;
+
       return {
         ...state,
         versionFiles: {

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -96,8 +96,8 @@ export type Version = {
   entries: VersionEntry[];
   id: VersionId;
   reviewed: string;
-  version: string;
   selectedPath: string;
+  version: string;
 };
 
 export const actions = {
@@ -169,8 +169,8 @@ export const createInternalVersion = (version: ExternalVersion): Version => {
     }),
     id: version.id,
     reviewed: version.reviewed,
-    version: version.version,
     selectedPath: version.file.selected_file,
+    version: version.version,
   };
 };
 

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -36,6 +36,7 @@ export const fakeVersionFile: ExternalVersionFile = Object.freeze({
   is_webextension: true,
   permissions: [],
   platform: 'all',
+  selected_file: 'manifest.json',
   size: 123,
   status: 'public',
   url: 'http://example.com/edit/',


### PR DESCRIPTION
Fixes #231

---

This PR adds a new field named `selectedPath` to the `versions` reducer. It stores the `file.selected_file` value. Given that retrieving a version without a `path` returns a default file, I also decided to store it. Last, I added a `getVersionFiles()` selector because we'll need it in the near future.

In the near future, we'll likely have a `selectPath` action.