### PR TITLE
Rename api.getVersionFile to api.getVersion

### DIFF
--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -5,7 +5,7 @@ import {
 } from '../reducers/api';
 import configureStore from '../configureStore';
 
-import { HttpMethod, callApi, getVersionFile, logOutFromServer } from '.';
+import { HttpMethod, callApi, getVersion, logOutFromServer } from '.';
 
 describe(__filename, () => {
   const getApiState = ({ authToken = '12345' } = {}) => {
@@ -145,12 +145,12 @@ describe(__filename, () => {
     });
   });
 
-  describe('getVersionFile', () => {
-    it('calls the API to retrieve default version file information', async () => {
+  describe('getVersion', () => {
+    it('calls the API to retrieve version information', async () => {
       const addonId = 999;
       const versionId = 123;
 
-      await getVersionFile({ apiState: defaultApiState, addonId, versionId });
+      await getVersion({ apiState: defaultApiState, addonId, versionId });
 
       expect(fetch).toHaveBeenCalledWith(
         `/api/v4/reviewers/addon/${addonId}/versions/${versionId}/`,
@@ -160,12 +160,13 @@ describe(__filename, () => {
         },
       );
     });
-    it('calls the API to retrieve information for a specific version file', async () => {
+
+    it('calls the API to retrieve information for a specific file', async () => {
       const path = 'test.js';
       const addonId = 999;
       const versionId = 123;
 
-      await getVersionFile({
+      await getVersion({
         apiState: defaultApiState,
         addonId,
         path,

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -76,7 +76,7 @@ export const callApi = async ({
   }
 };
 
-type GetVersionFileParams = {
+type GetVersionParams = {
   addonId: number;
   apiState: ApiState;
   path?: string;
@@ -88,7 +88,7 @@ export const getVersion = async ({
   path,
   addonId,
   versionId,
-}: GetVersionFileParams) => {
+}: GetVersionParams) => {
   return callApi({
     apiState,
     endpoint: `reviewers/addon/${addonId}/versions/${versionId}`,

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -83,7 +83,7 @@ type GetVersionFileParams = {
   versionId: number;
 };
 
-export const getVersionFile = async ({
+export const getVersion = async ({
   apiState,
   path,
   addonId,

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -81,7 +81,7 @@ describe(__filename, () => {
       id: 999,
     };
 
-    const mockApi = jest.spyOn(api, 'getVersionFile');
+    const mockApi = jest.spyOn(api, 'getVersion');
     mockApi.mockReturnValue(Promise.resolve(version));
 
     const store = configureStore();

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -5,7 +5,7 @@ import { Col } from 'react-bootstrap';
 
 import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
 import { ApiState } from '../../reducers/api';
-import { getVersionFile } from '../../api';
+import { getVersion } from '../../api';
 import FileTree from '../../components/FileTree';
 import {
   actions as versionActions,
@@ -35,7 +35,7 @@ export class BrowseBase extends React.Component<Props> {
     const { apiState, dispatch, match } = this.props;
     const { addonId, versionId } = match.params;
 
-    const response = (await getVersionFile({
+    const response = (await getVersion({
       addonId: parseInt(addonId, 10),
       apiState,
       versionId: parseInt(versionId, 10),


### PR DESCRIPTION
Fixes #235

---

This PR renames the api function `getVersionFile` to `getVersion`
because the current name is confusing. With the recent changes in the
API, renaming the function makes even more sense because what we really
do is retrieving a "version".

I found very confusing to use `getVersionFile` and then to dispatch a
`loadVersionInfo` in one case and `loadVersionFile` in another case. By
having `getVersion`, the code seems easier to follow to me.