### PR TITLE
[WIP] Controle FileTree expanded/collapsed state

### DIFF
--- a/src/@types/react-treefold/index.d.ts
+++ b/src/@types/react-treefold/index.d.ts
@@ -20,6 +20,8 @@ declare module 'react-treefold' {
   type TreefoldProps<NodeType> = {
     nodes: NodeType[];
     render: (props: TreefoldRenderProps<NodeType>) => React.Node;
+    isNodeExpanded?: (node: NodeType) => boolean;
+    onToggleExpand?: (node: NodeType) => void;
   };
 
   // eslint-disable-next-line no-undef

--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -25,6 +25,7 @@ describe(__filename, () => {
       expect(tree).toEqual({
         id: `root-${versionId}`,
         name: versionId,
+        expanded: true,
         children: [],
       });
     });
@@ -47,6 +48,7 @@ describe(__filename, () => {
         {
           id: entries[0].path,
           name: filename,
+          expanded: false,
         },
       ]);
     });
@@ -69,6 +71,7 @@ describe(__filename, () => {
         {
           id: entries[0].path,
           name: filename,
+          expanded: false,
           children: [],
         },
       ]);
@@ -101,10 +104,12 @@ describe(__filename, () => {
         {
           id: entries[0].path,
           name: directory,
+          expanded: false,
           children: [
             {
               id: entries[1].path,
               name: file,
+              expanded: false,
             },
           ],
         },
@@ -145,14 +150,17 @@ describe(__filename, () => {
         {
           id: entries[0].path,
           name: directoryName,
+          expanded: false,
           children: [
             {
               id: entries[1].path,
               name: directoryName,
+              expanded: false,
               children: [
                 {
                   id: entries[2].path,
                   name: fileName,
+                  expanded: false,
                 },
               ],
             },
@@ -187,16 +195,19 @@ describe(__filename, () => {
         {
           id: entries[0].path,
           name: 'B',
+          expanded: false,
           children: [],
         },
         {
           id: entries[2].path,
           name: 'C',
+          expanded: false,
           children: [],
         },
         {
           id: entries[1].path,
           name: 'A',
+          expanded: false,
         },
       ]);
     });
@@ -224,14 +235,17 @@ describe(__filename, () => {
         {
           id: entries[2].path,
           name: 'A',
+          expanded: false,
         },
         {
           id: entries[1].path,
           name: 'B',
+          expanded: false,
         },
         {
           id: entries[0].path,
           name: 'C',
+          expanded: false,
         },
       ]);
     });
@@ -257,11 +271,13 @@ describe(__filename, () => {
         {
           id: entries[1].path,
           name: 'A',
+          expanded: false,
           children: [],
         },
         {
           id: entries[0].path,
           name: 'B',
+          expanded: false,
           children: [],
         },
       ]);
@@ -297,10 +313,12 @@ describe(__filename, () => {
         {
           id: entries[2].path,
           name: 'A',
+          expanded: false,
         },
         {
           id: entries[1].path,
           name: 'B',
+          expanded: false,
         },
       ]);
     });
@@ -336,11 +354,13 @@ describe(__filename, () => {
         {
           id: entries[1].path,
           name: 'B',
+          expanded: false,
           children: [],
         },
         {
           id: entries[2].path,
           name: 'A',
+          expanded: false,
         },
       ]);
     });
@@ -368,6 +388,20 @@ describe(__filename, () => {
       expect(root.find(Treefold)).toHaveProp('nodes', [
         buildFileTree(String(version.id), version.entries),
       ]);
+    });
+
+    it('can collapse a node', () => {
+      const version = getVersion({ ...fakeVersion, id: 777 });
+
+      const root = render({ version });
+
+      const tree = root.state('tree');
+      // The root node is expanded by default.
+      expect(tree).toHaveProperty('expanded', true);
+
+      root.find(Treefold).prop('onToggleExpand')(tree);
+
+      expect(root.state('tree')).toHaveProperty('expanded', false);
     });
   });
 });

--- a/src/components/FileTreeNode/index.spec.tsx
+++ b/src/components/FileTreeNode/index.spec.tsx
@@ -20,6 +20,7 @@ describe(__filename, () => {
       node: {
         id,
         name,
+        expanded: false,
       },
       getToggleProps,
       hasChildNodes,

--- a/src/configureApplication.tsx
+++ b/src/configureApplication.tsx
@@ -17,6 +17,7 @@ type ConfigureApplicationParams = {
 const configureApplication = ({
   _Raven = Raven,
   _log = log,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   env = (process.env as any) as ClientEnvVars,
 }: ConfigureApplicationParams = {}) => {
   if (env.NODE_ENV === 'production') {


### PR DESCRIPTION
I am not quite sure that the tree should live in the component's state and not in redux (cf. #185), but in any case, if we want to have some control on this tree, we need to used `Treefold` in a "controlled" way. That's the aim of this PR.

Now, the first level of the tree (a.k.a. the root node) is automatically expanded.

<img width="1392" alt="screen shot 2019-02-20 at 12 28 28" src="https://user-images.githubusercontent.com/217628/53088791-13866d00-350b-11e9-8eed-3207428f0c75.png">
