### PR TITLE
Change order of arguments in getVersionFile

### DIFF
--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -177,7 +177,7 @@ describe(__filename, () => {
         actions.loadVersionFile({ path, version }),
       );
 
-      expect(getVersionFile(path, state, version.id)).toEqual(
+      expect(getVersionFile(state, version.id, path)).toEqual(
         createInternalVersionFile(version.file),
       );
     });
@@ -185,7 +185,7 @@ describe(__filename, () => {
     it('returns undefined if there is no version file found', () => {
       const state = initialState;
 
-      expect(getVersionFile('some-file-name.js', state, 1)).toEqual(undefined);
+      expect(getVersionFile(state, 1, 'some-file-name.js')).toEqual(undefined);
     });
   });
 

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -182,9 +182,9 @@ export const getVersionFiles = (
 };
 
 export const getVersionFile = (
-  path: string,
   versions: VersionsState,
   versionId: VersionId,
+  path: string,
 ) => {
   const filesForVersion = getVersionFiles(versions, versionId);
 


### PR DESCRIPTION
Minor change to make all selectors similar, i.e. all `versions`
selectors have the state as first argument, the versionId as second
argument, and then other arguments.