### PR TITLE
Introduce a Compare page

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,9 +9,6 @@
     "browser": true,
   },
   "rules": {
-    // TS configuration for the `indent` rule.
-    // https://github.com/typescript-eslint/typescript-eslint/blob/5b0b3d9edbcb3ab588a34c431037d9deece30824/packages/eslint-plugin/docs/rules/indent.md#options
-    "@typescript-eslint/indent": ["error", 2],
     "import/no-extraneous-dependencies": ["error", {
         "devDependencies": [
             "**/*.spec.*",
@@ -36,6 +33,7 @@
     "no-mixed-operators": "off",
     "operator-linebreak": "off",
     "react/jsx-one-expression-per-line": "off",
+    "@typescript-eslint/indent": "off",
     // Report an error when a variable is not used.
     "@typescript-eslint/no-unused-vars": "error",
     // The beauty of TS is that it infers types quite well, so let's not write

--- a/src/components/App/index.spec.tsx
+++ b/src/components/App/index.spec.tsx
@@ -110,7 +110,7 @@ describe(__filename, () => {
 
     const root = render({ store });
 
-    expect(root.find(Route)).toHaveLength(3);
+    expect(root.find(Route)).toHaveLength(4);
     expect(root.find(`.${styles.loginMessage}`)).toHaveLength(0);
   });
 

--- a/src/components/App/index.spec.tsx
+++ b/src/components/App/index.spec.tsx
@@ -110,7 +110,7 @@ describe(__filename, () => {
 
     const root = render({ store });
 
-    expect(root.find(Route)).toHaveLength(4);
+    expect(root.find(Route)).toExist();
     expect(root.find(`.${styles.loginMessage}`)).toHaveLength(0);
   });
 

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -22,6 +22,7 @@ import {
 } from '../../reducers/users';
 import Navbar from '../Navbar';
 import Browse from '../../pages/Browse';
+import Compare from '../../pages/Compare';
 import Index from '../../pages/Index';
 import NotFound from '../../pages/NotFound';
 import { gettext } from '../../utils';
@@ -101,6 +102,11 @@ export class AppBase extends React.Component<Props> {
             component={Browse}
             exact
             path="/:lang/browse/:addonId/versions/:versionId/"
+          />
+          <Route
+            component={Compare}
+            exact
+            path="/:lang/compare/:addonId/versions/:baseVersionId...:headVersionId/"
           />
           <Route component={NotFound} />
         </Switch>,

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -39,12 +39,10 @@ type PropsFromState = {
   user: User | null;
 };
 
-/* eslint-disable @typescript-eslint/indent */
 type Props = PublicProps &
   PropsFromState &
   ConnectedReduxProps &
   RouteComponentProps<{}>;
-/* eslint-enable @typescript-eslint/indent */
 
 export class AppBase extends React.Component<Props> {
   static defaultProps = {

--- a/src/components/DiffView/fixtures/basicDiff.tsx
+++ b/src/components/DiffView/fixtures/basicDiff.tsx
@@ -1,0 +1,11 @@
+export default `diff --git a/src/components/DiffView.test.tsx b/src/components/DiffView.test.tsx
+index 5ca1a30..4e2c90f 100644
+--- a/src/components/DiffView.test.tsx
++++ b/src/components/DiffView.test.tsx
+@@ -35,6 +35,8 @@ it('defaults the viewType to unified', () => {
+ it('renders with a specified viewType', () => {
+   const viewType = 'split';
+   const root = render({ viewType });
++
++  expect(root).toHaveProp('viewType', viewType);
+ });`;

--- a/src/components/DiffView/fixtures/multipleDiff.tsx
+++ b/src/components/DiffView/fixtures/multipleDiff.tsx
@@ -1,0 +1,19 @@
+export default `diff --git a/src/index1.js b/src/index1.js
+index e69de29..d00491f 100644
+--- a/src/index1.js
++++ b/src/index1.js
+@@ -0,0 +1 @@
++1
+diff --git a/src/index.js b/src/index2.js
+index d00491f..0cfbf08 100644
+--- a/src/index2.js
++++ b/src/index2.js
+@@ -1 +1 @@
+-1
++2
+diff --git a/src/index3.js b/src/index3.js
+index 0cfbf08..e69de29 100644
+--- a/src/index3.js
++++ b/src/index3.js
+@@ -1 +0,0 @@
+-2`;

--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -2,41 +2,12 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import { Diff, parseDiff } from 'react-diff-view';
 
+import basicDiff from './fixtures/basicDiff';
+import multipleDiff from './fixtures/multipleDiff';
+
 import DiffView from '.';
 
 describe(__filename, () => {
-  const basicDiff = `diff --git a/src/components/DiffView.test.tsx b/src/components/DiffView.test.tsx
-index 5ca1a30..4e2c90f 100644
---- a/src/components/DiffView.test.tsx
-+++ b/src/components/DiffView.test.tsx
-@@ -35,6 +35,8 @@ it('defaults the viewType to unified', () => {
- it('renders with a specified viewType', () => {
-   const viewType = 'split';
-   const root = render({ viewType });
-+
-+  expect(root).toHaveProp('viewType', viewType);
- });`;
-
-  const multipleDiff = `diff --git a/src/index1.js b/src/index1.js
-index e69de29..d00491f 100644
---- a/src/index1.js
-+++ b/src/index1.js
-@@ -0,0 +1 @@
-+1
-diff --git a/src/index.js b/src/index2.js
-index d00491f..0cfbf08 100644
---- a/src/index2.js
-+++ b/src/index2.js
-@@ -1 +1 @@
--1
-+2
-diff --git a/src/index3.js b/src/index3.js
-index 0cfbf08..e69de29 100644
---- a/src/index3.js
-+++ b/src/index3.js
-@@ -1 +0,0 @@
--2`;
-
   const render = (props = {}) => {
     return shallow(<DiffView diff={basicDiff} {...props} />);
   };

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Diff, DiffProps, parseDiff } from 'react-diff-view';
 
+import 'react-diff-view/style/index.css';
+
 type Props = {
   diff: string;
   viewType: DiffProps['viewType'];

--- a/src/components/Loading/index.spec.tsx
+++ b/src/components/Loading/index.spec.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import Loading from '.';
+
+describe(__filename, () => {
+  const render = ({ message = 'default' } = {}) => {
+    const props = {
+      message,
+    };
+
+    return shallow(<Loading {...props} />);
+  };
+
+  it('renders a Loading message', () => {
+    const message = 'loading content';
+
+    const root = render({ message });
+
+    expect(root).toIncludeText(message);
+    expect(root.find(FontAwesomeIcon)).toHaveLength(1);
+  });
+});

--- a/src/components/Loading/index.tsx
+++ b/src/components/Loading/index.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+type PublicProps = {
+  message: string;
+};
+
+const LoadingBase = ({ message }: PublicProps) => {
+  return (
+    <React.Fragment>
+      <FontAwesomeIcon icon="spinner" spin /> {message}
+    </React.Fragment>
+  );
+};
+
+export default LoadingBase;

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Store } from 'redux';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Highlight from 'react-highlight';
 
 import {
@@ -17,6 +16,7 @@ import {
   createInternalVersion,
 } from '../../reducers/versions';
 import FileTree from '../../components/FileTree';
+import Loading from '../../components/Loading';
 
 import Browse, { BrowseBase, PublicProps, Props } from '.';
 
@@ -76,8 +76,8 @@ describe(__filename, () => {
 
     const root = render({ versionId });
 
-    expect(root.find(FontAwesomeIcon)).toHaveLength(1);
-    expect(root).toIncludeText('Loading version');
+    expect(root.find(Loading)).toHaveLength(1);
+    expect(root.find(Loading)).toHaveProp('message', 'Loading version...');
   });
 
   it('renders a FileTree component when a version has been loaded', () => {
@@ -132,8 +132,8 @@ describe(__filename, () => {
     const root = render({ store, versionId: String(version.id) });
 
     expect(root.find(Highlight)).toHaveLength(0);
-    expect(root.find(FontAwesomeIcon)).toHaveLength(1);
-    expect(root).toIncludeText('Loading content');
+    expect(root.find(Loading)).toHaveLength(1);
+    expect(root.find(Loading)).toHaveProp('message', 'Loading content...');
   });
 
   it('dispatches fetchVersion() on mount', () => {

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import { Col } from 'react-bootstrap';
 import log from 'loglevel';
 import Highlight from 'react-highlight';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
 import { ApiState } from '../../reducers/api';
@@ -18,6 +17,7 @@ import {
   getVersionInfo,
 } from '../../reducers/versions';
 import { gettext } from '../../utils';
+import Loading from '../../components/Loading';
 
 import 'highlight.js/styles/github.css';
 
@@ -83,8 +83,7 @@ export class BrowseBase extends React.Component<Props> {
     if (!version) {
       return (
         <Col>
-          <FontAwesomeIcon icon="spinner" spin />{' '}
-          {gettext('Loading version...')}
+          <Loading message={gettext('Loading version...')} />
         </Col>
       );
     }
@@ -98,10 +97,7 @@ export class BrowseBase extends React.Component<Props> {
           {file ? (
             <Highlight className="auto">{file.content}</Highlight>
           ) : (
-            <React.Fragment>
-              <FontAwesomeIcon icon="spinner" spin />{' '}
-              {gettext('Loading content...')}
-            </React.Fragment>
+            <Loading message={gettext('Loading content...')} />
           )}
         </Col>
       </React.Fragment>

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -38,12 +38,10 @@ type PropsFromState = {
   version: Version;
 };
 
-/* eslint-disable @typescript-eslint/indent */
 export type Props = RouteComponentProps<PropsFromRouter> &
   PropsFromState &
   PublicProps &
   ConnectedReduxProps;
-/* eslint-enable @typescript-eslint/indent */
 
 export class BrowseBase extends React.Component<Props> {
   static defaultProps = {

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -77,36 +77,38 @@ describe(__filename, () => {
   });
 
   it('renders a FileTree component when a version has been loaded', () => {
-    const version = fakeVersion;
+    const baseVersion = fakeVersion;
+    const headVersion = { ...fakeVersion, id: baseVersion.id + 1 };
 
     const store = configureStore();
-    store.dispatch(versionActions.loadVersionInfo({ version }));
+    store.dispatch(versionActions.loadVersionInfo({ version: baseVersion }));
+    store.dispatch(versionActions.loadVersionInfo({ version: headVersion }));
 
     const root = render({
       store,
-      baseVersionId: String(version.id),
-      // TODO: ideally, we should have different version IDs.
-      headVersionId: String(version.id),
+      baseVersionId: String(baseVersion.id),
+      headVersionId: String(headVersion.id),
     });
 
     expect(root.find(FileTree)).toHaveLength(1);
     expect(root.find(FileTree)).toHaveProp(
       'version',
-      createInternalVersion(version),
+      createInternalVersion(baseVersion),
     );
   });
 
   it('renders a DiffView', () => {
-    const version = fakeVersion;
+    const baseVersion = fakeVersion;
+    const headVersion = { ...fakeVersion, id: baseVersion.id + 1 };
 
     const store = configureStore();
-    store.dispatch(versionActions.loadVersionInfo({ version }));
+    store.dispatch(versionActions.loadVersionInfo({ version: baseVersion }));
+    store.dispatch(versionActions.loadVersionInfo({ version: headVersion }));
 
     const root = render({
       store,
-      baseVersionId: String(version.id),
-      // TODO: ideally, we should have different version IDs.
-      headVersionId: String(version.id),
+      baseVersionId: String(baseVersion.id),
+      headVersionId: String(headVersion.id),
     });
 
     expect(root.find(DiffView)).toHaveLength(1);

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -1,0 +1,132 @@
+import * as React from 'react';
+import { Store } from 'redux';
+
+import {
+  createFakeHistory,
+  createFakeThunk,
+  fakeVersion,
+  shallowUntilTarget,
+  spyOn,
+} from '../../test-helpers';
+import configureStore from '../../configureStore';
+import {
+  actions as versionActions,
+  createInternalVersion,
+} from '../../reducers/versions';
+import FileTree from '../../components/FileTree';
+import DiffView from '../../components/DiffView';
+import Loading from '../../components/Loading';
+
+import Compare, { CompareBase, PublicProps } from '.';
+
+describe(__filename, () => {
+  const createFakeRouteComponentProps = ({
+    history = createFakeHistory(),
+    params = {
+      addonId: '999',
+      baseVersionId: '1',
+      headVersionId: '2',
+    },
+  } = {}) => {
+    return {
+      history,
+      location: history.location,
+      match: {
+        params,
+        isExact: true,
+        path: '/some-path',
+        url: '/some-url',
+      },
+    };
+  };
+
+  type RenderParams = {
+    _fetchVersion?: PublicProps['_fetchVersion'];
+    addonId?: string;
+    baseVersionId?: string;
+    headVersionId?: string;
+    store?: Store;
+  };
+
+  const render = ({
+    _fetchVersion,
+    addonId = '999',
+    baseVersionId = '1',
+    headVersionId = '2',
+    store = configureStore(),
+  }: RenderParams = {}) => {
+    const props = {
+      ...createFakeRouteComponentProps({
+        params: { addonId, baseVersionId, headVersionId },
+      }),
+      _fetchVersion,
+    };
+
+    return shallowUntilTarget(<Compare {...props} />, CompareBase, {
+      shallowOptions: {
+        context: { store },
+      },
+    });
+  };
+
+  it('renders a page with a loading message', () => {
+    const root = render();
+
+    expect(root.find(Loading)).toHaveLength(1);
+    expect(root.find(Loading)).toHaveProp('message', 'Loading version...');
+  });
+
+  it('renders a FileTree component when a version has been loaded', () => {
+    const version = fakeVersion;
+
+    const store = configureStore();
+    store.dispatch(versionActions.loadVersionInfo({ version }));
+
+    const root = render({
+      store,
+      baseVersionId: String(version.id),
+      // TODO: ideally, we should have different version IDs.
+      headVersionId: String(version.id),
+    });
+
+    expect(root.find(FileTree)).toHaveLength(1);
+    expect(root.find(FileTree)).toHaveProp(
+      'version',
+      createInternalVersion(version),
+    );
+  });
+
+  it('renders a DiffView', () => {
+    const version = fakeVersion;
+
+    const store = configureStore();
+    store.dispatch(versionActions.loadVersionInfo({ version }));
+
+    const root = render({
+      store,
+      baseVersionId: String(version.id),
+      // TODO: ideally, we should have different version IDs.
+      headVersionId: String(version.id),
+    });
+
+    expect(root.find(DiffView)).toHaveLength(1);
+  });
+
+  it('dispatches fetchVersion() on mount', () => {
+    const version = fakeVersion;
+
+    const store = configureStore();
+    const dispatch = spyOn(store, 'dispatch');
+    const fakeThunk = createFakeThunk();
+
+    render({
+      _fetchVersion: fakeThunk.createThunk,
+      store,
+      baseVersionId: String(version.id),
+      // TODO: ideally, we should have different version IDs.
+      headVersionId: String(version.id),
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
+  });
+});

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -27,12 +27,10 @@ type PropsFromState = {
   version: Version;
 };
 
-/* eslint-disable @typescript-eslint/indent */
 type Props = RouteComponentProps<PropsFromRouter> &
   PropsFromState &
   PublicProps &
   ConnectedReduxProps;
-/* eslint-enable @typescript-eslint/indent */
 
 export class CompareBase extends React.Component<Props> {
   static defaultProps = {
@@ -51,6 +49,8 @@ export class CompareBase extends React.Component<Props> {
     );
   }
 
+  onSelectFile = () => {};
+
   render() {
     const { version } = this.props;
 
@@ -65,7 +65,7 @@ export class CompareBase extends React.Component<Props> {
     return (
       <React.Fragment>
         <Col md="3">
-          <FileTree version={version} />
+          <FileTree version={version} onSelect={this.onSelectFile} />
         </Col>
         <Col md="9">
           <DiffView diff={basicDiff} />

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import { Col } from 'react-bootstrap';
+import { RouteComponentProps } from 'react-router-dom';
+import { connect } from 'react-redux';
+
+import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
+import { ApiState } from '../../reducers/api';
+import FileTree from '../../components/FileTree';
+import DiffView from '../../components/DiffView';
+import Loading from '../../components/Loading';
+import { Version, fetchVersion, getVersionInfo } from '../../reducers/versions';
+import { gettext } from '../../utils';
+import basicDiff from '../../components/DiffView/fixtures/basicDiff';
+
+export type PublicProps = {
+  _fetchVersion: typeof fetchVersion;
+};
+
+type PropsFromRouter = {
+  addonId: string;
+  baseVersionId: string;
+  headVersionId: string;
+};
+
+type PropsFromState = {
+  apiState: ApiState;
+  version: Version;
+};
+
+/* eslint-disable @typescript-eslint/indent */
+type Props = RouteComponentProps<PropsFromRouter> &
+  PropsFromState &
+  PublicProps &
+  ConnectedReduxProps;
+/* eslint-enable @typescript-eslint/indent */
+
+export class CompareBase extends React.Component<Props> {
+  static defaultProps = {
+    _fetchVersion: fetchVersion,
+  };
+
+  componentDidMount() {
+    const { _fetchVersion, dispatch, match } = this.props;
+    const { addonId, baseVersionId } = match.params;
+
+    dispatch(
+      _fetchVersion({
+        addonId: parseInt(addonId, 10),
+        versionId: parseInt(baseVersionId, 10),
+      }),
+    );
+  }
+
+  render() {
+    const { version } = this.props;
+
+    if (!version) {
+      return (
+        <Col>
+          <Loading message={gettext('Loading version...')} />
+        </Col>
+      );
+    }
+
+    return (
+      <React.Fragment>
+        <Col md="3">
+          <FileTree version={version} />
+        </Col>
+        <Col md="9">
+          <DiffView diff={basicDiff} />
+        </Col>
+      </React.Fragment>
+    );
+  }
+}
+
+const mapStateToProps = (
+  state: ApplicationState,
+  ownProps: RouteComponentProps<PropsFromRouter>,
+): PropsFromState => {
+  const { match } = ownProps;
+  const baseVersionId = parseInt(match.params.baseVersionId, 10);
+
+  const version = getVersionInfo(state.versions, baseVersionId);
+
+  return {
+    apiState: state.api,
+    version,
+  };
+};
+
+export default connect(mapStateToProps)(CompareBase);

--- a/src/pages/Index/index.spec.tsx
+++ b/src/pages/Index/index.spec.tsx
@@ -8,6 +8,6 @@ describe(__filename, () => {
   it('renders a page', () => {
     const root = shallow(<Index />);
 
-    expect(root.find(Link)).toHaveLength(2);
+    expect(root.find(Link)).toExist();
   });
 });

--- a/src/pages/Index/index.spec.tsx
+++ b/src/pages/Index/index.spec.tsx
@@ -8,6 +8,6 @@ describe(__filename, () => {
   it('renders a page', () => {
     const root = shallow(<Index />);
 
-    expect(root.find(Link)).toHaveLength(1);
+    expect(root.find(Link)).toHaveLength(2);
   });
 });

--- a/src/pages/Index/index.tsx
+++ b/src/pages/Index/index.tsx
@@ -11,7 +11,11 @@ export class IndexBase extends React.Component<PublicProps> {
         <p>
           There is nothing you can do here, but try{' '}
           <Link to="/en-US/browse/502955/versions/1541798/">
-            browsing this add-on version.
+            browsing this add-on version
+          </Link>{' '}
+          or{' '}
+          <Link to="/en-US/compare/502955/versions/1541798...1541798/">
+            look at this compare view.
           </Link>
         </p>
       </Col>

--- a/stories/Loading.stories.tsx
+++ b/stories/Loading.stories.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import Loading from '../src/components/Loading';
+
+storiesOf('Loading', module).add('default', () => (
+  <Loading message="Loading content..." />
+));


### PR DESCRIPTION
This patch creates a new page for the "compare" (or diff) view to start this new page soon-ish (hello #111). Of course, it is incomplete as there is no API endpoint yet, but it shows the `DiffView` (and fixes a visual issue). API responses will be similar but not exactly the same so I can't find a way to DRY better than what's here.

I created a new `Loading` component to display a loading state (message for now, but could maybe be reused for other loading states).

Given that validator results will be displayed in both views, I think we need this view right now so that we can think about both use cases.

## Screenshot

<img width="1392" alt="screen shot 2019-02-22 at 10 36 37" src="https://user-images.githubusercontent.com/217628/53233456-c252b680-368d-11e9-8c25-b3888aab0151.png">
