### PR TITLE
Fix empty folder node height

### DIFF
--- a/src/components/FileTreeNode/index.tsx
+++ b/src/components/FileTreeNode/index.tsx
@@ -58,7 +58,7 @@ class FileTreeNodeBase<TreeNodeType> extends React.Component<PublicProps> {
             renderChildNodes()
           ) : (
             <ListGroup.Item
-              className={styles.emptyNodeDirectory}
+              className={makeClassName(styles.node, styles.emptyNodeDirectory)}
               style={{ paddingLeft: `${(level + 2) * 20}px` }}
             >
               {gettext('This folder is empty')}


### PR DESCRIPTION
Fixes #258 

---

This is a small fix for a small issue I noticed in Storybook 😎 

Before:

![screen shot 2019-02-22 at 14 47 34](https://user-images.githubusercontent.com/217628/53246389-d065fe80-36b0-11e9-821d-40aeebb614cd.png)

After:

![screen shot 2019-02-22 at 14 47 25](https://user-images.githubusercontent.com/217628/53246419-e70c5580-36b0-11e9-9e15-acc654455f4b.png)