### PR TITLE
Display add-on's name in the FileTree

### DIFF
--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -12,6 +12,7 @@ import {
   getVersionInfo,
 } from '../../reducers/versions';
 import { fakeVersion, fakeVersionEntry } from '../../test-helpers';
+import { getLocalizedString } from '../../utils';
 
 import FileTree, { buildFileTree, DirectoryNode } from '.';
 
@@ -367,7 +368,7 @@ describe(__filename, () => {
       expect(root.find(ListGroup)).toHaveLength(1);
       expect(root.find(Treefold)).toHaveLength(1);
       expect(root.find(Treefold)).toHaveProp('nodes', [
-        buildFileTree(String(version.id), version.entries),
+        buildFileTree(getLocalizedString(version.addon.name), version.entries),
       ]);
     });
   });

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -4,6 +4,7 @@ import { ListGroup } from 'react-bootstrap';
 
 import FileTreeNode from '../FileTreeNode';
 import { Version } from '../../reducers/versions';
+import { getLocalizedString } from '../../utils';
 
 type FileNode = {
   id: string;
@@ -137,7 +138,10 @@ export class FileTreeBase extends React.Component<PublicProps> {
   render() {
     const { version } = this.props;
 
-    const tree = buildFileTree(`${version.id}`, version.entries);
+    const tree = buildFileTree(
+      getLocalizedString(version.addon.name),
+      version.entries,
+    );
 
     return (
       <ListGroup>

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -4,12 +4,9 @@ import log from 'loglevel';
 
 import { ThunkActionCreator } from '../configureStore';
 import { getVersion, isErrorResponse } from '../api';
+import { LocalizedStringMap } from '../utils';
 
 type VersionId = number;
-
-type LocalizedString = {
-  [lang: string]: string;
-};
 
 type VersionCompatibility = {
   [appName: string]: {
@@ -21,8 +18,8 @@ type VersionCompatibility = {
 type VersionLicense = {
   id: number;
   isCustom: boolean;
-  name: LocalizedString;
-  text: LocalizedString;
+  name: LocalizedStringMap;
+  text: LocalizedStringMap;
   url: string;
 };
 
@@ -61,7 +58,7 @@ export type ExternalVersionFile = {
 export type ExternalVersionAddon = {
   icon_url: string;
   id: number;
-  name: LocalizedString;
+  name: LocalizedStringMap;
   slug: string;
 };
 
@@ -75,7 +72,7 @@ export type ExternalVersion = {
   id: VersionId;
   is_strict_compatibility_enabled: boolean;
   license: VersionLicense;
-  release_notes: LocalizedString | null;
+  release_notes: LocalizedStringMap | null;
   reviewed: string;
   url: string;
   validation_url: string;
@@ -101,7 +98,7 @@ type VersionEntry = {
 type VersionAddon = {
   iconUrl: string;
   id: number;
-  name: LocalizedString;
+  name: LocalizedStringMap;
   slug: string;
 };
 

--- a/src/utils.spec.tsx
+++ b/src/utils.spec.tsx
@@ -6,6 +6,7 @@ describe(__filename, () => {
       const lang = 'fr';
       const value = 'un peu de contenu';
       const localizedStringMap = {
+        en: 'some content',
         [lang]: value,
       };
 

--- a/src/utils.spec.tsx
+++ b/src/utils.spec.tsx
@@ -1,0 +1,32 @@
+import { getLocalizedString } from './utils';
+
+describe(__filename, () => {
+  describe('getLocalizedString', () => {
+    it('returns a localized string for a given language', () => {
+      const lang = 'fr';
+      const value = 'un peu de contenu';
+      const localizedStringMap = {
+        [lang]: value,
+      };
+
+      expect(getLocalizedString(localizedStringMap, lang)).toEqual(value);
+    });
+
+    it('returns undefined when localized string map does not contain the specified language', () => {
+      const lang = 'fr';
+      const localizedStringMap = {};
+
+      expect(getLocalizedString(localizedStringMap, lang)).toEqual(undefined);
+    });
+
+    it('defaults to REACT_APP_DEFAULT_API_LANG', () => {
+      const lang = process.env.REACT_APP_DEFAULT_API_LANG as string;
+      const value = 'some content';
+      const localizedStringMap = {
+        [lang]: value,
+      };
+
+      expect(getLocalizedString(localizedStringMap)).toEqual(value);
+    });
+  });
+});

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,1 +1,12 @@
+export type LocalizedStringMap = {
+  [lang: string]: string;
+};
+
 export const gettext = (text: string) => text;
+
+export const getLocalizedString = (
+  localizedStringMap: LocalizedStringMap,
+  lang = process.env.REACT_APP_DEFAULT_API_LANG as string,
+) => {
+  return localizedStringMap[lang];
+};


### PR DESCRIPTION
Fixes #261

This patch was an excuse to see how to consume localized content :)

## Screenshot

![screen shot 2019-02-22 at 17 38 21](https://user-images.githubusercontent.com/217628/53256755-e7b0e600-36c8-11e9-9b47-331de833ca7d.png)
