### PR TITLE
Add tests for the map* functions

### DIFF
--- a/src/@types/refractor/index.d.ts
+++ b/src/@types/refractor/index.d.ts
@@ -8,6 +8,9 @@ declare module 'refractor' {
     value: string;
     properties?: {
       className?: string | string[];
+      // A node might have arbitrary properties.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      [key: string]: any;
     };
   };
 

--- a/src/@types/refractor/index.d.ts
+++ b/src/@types/refractor/index.d.ts
@@ -2,8 +2,8 @@ declare module 'refractor' {
   declare function register(language: object): void;
 
   type RefractorNode = {
-    children: RefractorNode[];
-    tagName: string;
+    children?: RefractorNode[];
+    tagName?: string;
     type: string;
     value: string;
     properties?: {

--- a/src/components/CodeView/utils.spec.tsx
+++ b/src/components/CodeView/utils.spec.tsx
@@ -136,6 +136,20 @@ describe(__filename, () => {
 
         expect(element).toEqual(value);
       });
+
+      it('passes all child properties to the element', () => {
+        const target = '_blank';
+        const title = 'link title';
+        const child = createChild({
+          tagName: 'a',
+          properties: { target, title },
+        });
+
+        const element = mapChild(child, 0, 0);
+
+        expect(element).toHaveProperty('props.target', target);
+        expect(element).toHaveProperty('props.title', title);
+      });
     });
 
     describe('mapWithDepth', () => {

--- a/src/components/CodeView/utils.spec.tsx
+++ b/src/components/CodeView/utils.spec.tsx
@@ -1,4 +1,7 @@
-import { getLines } from './utils';
+import { RefractorNode } from 'refractor';
+import makeClassName from 'classnames';
+
+import { mapWithDepth, mapChild, getLines } from './utils';
 
 describe(__filename, () => {
   describe('getLines', () => {
@@ -14,6 +17,140 @@ describe(__filename, () => {
       const content = `${lines.join('\r\n')}`;
 
       expect(getLines(content)).toEqual(lines);
+    });
+  });
+
+  describe('map functions', () => {
+    const createChild = ({
+      children,
+      properties,
+      tagName,
+      type = '',
+      value = '',
+    }: Partial<RefractorNode>): RefractorNode => {
+      return {
+        children,
+        properties,
+        tagName,
+        type,
+        value,
+      };
+    };
+
+    describe('mapChild', () => {
+      it('creates a React element from a child with a tagName and a className', () => {
+        const depth = 0;
+        const i = 0;
+        const className = 'some-css-class';
+        const tagName = 'a';
+        const child = createChild({ tagName, properties: { className } });
+
+        const element = mapChild(child, i, depth);
+
+        expect(element).toHaveProperty('key', `code-child-${depth}-${i}`);
+        expect(element).toHaveProperty('type', tagName);
+        expect(element).toHaveProperty('props.className', className);
+      });
+
+      it('creates a React element with strictly positive depth and index', () => {
+        const depth = 2;
+        const i = 4;
+        const tagName = 'a';
+        const child = createChild({ tagName });
+
+        const element = mapChild(child, i, depth);
+
+        expect(element).toHaveProperty('key', `code-child-${depth}-${i}`);
+      });
+
+      it('creates a React element from a child with a tagName and empty properties', () => {
+        const depth = 0;
+        const i = 0;
+        const tagName = 'a';
+        const child = createChild({ tagName, properties: {} });
+
+        const element = mapChild(child, i, depth);
+
+        expect(element).toHaveProperty('props.className', '');
+      });
+
+      it('creates a React element from a child with a tagName only', () => {
+        const depth = 0;
+        const i = 0;
+        const tagName = 'a';
+        const child = createChild({ tagName, properties: undefined });
+
+        const element = mapChild(child, i, depth);
+
+        expect(element).toHaveProperty('props.className', '');
+      });
+
+      it('creates a React element from a child with multiple class names', () => {
+        const depth = 0;
+        const i = 0;
+        const className = ['some-css-class', 'some-other-css'];
+        const tagName = 'a';
+        const child = createChild({ tagName, properties: { className } });
+
+        const element = mapChild(child, i, depth);
+
+        expect(element).toHaveProperty(
+          'props.className',
+          makeClassName(className),
+        );
+      });
+
+      it('create a React element embedding a child from a child with children', () => {
+        const depth = 2;
+        const i = 3;
+        const tagName = 'a';
+        const className = 'child-css-class';
+        const children = [
+          createChild({ tagName, properties: { className } }),
+          createChild({ tagName, properties: { className } }),
+        ];
+
+        const child = createChild({ tagName, children });
+
+        const element = mapChild(child, i, depth);
+
+        expect(element).toHaveProperty('key', `code-child-${depth}-${i}`);
+        expect(element).toHaveProperty('props.children');
+
+        const { props } = element as React.ReactElement;
+
+        expect(props.children).toHaveLength(2);
+        props.children.forEach((el: React.ReactElement, index: number) => {
+          expect(el).toHaveProperty('key', `code-child-${depth + 1}-${index}`);
+          expect(el).toHaveProperty('props.className', className);
+        });
+      });
+
+      it('returns the value of the child when it has no tagName', () => {
+        const depth = 0;
+        const i = 0;
+        const value = 'some value';
+        const child = createChild({ tagName: undefined, value });
+
+        const element = mapChild(child, i, depth);
+
+        expect(element).toEqual(value);
+      });
+    });
+
+    describe('mapWithDepth', () => {
+      it('returns a function that calls mapChild() with a fixed depth', () => {
+        const child = createChild({ tagName: 'a' });
+        const depth = 123;
+        const index = 2;
+
+        const _mapChild = jest.fn();
+
+        const func = mapWithDepth(depth, _mapChild);
+        func(child, index);
+
+        expect(_mapChild).toHaveBeenCalledWith(child, index, depth);
+      });
     });
   });
 });

--- a/src/components/CodeView/utils.tsx
+++ b/src/components/CodeView/utils.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { RefractorNode } from 'refractor';
 import makeClassName from 'classnames';
 
-const mapChild = (
+export const mapChild = (
   child: RefractorNode,
   i: number,
   depth: number,
@@ -27,9 +27,9 @@ const mapChild = (
   return child.value;
 };
 
-export const mapWithDepth = (depth: number) => {
+export const mapWithDepth = (depth: number, _mapChild = mapChild) => {
   return (child: RefractorNode, i: number) => {
-    return mapChild(child, i, depth);
+    return _mapChild(child, i, depth);
   };
 };
 


### PR DESCRIPTION
Fixes #299

---

This patch adds test cases for the `map*` functions, used in the `CodeView` component.