### PR TITLE
Version chooser

### DIFF
--- a/src/components/VersionChooser/index.spec.tsx
+++ b/src/components/VersionChooser/index.spec.tsx
@@ -3,26 +3,15 @@ import { shallow } from 'enzyme';
 
 import VersionSelect from '../VersionSelect';
 import { fakeVersions } from '../../test-helpers';
-import styles from './styles.module.scss';
 
 import VersionChooser from '.';
 
 describe(__filename, () => {
   const render = ({ versions = fakeVersions } = {}) => {
-    const props = {
-      versions,
-    };
-
-    return shallow(<VersionChooser {...props} />);
+    return shallow(<VersionChooser versions={versions} />);
   };
 
-  it('renders a title', () => {
-    const root = render();
-
-    expect(root.find(`.${styles.heading}`)).toHaveLength(1);
-  });
-
-  it('renders two VersionSelect components and an arrow', () => {
+  it('renders a VersionChooser', () => {
     const root = render();
 
     expect(root.find(VersionSelect)).toHaveLength(2);
@@ -34,7 +23,7 @@ describe(__filename, () => {
       'label',
       'Choose a new version',
     );
-    expect(root.find(`.${styles.arrow}`)).toHaveLength(1);
+    expect(root.find(VersionSelect).at(1)).toHaveProp('withLeftArrow', true);
   });
 
   it('splits the list of versions into listed and unlisted lists', () => {

--- a/src/components/VersionChooser/index.spec.tsx
+++ b/src/components/VersionChooser/index.spec.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+
+import VersionSelect from '../VersionSelect';
+import { fakeVersions } from '../../test-helpers';
+import styles from './styles.module.scss';
+
+import VersionChooser from '.';
+
+describe(__filename, () => {
+  const render = ({ versions = fakeVersions } = {}) => {
+    const props = {
+      versions,
+    };
+
+    return shallow(<VersionChooser {...props} />);
+  };
+
+  it('renders a title', () => {
+    const root = render();
+
+    expect(root.find(`.${styles.heading}`)).toHaveLength(1);
+  });
+
+  it('renders two VersionSelect components and an arrow', () => {
+    const root = render();
+
+    expect(root.find(VersionSelect)).toHaveLength(2);
+    expect(root.find(VersionSelect).at(0)).toHaveProp(
+      'label',
+      'Choose a base version',
+    );
+    expect(root.find(VersionSelect).at(1)).toHaveProp(
+      'label',
+      'Choose a head version',
+    );
+    expect(root.find(`.${styles.arrow}`)).toHaveLength(1);
+  });
+
+  it('splits the list of versions into listed and unlisted lists', () => {
+    const listedVersions = [
+      {
+        ...fakeVersions[0],
+        channel: 'listed',
+      },
+    ];
+    const unlistedVersions = [
+      {
+        ...fakeVersions[1],
+        channel: 'unlisted',
+      },
+    ];
+
+    const root = render({ versions: [...listedVersions, ...unlistedVersions] });
+
+    root.find(VersionSelect).forEach((versionSelect) => {
+      expect(versionSelect).toHaveProp('listedVersions', listedVersions);
+      expect(versionSelect).toHaveProp('unlistedVersions', unlistedVersions);
+    });
+  });
+});

--- a/src/components/VersionChooser/index.spec.tsx
+++ b/src/components/VersionChooser/index.spec.tsx
@@ -28,11 +28,11 @@ describe(__filename, () => {
     expect(root.find(VersionSelect)).toHaveLength(2);
     expect(root.find(VersionSelect).at(0)).toHaveProp(
       'label',
-      'Choose a base version',
+      'Choose an old version',
     );
     expect(root.find(VersionSelect).at(1)).toHaveProp(
       'label',
-      'Choose a head version',
+      'Choose a new version',
     );
     expect(root.find(`.${styles.arrow}`)).toHaveLength(1);
   });

--- a/src/components/VersionChooser/index.tsx
+++ b/src/components/VersionChooser/index.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { Col, Form, Row } from 'react-bootstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import VersionSelect, { Version } from '../VersionSelect';
+import { gettext } from '../../utils';
+import styles from './styles.module.scss';
+
+type PublicProps = {
+  versions: Version[];
+};
+
+class VersionChooserBase extends React.Component<PublicProps> {
+  render() {
+    const { versions } = this.props;
+
+    const listedVersions = versions.filter(
+      (version) => version.channel === 'listed',
+    );
+    const unlistedVersions = versions.filter(
+      (version) => version.channel === 'unlisted',
+    );
+
+    return (
+      <div className={styles.VersionChooser}>
+        <Form>
+          <Row className={styles.heading}>
+            <Col>
+              <h3>{gettext('Compare changes between two versions')}</h3>
+            </Col>
+          </Row>
+
+          <Form.Row>
+            <VersionSelect
+              label={gettext('Choose a base version')}
+              listedVersions={listedVersions}
+              unlistedVersions={unlistedVersions}
+            />
+
+            <div className={styles.arrow}>
+              <FontAwesomeIcon icon="long-arrow-alt-left" />
+            </div>
+
+            <VersionSelect
+              label={gettext('Choose a head version')}
+              listedVersions={listedVersions}
+              unlistedVersions={unlistedVersions}
+            />
+          </Form.Row>
+        </Form>
+      </div>
+    );
+  }
+}
+
+export default VersionChooserBase;

--- a/src/components/VersionChooser/index.tsx
+++ b/src/components/VersionChooser/index.tsx
@@ -32,7 +32,7 @@ class VersionChooserBase extends React.Component<PublicProps> {
 
           <Form.Row>
             <VersionSelect
-              label={gettext('Choose a base version')}
+              label={gettext('Choose an old version')}
               listedVersions={listedVersions}
               unlistedVersions={unlistedVersions}
             />
@@ -42,7 +42,7 @@ class VersionChooserBase extends React.Component<PublicProps> {
             </div>
 
             <VersionSelect
-              label={gettext('Choose a head version')}
+              label={gettext('Choose a new version')}
               listedVersions={listedVersions}
               unlistedVersions={unlistedVersions}
             />

--- a/src/components/VersionChooser/index.tsx
+++ b/src/components/VersionChooser/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Col, Form, Row } from 'react-bootstrap';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import VersionSelect, { Version } from '../VersionSelect';
 import { gettext } from '../../utils';
@@ -26,7 +25,7 @@ class VersionChooserBase extends React.Component<PublicProps> {
         <Form>
           <Row className={styles.heading}>
             <Col>
-              <h3>{gettext('Compare changes between two versions')}</h3>
+              <h3>{gettext('Compare changes')}</h3>
             </Col>
           </Row>
 
@@ -37,14 +36,11 @@ class VersionChooserBase extends React.Component<PublicProps> {
               unlistedVersions={unlistedVersions}
             />
 
-            <div className={styles.arrow}>
-              <FontAwesomeIcon icon="long-arrow-alt-left" />
-            </div>
-
             <VersionSelect
               label={gettext('Choose a new version')}
               listedVersions={listedVersions}
               unlistedVersions={unlistedVersions}
+              withLeftArrow
             />
           </Form.Row>
         </Form>

--- a/src/components/VersionChooser/styles.module.scss
+++ b/src/components/VersionChooser/styles.module.scss
@@ -1,0 +1,17 @@
+@import '../../scss/variables';
+
+.VersionChooser {
+  border-radius: $border-radius;
+  border: 1px solid $light-gray;
+  margin-bottom: $default-padding;
+  padding: $default-padding;
+  width: 100%;
+}
+
+.heading {
+  margin-bottom: $default-padding;
+}
+
+.arrow {
+  margin-top: 7px;
+}

--- a/src/components/VersionChooser/styles.module.scss
+++ b/src/components/VersionChooser/styles.module.scss
@@ -13,5 +13,5 @@
 }
 
 .arrow {
-  margin-top: 7px;
+  margin-top: 40px;
 }

--- a/src/components/VersionChooser/styles.module.scss
+++ b/src/components/VersionChooser/styles.module.scss
@@ -11,7 +11,3 @@
 .heading {
   margin-bottom: $default-padding;
 }
-
-.arrow {
-  margin-top: 40px;
-}

--- a/src/components/VersionSelect/index.spec.tsx
+++ b/src/components/VersionSelect/index.spec.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { Form } from 'react-bootstrap';
+
+import { fakeVersions } from '../../test-helpers';
+
+import VersionSelect from '.';
+
+describe(__filename, () => {
+  const render = (props = {}) => {
+    const allProps = {
+      label: 'select a version',
+      listedVersions: [
+        {
+          ...fakeVersions[0],
+          channel: 'listed',
+        },
+      ],
+      unlistedVersions: [
+        {
+          ...fakeVersions[1],
+          channel: 'unlisted',
+        },
+      ],
+      ...props,
+    };
+
+    return shallow(<VersionSelect {...allProps} />);
+  };
+
+  it('renders a select form control', () => {
+    const root = render();
+
+    expect(root.find(Form.Control)).toHaveLength(1);
+    expect(root.find(Form.Control)).toHaveProp('as', 'select');
+  });
+
+  it('renders a label as first option', () => {
+    const label = 'some label';
+    const root = render({ label });
+
+    expect(root.find('option').at(0)).toIncludeText(label);
+  });
+
+  it('renders two lists of versions', () => {
+    const listedVersions = [
+      {
+        id: 123,
+        channel: 'listed',
+        version: 'v1',
+      },
+    ];
+    const unlistedVersions = [
+      {
+        id: 456,
+        channel: 'unlisted',
+        version: 'v2',
+      },
+    ];
+
+    const root = render({ listedVersions, unlistedVersions });
+
+    expect(root.find('optgroup').at(0)).toHaveProp('label', 'Listed');
+    expect(root.find('option').at(1)).toHaveProp('value', listedVersions[0].id);
+    expect(root.find('option').at(1)).toIncludeText(listedVersions[0].version);
+
+    expect(root.find('optgroup').at(1)).toHaveProp('label', 'Unlisted');
+    expect(root.find('option').at(2)).toHaveProp(
+      'value',
+      unlistedVersions[0].id,
+    );
+    expect(root.find('option').at(2)).toIncludeText(
+      unlistedVersions[0].version,
+    );
+  });
+});

--- a/src/components/VersionSelect/index.spec.tsx
+++ b/src/components/VersionSelect/index.spec.tsx
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import { Form } from 'react-bootstrap';
 
 import { fakeVersions } from '../../test-helpers';
+import styles from './styles.module.scss';
 
 import VersionSelect from '.';
 
@@ -28,19 +29,24 @@ describe(__filename, () => {
     return shallow(<VersionSelect {...allProps} />);
   };
 
-  it('renders a select form control', () => {
-    const root = render();
-
-    expect(root.find(Form.Control)).toHaveLength(1);
-    expect(root.find(Form.Control)).toHaveProp('as', 'select');
-  });
-
   it('renders a label', () => {
     const label = 'some label';
     const root = render({ label });
 
     expect(root.find(Form.Label)).toHaveLength(1);
     expect(root.find(Form.Label)).toIncludeText(label);
+  });
+
+  it('does not render an arrow by default', () => {
+    const root = render();
+
+    expect(root.find(`.${styles.arrow}`)).toHaveLength(0);
+  });
+
+  it('renders an arrow when withLeftArrow is true', () => {
+    const root = render({ withLeftArrow: true });
+
+    expect(root.find(`.${styles.arrow}`)).toHaveLength(1);
   });
 
   it('renders two lists of versions', () => {
@@ -61,11 +67,14 @@ describe(__filename, () => {
 
     const root = render({ listedVersions, unlistedVersions });
 
-    expect(root.find('optgroup').at(0)).toHaveProp('label', 'Listed');
+    expect(root.find(`.${styles.listedGroup}`)).toHaveProp('label', 'Listed');
     expect(root.find('option').at(0)).toHaveProp('value', listedVersions[0].id);
     expect(root.find('option').at(0)).toIncludeText(listedVersions[0].version);
 
-    expect(root.find('optgroup').at(1)).toHaveProp('label', 'Unlisted');
+    expect(root.find(`.${styles.unlistedGroup}`)).toHaveProp(
+      'label',
+      'Unlisted',
+    );
     expect(root.find('option').at(1)).toHaveProp(
       'value',
       unlistedVersions[0].id,

--- a/src/components/VersionSelect/index.spec.tsx
+++ b/src/components/VersionSelect/index.spec.tsx
@@ -35,11 +35,12 @@ describe(__filename, () => {
     expect(root.find(Form.Control)).toHaveProp('as', 'select');
   });
 
-  it('renders a label as first option', () => {
+  it('renders a label', () => {
     const label = 'some label';
     const root = render({ label });
 
-    expect(root.find('option').at(0)).toIncludeText(label);
+    expect(root.find(Form.Label)).toHaveLength(1);
+    expect(root.find(Form.Label)).toIncludeText(label);
   });
 
   it('renders two lists of versions', () => {
@@ -61,15 +62,15 @@ describe(__filename, () => {
     const root = render({ listedVersions, unlistedVersions });
 
     expect(root.find('optgroup').at(0)).toHaveProp('label', 'Listed');
-    expect(root.find('option').at(1)).toHaveProp('value', listedVersions[0].id);
-    expect(root.find('option').at(1)).toIncludeText(listedVersions[0].version);
+    expect(root.find('option').at(0)).toHaveProp('value', listedVersions[0].id);
+    expect(root.find('option').at(0)).toIncludeText(listedVersions[0].version);
 
     expect(root.find('optgroup').at(1)).toHaveProp('label', 'Unlisted');
-    expect(root.find('option').at(2)).toHaveProp(
+    expect(root.find('option').at(1)).toHaveProp(
       'value',
       unlistedVersions[0].id,
     );
-    expect(root.find('option').at(2)).toIncludeText(
+    expect(root.find('option').at(1)).toIncludeText(
       unlistedVersions[0].version,
     );
   });

--- a/src/components/VersionSelect/index.tsx
+++ b/src/components/VersionSelect/index.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { Col, Form } from 'react-bootstrap';
+
+import { gettext } from '../../utils';
+
+export type Version = {
+  channel: string;
+  id: number;
+  version: string;
+};
+
+type PublicProps = {
+  label: string;
+  listedVersions: Version[];
+  unlistedVersions: Version[];
+};
+
+class VersionSelectBase extends React.Component<PublicProps> {
+  render() {
+    const { label, listedVersions, unlistedVersions } = this.props;
+
+    return (
+      <Form.Group as={Col}>
+        <Form.Control as="select">
+          <option>{label}</option>
+          {listedVersions.length && (
+            <optgroup label={gettext('Listed')}>
+              {listedVersions.map((version) => (
+                <option key={version.id} value={version.id}>
+                  {version.version}
+                </option>
+              ))}
+            </optgroup>
+          )}
+          {unlistedVersions.length && (
+            <optgroup label={gettext('Unlisted')}>
+              {unlistedVersions.map((version) => (
+                <option key={version.id} value={version.id}>
+                  {version.version}
+                </option>
+              ))}
+            </optgroup>
+          )}
+        </Form.Control>
+      </Form.Group>
+    );
+  }
+}
+
+export default VersionSelectBase;

--- a/src/components/VersionSelect/index.tsx
+++ b/src/components/VersionSelect/index.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { Col, Form } from 'react-bootstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { gettext } from '../../utils';
+import styles from './styles.module.scss';
 
 export type Version = {
   channel: string;
@@ -13,36 +15,60 @@ type PublicProps = {
   label: string;
   listedVersions: Version[];
   unlistedVersions: Version[];
+  withLeftArrow: boolean;
 };
 
 class VersionSelectBase extends React.Component<PublicProps> {
+  static defaultProps = {
+    withLeftArrow: false,
+  };
+
   render() {
-    const { label, listedVersions, unlistedVersions } = this.props;
+    const {
+      label,
+      listedVersions,
+      unlistedVersions,
+      withLeftArrow,
+    } = this.props;
 
     return (
-      <Form.Group as={Col}>
-        <Form.Label>{label}</Form.Label>
-        <Form.Control as="select">
-          {listedVersions.length && (
-            <optgroup label={gettext('Listed')}>
-              {listedVersions.map((version) => (
-                <option key={version.id} value={version.id}>
-                  {version.version}
-                </option>
-              ))}
-            </optgroup>
-          )}
-          {unlistedVersions.length && (
-            <optgroup label={gettext('Unlisted')}>
-              {unlistedVersions.map((version) => (
-                <option key={version.id} value={version.id}>
-                  {version.version}
-                </option>
-              ))}
-            </optgroup>
-          )}
-        </Form.Control>
-      </Form.Group>
+      <React.Fragment>
+        {withLeftArrow && (
+          <div className={styles.arrow}>
+            <FontAwesomeIcon icon="long-arrow-alt-left" />
+          </div>
+        )}
+
+        <Form.Group as={Col}>
+          <Form.Label>{label}</Form.Label>
+          <Form.Control as="select">
+            {listedVersions.length && (
+              <optgroup
+                className={styles.listedGroup}
+                label={gettext('Listed')}
+              >
+                {listedVersions.map((version) => (
+                  <option key={version.id} value={version.id}>
+                    {version.version}
+                  </option>
+                ))}
+              </optgroup>
+            )}
+            {unlistedVersions.length && (
+              <optgroup
+                className={styles.unlistedGroup}
+                label={gettext('Unlisted')}
+              >
+                {unlistedVersions.map((version) => (
+                  <option key={version.id} value={version.id}>
+                    {version.version}
+                  </option>
+                ))}
+              </optgroup>
+            )}
+          </Form.Control>
+        </Form.Group>
+      </React.Fragment>
     );
   }
 }

--- a/src/components/VersionSelect/index.tsx
+++ b/src/components/VersionSelect/index.tsx
@@ -21,8 +21,8 @@ class VersionSelectBase extends React.Component<PublicProps> {
 
     return (
       <Form.Group as={Col}>
+        <Form.Label>{label}</Form.Label>
         <Form.Control as="select">
-          <option>{label}</option>
           {listedVersions.length && (
             <optgroup label={gettext('Listed')}>
               {listedVersions.map((version) => (

--- a/src/components/VersionSelect/styles.module.scss
+++ b/src/components/VersionSelect/styles.module.scss
@@ -1,0 +1,4 @@
+.arrow {
+  margin: auto;
+  padding-top: 14px;
+}

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Col } from 'react-bootstrap';
+import { Col, Row } from 'react-bootstrap';
 import { RouteComponentProps } from 'react-router-dom';
 import { connect } from 'react-redux';
 
@@ -8,9 +8,11 @@ import { ApiState } from '../../reducers/api';
 import FileTree from '../../components/FileTree';
 import DiffView from '../../components/DiffView';
 import Loading from '../../components/Loading';
+import VersionChooser from '../../components/VersionChooser';
 import { Version, fetchVersion, getVersionInfo } from '../../reducers/versions';
 import { gettext } from '../../utils';
 import diffWithDeletions from '../../components/DiffView/fixtures/diffWithDeletions';
+import { fakeVersions } from '../../test-helpers';
 
 export type PublicProps = {
   _fetchVersion: typeof fetchVersion;
@@ -68,7 +70,16 @@ export class CompareBase extends React.Component<Props> {
           <FileTree version={version} onSelect={this.onSelectFile} />
         </Col>
         <Col md="9">
-          <DiffView diff={diffWithDeletions} mimeType="text/javascript" />
+          <Row>
+            <Col>
+              <VersionChooser versions={fakeVersions} />
+            </Col>
+          </Row>
+          <Row>
+            <Col>
+              <DiffView diff={diffWithDeletions} mimeType="text/javascript" />
+            </Col>
+          </Row>
         </Col>
       </React.Fragment>
     );

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -111,6 +111,24 @@ export const fakeUser: ExternalUser = Object.freeze({
 
 /* eslint-enable @typescript-eslint/camelcase */
 
+export const fakeVersions = [
+  {
+    id: 1541798,
+    channel: 'unlisted',
+    version: '1.5.0',
+  },
+  {
+    id: 1541794,
+    channel: 'listed',
+    version: '1.4.0',
+  },
+  {
+    id: 1541786,
+    channel: 'listed',
+    version: '1.3.0',
+  },
+];
+
 export const createFakeLocation = (props = {}): Location<{}> => {
   return {
     hash: '',

--- a/stories/VersionChooser.stories.tsx
+++ b/stories/VersionChooser.stories.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import VersionChooser from '../src/components/VersionChooser';
+import { fakeVersions } from '../src/test-helpers';
+
+storiesOf('VersionChooser', module).addWithChapters('all variants', {
+  chapters: [
+    {
+      sections: [
+        {
+          title: 'default state',
+          sectionFn: () => <VersionChooser versions={fakeVersions} />,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Fixes #293

---

This patch adds a new `VersionChooser` component (that relies on a `VersionSelect` component for DRY). It will be used to select different versions of an add-on in order to see a `diff` in the compare page.

This is only the first step. Once we get and store data from the API, we can render real data and start the work to select a version. I envision this user action as a simple click into the list of versions that updates the URL and the diff view. That's why there is no "Go" button. [GitHub does that](https://github.com/mozilla/addons-code-manager/compare), too. We will probably need an exclusion list (or at least one version) on the `VersionSelect` component too, so that we can disable the version that has been selected in the other `select` (because we can't diff the same version).


## Screenshots

**New UI:**

<img width="1159" alt="screen shot 2019-03-05 at 19 23 28" src="https://user-images.githubusercontent.com/217628/53827849-5c630a80-3f7c-11e9-8f06-1c2f5902b3b6.png">

Old UI:

<img width="1552" alt="screen shot 2019-03-04 at 11 43 11" src="https://user-images.githubusercontent.com/217628/53730161-6c44f680-3e77-11e9-83f0-8ef7f384ec06.png">
