### PR TITLE
Fetch, store and render a list of versions for an add-on

### DIFF
--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -10,6 +10,7 @@ import {
   callApi,
   getCurrentUser,
   getVersion,
+  getVersionsList,
   isErrorResponse,
   logOutFromServer,
 } from '.';
@@ -235,6 +236,21 @@ describe(__filename, () => {
       );
       expect(fetch).toHaveBeenCalledWith(
         expect.urlWithTheseParams({ file: path }),
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('getVersionsList', () => {
+    it('calls the API to retrieve the list of versions for an add-on', async () => {
+      const addonId = 999;
+
+      await getVersionsList({ apiState: defaultApiState, addonId });
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(
+          `/api/${defaultVersion}/reviewers/addon/${addonId}/versions/`,
+        ),
         expect.any(Object),
       );
     });

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -2,7 +2,7 @@ import log from 'loglevel';
 
 import { ApiState } from '../reducers/api';
 import { ExternalUser } from '../reducers/users';
-import { ExternalVersion } from '../reducers/versions';
+import { ExternalVersion, ExternalVersionsList } from '../reducers/versions';
 
 export enum HttpMethod {
   DELETE = 'DELETE',
@@ -119,6 +119,21 @@ export const getVersion = async ({
     apiState,
     endpoint: `reviewers/addon/${addonId}/versions/${versionId}`,
     query: path ? { file: path } : undefined,
+  });
+};
+
+type GetVersionsListParams = {
+  addonId: number;
+  apiState: ApiState;
+};
+
+export const getVersionsList = async ({
+  apiState,
+  addonId,
+}: GetVersionsListParams) => {
+  return callApi<ExternalVersionsList>({
+    apiState,
+    endpoint: `reviewers/addon/${addonId}/versions/`,
   });
 };
 

--- a/src/components/VersionChooser/index.spec.tsx
+++ b/src/components/VersionChooser/index.spec.tsx
@@ -1,18 +1,64 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
+import { Store } from 'redux';
 
+import configureStore from '../../configureStore';
 import VersionSelect from '../VersionSelect';
-import { fakeVersions } from '../../test-helpers';
+import Loading from '../Loading';
+import {
+  ExternalVersionsList,
+  actions as versionActions,
+} from '../../reducers/versions';
+import {
+  createFakeThunk,
+  fakeVersionsList,
+  shallowUntilTarget,
+  spyOn,
+} from '../../test-helpers';
 
-import VersionChooser from '.';
+import VersionChooser, { VersionChooserBase, PublicProps } from '.';
 
 describe(__filename, () => {
-  const render = ({ versions = fakeVersions } = {}) => {
-    return shallow(<VersionChooser versions={versions} />);
+  type RenderParams = Partial<PublicProps> & { store?: Store };
+
+  const render = ({
+    _fetchVersionsList,
+    addonId = 123,
+    store = configureStore(),
+  }: RenderParams = {}) => {
+    const props = { addonId, _fetchVersionsList };
+
+    return shallowUntilTarget(
+      <VersionChooser {...props} />,
+      VersionChooserBase,
+      {
+        shallowOptions: {
+          context: { store },
+        },
+      },
+    );
   };
 
-  it('renders a VersionChooser', () => {
+  const _loadVersionsList = (
+    store: Store,
+    addonId: number,
+    versions: ExternalVersionsList,
+  ) => {
+    store.dispatch(versionActions.loadVersionsList({ addonId, versions }));
+  };
+
+  it('renders a loading message when lists of versions are not loaded', () => {
     const root = render();
+
+    expect(root.find(VersionSelect)).toHaveLength(0);
+    expect(root.find(Loading)).toHaveLength(1);
+  });
+
+  it('renders two VersionSelect components when lists of versions are loaded', () => {
+    const addonId = 999;
+    const store = configureStore();
+    _loadVersionsList(store, addonId, fakeVersionsList);
+
+    const root = render({ addonId, store });
 
     expect(root.find(VersionSelect)).toHaveLength(2);
     expect(root.find(VersionSelect).at(0)).toHaveProp(
@@ -27,24 +73,54 @@ describe(__filename, () => {
   });
 
   it('splits the list of versions into listed and unlisted lists', () => {
-    const listedVersions = [
+    const addonId = 999;
+    const listedVersions: ExternalVersionsList = [
       {
-        ...fakeVersions[0],
+        ...fakeVersionsList[0],
         channel: 'listed',
       },
     ];
-    const unlistedVersions = [
+    const unlistedVersions: ExternalVersionsList = [
       {
-        ...fakeVersions[1],
+        ...fakeVersionsList[1],
         channel: 'unlisted',
       },
     ];
 
-    const root = render({ versions: [...listedVersions, ...unlistedVersions] });
+    const store = configureStore();
+    _loadVersionsList(store, addonId, [...listedVersions, ...unlistedVersions]);
+
+    const root = render({ addonId, store });
 
     root.find(VersionSelect).forEach((versionSelect) => {
       expect(versionSelect).toHaveProp('listedVersions', listedVersions);
       expect(versionSelect).toHaveProp('unlistedVersions', unlistedVersions);
     });
+  });
+
+  it('dispatches fetchVersionsList() on mount', () => {
+    const addonId = 888;
+    const store = configureStore();
+    const dispatch = spyOn(store, 'dispatch');
+    const fakeThunk = createFakeThunk();
+    const _fetchVersionsList = fakeThunk.createThunk;
+
+    render({ _fetchVersionsList, addonId, store });
+
+    expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
+    expect(_fetchVersionsList).toHaveBeenCalledWith({ addonId });
+  });
+
+  it('does not dispatch fetchVersionsList() on mount when lists are already loaded', () => {
+    const addonId = 888;
+    const store = configureStore();
+    _loadVersionsList(store, addonId, []);
+
+    const dispatch = spyOn(store, 'dispatch');
+    const fakeThunk = createFakeThunk();
+
+    render({ _fetchVersionsList: fakeThunk.createThunk, addonId, store });
+
+    expect(dispatch).not.toHaveBeenCalled();
   });
 });

--- a/src/components/VersionChooser/index.spec.tsx
+++ b/src/components/VersionChooser/index.spec.tsx
@@ -11,6 +11,7 @@ import {
 import {
   createFakeThunk,
   fakeVersionsList,
+  fakeVersionsListItem,
   shallowUntilTarget,
   spyOn,
 } from '../../test-helpers';
@@ -76,13 +77,15 @@ describe(__filename, () => {
     const addonId = 999;
     const listedVersions: ExternalVersionsList = [
       {
-        ...fakeVersionsList[0],
+        ...fakeVersionsListItem,
+        id: 1,
         channel: 'listed',
       },
     ];
     const unlistedVersions: ExternalVersionsList = [
       {
-        ...fakeVersionsList[1],
+        ...fakeVersionsListItem,
+        id: 2,
         channel: 'unlisted',
       },
     ];
@@ -122,5 +125,22 @@ describe(__filename, () => {
     render({ _fetchVersionsList: fakeThunk.createThunk, addonId, store });
 
     expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('dispatches fetchVersionsList() on mount when a different addonId is passed', () => {
+    const addonId = 888;
+    const store = configureStore();
+    _loadVersionsList(store, addonId, []);
+
+    const dispatch = spyOn(store, 'dispatch');
+    const fakeThunk = createFakeThunk();
+    const _fetchVersionsList = fakeThunk.createThunk;
+
+    const secondAddonId = addonId + 123;
+
+    render({ _fetchVersionsList, addonId: secondAddonId, store });
+
+    expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
+    expect(_fetchVersionsList).toHaveBeenCalledWith({ addonId: secondAddonId });
   });
 });

--- a/src/components/VersionChooser/index.tsx
+++ b/src/components/VersionChooser/index.tsx
@@ -1,24 +1,40 @@
 import * as React from 'react';
 import { Col, Form, Row } from 'react-bootstrap';
+import { connect } from 'react-redux';
 
-import VersionSelect, { Version } from '../VersionSelect';
+import Loading from '../Loading';
+import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
+import VersionSelect from '../VersionSelect';
+import { VersionsLists, fetchVersionsList } from '../../reducers/versions';
 import { gettext } from '../../utils';
 import styles from './styles.module.scss';
 
-type PublicProps = {
-  versions: Version[];
+export type PublicProps = {
+  _fetchVersionsList: typeof fetchVersionsList;
+  addonId: number;
 };
 
-class VersionChooserBase extends React.Component<PublicProps> {
-  render() {
-    const { versions } = this.props;
+type PropsFromState = {
+  versionsLists: VersionsLists;
+};
 
-    const listedVersions = versions.filter(
-      (version) => version.channel === 'listed',
-    );
-    const unlistedVersions = versions.filter(
-      (version) => version.channel === 'unlisted',
-    );
+type Props = PropsFromState & PublicProps & ConnectedReduxProps;
+
+export class VersionChooserBase extends React.Component<Props> {
+  static defaultProps = {
+    _fetchVersionsList: fetchVersionsList,
+  };
+
+  componentDidMount() {
+    const { _fetchVersionsList, addonId, dispatch, versionsLists } = this.props;
+
+    if (!versionsLists) {
+      dispatch(_fetchVersionsList({ addonId }));
+    }
+  }
+
+  render() {
+    const { versionsLists } = this.props;
 
     return (
       <div className={styles.VersionChooser}>
@@ -29,24 +45,41 @@ class VersionChooserBase extends React.Component<PublicProps> {
             </Col>
           </Row>
 
-          <Form.Row>
-            <VersionSelect
-              label={gettext('Choose an old version')}
-              listedVersions={listedVersions}
-              unlistedVersions={unlistedVersions}
-            />
+          {versionsLists ? (
+            <Form.Row>
+              <VersionSelect
+                label={gettext('Choose an old version')}
+                listedVersions={versionsLists.listed}
+                unlistedVersions={versionsLists.unlisted}
+              />
 
-            <VersionSelect
-              label={gettext('Choose a new version')}
-              listedVersions={listedVersions}
-              unlistedVersions={unlistedVersions}
-              withLeftArrow
+              <VersionSelect
+                label={gettext('Choose a new version')}
+                listedVersions={versionsLists.listed}
+                unlistedVersions={versionsLists.unlisted}
+                withLeftArrow
+              />
+            </Form.Row>
+          ) : (
+            <Loading
+              message={gettext('Retrieving all the versions of this add-on...')}
             />
-          </Form.Row>
+          )}
         </Form>
       </div>
     );
   }
 }
 
-export default VersionChooserBase;
+const mapStateToProps = (
+  state: ApplicationState,
+  ownProps: PublicProps,
+): PropsFromState => {
+  const versionsLists = state.versions.byAddonId[ownProps.addonId];
+
+  return {
+    versionsLists,
+  };
+};
+
+export default connect(mapStateToProps)(VersionChooserBase);

--- a/src/components/VersionChooser/index.tsx
+++ b/src/components/VersionChooser/index.tsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import Loading from '../Loading';
 import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
 import VersionSelect from '../VersionSelect';
-import { VersionsLists, fetchVersionsList } from '../../reducers/versions';
+import { VersionsMap, fetchVersionsList } from '../../reducers/versions';
 import { gettext } from '../../utils';
 import styles from './styles.module.scss';
 
@@ -15,7 +15,7 @@ export type PublicProps = {
 };
 
 type PropsFromState = {
-  versionsLists: VersionsLists;
+  versionsMap: VersionsMap;
 };
 
 type Props = PropsFromState & PublicProps & ConnectedReduxProps;
@@ -26,15 +26,15 @@ export class VersionChooserBase extends React.Component<Props> {
   };
 
   componentDidMount() {
-    const { _fetchVersionsList, addonId, dispatch, versionsLists } = this.props;
+    const { _fetchVersionsList, addonId, dispatch, versionsMap } = this.props;
 
-    if (!versionsLists) {
+    if (!versionsMap) {
       dispatch(_fetchVersionsList({ addonId }));
     }
   }
 
   render() {
-    const { versionsLists } = this.props;
+    const { versionsMap } = this.props;
 
     return (
       <div className={styles.VersionChooser}>
@@ -45,18 +45,18 @@ export class VersionChooserBase extends React.Component<Props> {
             </Col>
           </Row>
 
-          {versionsLists ? (
+          {versionsMap ? (
             <Form.Row>
               <VersionSelect
                 label={gettext('Choose an old version')}
-                listedVersions={versionsLists.listed}
-                unlistedVersions={versionsLists.unlisted}
+                listedVersions={versionsMap.listed}
+                unlistedVersions={versionsMap.unlisted}
               />
 
               <VersionSelect
                 label={gettext('Choose a new version')}
-                listedVersions={versionsLists.listed}
-                unlistedVersions={versionsLists.unlisted}
+                listedVersions={versionsMap.listed}
+                unlistedVersions={versionsMap.unlisted}
                 withLeftArrow
               />
             </Form.Row>
@@ -75,10 +75,10 @@ const mapStateToProps = (
   state: ApplicationState,
   ownProps: PublicProps,
 ): PropsFromState => {
-  const versionsLists = state.versions.byAddonId[ownProps.addonId];
+  const versionsMap = state.versions.byAddonId[ownProps.addonId];
 
   return {
-    versionsLists,
+    versionsMap,
   };
 };
 

--- a/src/components/VersionSelect/index.spec.tsx
+++ b/src/components/VersionSelect/index.spec.tsx
@@ -2,10 +2,9 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { Form } from 'react-bootstrap';
 
-import configureStore from '../../configureStore';
 import {
   ExternalVersionsList,
-  actions as versionActions,
+  createVersionsMap,
 } from '../../reducers/versions';
 import { fakeVersionsList } from '../../test-helpers';
 import styles from './styles.module.scss';
@@ -18,15 +17,12 @@ describe(__filename, () => {
     versions = fakeVersionsList,
     withLeftArrow = false,
   } = {}) => {
-    const addonId = 123;
-    const store = configureStore();
-    store.dispatch(versionActions.loadVersionsList({ addonId, versions }));
-    const versionsLists = store.getState().versions.byAddonId[addonId];
+    const versionsMap = createVersionsMap(versions);
 
     const allProps = {
       label,
-      listedVersions: versionsLists.listed,
-      unlistedVersions: versionsLists.unlisted,
+      listedVersions: versionsMap.listed,
+      unlistedVersions: versionsMap.unlisted,
       withLeftArrow,
     };
 

--- a/src/components/VersionSelect/index.spec.tsx
+++ b/src/components/VersionSelect/index.spec.tsx
@@ -2,28 +2,32 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { Form } from 'react-bootstrap';
 
-import { fakeVersions } from '../../test-helpers';
+import configureStore from '../../configureStore';
+import {
+  ExternalVersionsList,
+  actions as versionActions,
+} from '../../reducers/versions';
+import { fakeVersionsList } from '../../test-helpers';
 import styles from './styles.module.scss';
 
 import VersionSelect from '.';
 
 describe(__filename, () => {
-  const render = (props = {}) => {
+  const render = ({
+    label = 'select a version',
+    versions = fakeVersionsList,
+    withLeftArrow = false,
+  } = {}) => {
+    const addonId = 123;
+    const store = configureStore();
+    store.dispatch(versionActions.loadVersionsList({ addonId, versions }));
+    const versionsLists = store.getState().versions.byAddonId[addonId];
+
     const allProps = {
-      label: 'select a version',
-      listedVersions: [
-        {
-          ...fakeVersions[0],
-          channel: 'listed',
-        },
-      ],
-      unlistedVersions: [
-        {
-          ...fakeVersions[1],
-          channel: 'unlisted',
-        },
-      ],
-      ...props,
+      label,
+      listedVersions: versionsLists.listed,
+      unlistedVersions: versionsLists.unlisted,
+      withLeftArrow,
     };
 
     return shallow(<VersionSelect {...allProps} />);
@@ -50,14 +54,14 @@ describe(__filename, () => {
   });
 
   it('renders two lists of versions', () => {
-    const listedVersions = [
+    const listedVersions: ExternalVersionsList = [
       {
         id: 123,
         channel: 'listed',
         version: 'v1',
       },
     ];
-    const unlistedVersions = [
+    const unlistedVersions: ExternalVersionsList = [
       {
         id: 456,
         channel: 'unlisted',
@@ -65,7 +69,7 @@ describe(__filename, () => {
       },
     ];
 
-    const root = render({ listedVersions, unlistedVersions });
+    const root = render({ versions: [...listedVersions, ...unlistedVersions] });
 
     expect(root.find(`.${styles.listedGroup}`)).toHaveProp('label', 'Listed');
     expect(root.find('option').at(0)).toHaveProp('value', listedVersions[0].id);

--- a/src/components/VersionSelect/index.spec.tsx
+++ b/src/components/VersionSelect/index.spec.tsx
@@ -6,7 +6,7 @@ import {
   ExternalVersionsList,
   createVersionsMap,
 } from '../../reducers/versions';
-import { fakeVersionsList } from '../../test-helpers';
+import { fakeVersionsList, fakeVersionsListItem } from '../../test-helpers';
 import styles from './styles.module.scss';
 
 import VersionSelect from '.';
@@ -52,6 +52,7 @@ describe(__filename, () => {
   it('renders two lists of versions', () => {
     const listedVersions: ExternalVersionsList = [
       {
+        ...fakeVersionsListItem,
         id: 123,
         channel: 'listed',
         version: 'v1',
@@ -59,6 +60,7 @@ describe(__filename, () => {
     ];
     const unlistedVersions: ExternalVersionsList = [
       {
+        ...fakeVersionsListItem,
         id: 456,
         channel: 'unlisted',
         version: 'v2',

--- a/src/components/VersionSelect/index.tsx
+++ b/src/components/VersionSelect/index.tsx
@@ -2,19 +2,14 @@ import * as React from 'react';
 import { Col, Form } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
+import { VersionsList } from '../../reducers/versions';
 import { gettext } from '../../utils';
 import styles from './styles.module.scss';
 
-export type Version = {
-  channel: string;
-  id: number;
-  version: string;
-};
-
 type PublicProps = {
   label: string;
-  listedVersions: Version[];
-  unlistedVersions: Version[];
+  listedVersions: VersionsList;
+  unlistedVersions: VersionsList;
   withLeftArrow: boolean;
 };
 

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -4,7 +4,6 @@ import { RouteComponentProps } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
-import { ApiState } from '../../reducers/api';
 import FileTree from '../../components/FileTree';
 import DiffView from '../../components/DiffView';
 import Loading from '../../components/Loading';
@@ -12,7 +11,6 @@ import VersionChooser from '../../components/VersionChooser';
 import { Version, fetchVersion, getVersionInfo } from '../../reducers/versions';
 import { gettext } from '../../utils';
 import diffWithDeletions from '../../components/DiffView/fixtures/diffWithDeletions';
-import { fakeVersions } from '../../test-helpers';
 
 export type PublicProps = {
   _fetchVersion: typeof fetchVersion;
@@ -25,7 +23,7 @@ type PropsFromRouter = {
 };
 
 type PropsFromState = {
-  apiState: ApiState;
+  addonId: number;
   version: Version;
 };
 
@@ -54,7 +52,7 @@ export class CompareBase extends React.Component<Props> {
   onSelectFile = () => {};
 
   render() {
-    const { version } = this.props;
+    const { addonId, version } = this.props;
 
     if (!version) {
       return (
@@ -72,7 +70,7 @@ export class CompareBase extends React.Component<Props> {
         <Col md="9">
           <Row>
             <Col>
-              <VersionChooser versions={fakeVersions} />
+              <VersionChooser addonId={addonId} />
             </Col>
           </Row>
           <Row>
@@ -91,12 +89,13 @@ const mapStateToProps = (
   ownProps: RouteComponentProps<PropsFromRouter>,
 ): PropsFromState => {
   const { match } = ownProps;
+  const addonId = parseInt(match.params.addonId, 10);
   const baseVersionId = parseInt(match.params.baseVersionId, 10);
 
   const version = getVersionInfo(state.versions, baseVersionId);
 
   return {
-    apiState: state.api,
+    addonId,
     version,
   };
 };

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -8,7 +8,7 @@ import reducer, {
   createInternalVersionAddon,
   createInternalVersionEntry,
   createInternalVersionFile,
-  createVersionsLists,
+  createVersionsMap,
   fetchVersion,
   fetchVersionFile,
   fetchVersionsList,
@@ -23,6 +23,7 @@ import {
   fakeVersionEntry,
   fakeVersionFile,
   fakeVersionsList,
+  fakeVersionsListItem,
   getFakeLogger,
   thunkTester,
 } from '../test-helpers';
@@ -118,7 +119,7 @@ describe(__filename, () => {
         actions.loadVersionsList({ addonId, versions }),
       );
 
-      expect(state.byAddonId[addonId]).toEqual(createVersionsLists(versions));
+      expect(state.byAddonId[addonId]).toEqual(createVersionsMap(versions));
     });
   });
 
@@ -569,27 +570,30 @@ describe(__filename, () => {
     });
   });
 
-  describe('createVersionsLists', () => {
+  describe('createVersionsMap', () => {
     it('splits a list of versions into listed and unlisted versions', () => {
       const listedVersions: ExternalVersionsList = [
         {
-          ...fakeVersionsList[0],
+          ...fakeVersionsListItem,
+          id: 1,
           channel: 'listed',
         },
       ];
       const unlistedVersions: ExternalVersionsList = [
         {
-          ...fakeVersionsList[1],
+          ...fakeVersionsListItem,
+          id: 2,
           channel: 'unlisted',
         },
         {
-          ...fakeVersionsList[2],
+          ...fakeVersionsListItem,
+          id: 3,
           channel: 'unlisted',
         },
       ];
       const versions = [...listedVersions, ...unlistedVersions];
 
-      const { listed, unlisted } = createVersionsLists(versions);
+      const { listed, unlisted } = createVersionsMap(versions);
 
       expect(listed).toHaveLength(listedVersions.length);
       expect(unlisted).toHaveLength(unlistedVersions.length);

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -1,14 +1,17 @@
 import { getType } from 'typesafe-actions';
 
 import reducer, {
+  ExternalVersionsList,
   VersionEntryType,
   actions,
   createInternalVersion,
   createInternalVersionAddon,
   createInternalVersionEntry,
   createInternalVersionFile,
+  createVersionsLists,
   fetchVersion,
   fetchVersionFile,
+  fetchVersionsList,
   getVersionFile,
   getVersionFiles,
   getVersionInfo,
@@ -19,6 +22,7 @@ import {
   fakeVersionAddon,
   fakeVersionEntry,
   fakeVersionFile,
+  fakeVersionsList,
   getFakeLogger,
   thunkTester,
 } from '../test-helpers';
@@ -103,6 +107,18 @@ describe(__filename, () => {
         `versionInfo.${version.id}.selectedPath`,
         selectedPath,
       );
+    });
+
+    it('stores lists of versions by add-on ID', () => {
+      const addonId = 1245;
+      const versions = fakeVersionsList;
+
+      const state = reducer(
+        undefined,
+        actions.loadVersionsList({ addonId, versions }),
+      );
+
+      expect(state.byAddonId[addonId]).toEqual(createVersionsLists(versions));
     });
   });
 
@@ -470,6 +486,121 @@ describe(__filename, () => {
           type: getType(actions.loadVersionFile),
         }),
       );
+    });
+  });
+
+  describe('fetchVersionsList', () => {
+    const _fetchVersionsList = ({
+      _getVersionsList = jest
+        .fn()
+        .mockReturnValue(Promise.resolve(fakeVersionsList)),
+      _log = getFakeLogger(),
+      addonId = 123,
+    } = {}) => {
+      return thunkTester({
+        createThunk: () =>
+          fetchVersionsList({
+            _getVersionsList,
+            _log,
+            addonId,
+          }),
+      });
+    };
+
+    it('calls getVersionsList', async () => {
+      const addonId = 123;
+      const _getVersionsList = jest
+        .fn()
+        .mockReturnValue(Promise.resolve(fakeVersionsList));
+
+      const { store, thunk } = _fetchVersionsList({
+        _getVersionsList,
+        addonId,
+      });
+
+      await thunk();
+
+      expect(_getVersionsList).toHaveBeenCalledWith({
+        addonId,
+        apiState: store.getState().api,
+      });
+    });
+
+    it('dispatches loadVersionsList when API response is successful', async () => {
+      const addonId = 123;
+      const versions = fakeVersionsList;
+      const _getVersionsList = jest
+        .fn()
+        .mockReturnValue(Promise.resolve(versions));
+
+      const { dispatch, thunk } = _fetchVersionsList({
+        _getVersionsList,
+        addonId,
+      });
+
+      await thunk();
+
+      expect(dispatch).toHaveBeenCalledWith(
+        actions.loadVersionsList({ addonId, versions }),
+      );
+    });
+
+    it('logs an error when API response is not successful', async () => {
+      const _log = getFakeLogger();
+      const _getVersionsList = jest.fn().mockReturnValue(
+        Promise.resolve({
+          error: new Error('Bad Request'),
+        }),
+      );
+
+      const { dispatch, thunk } = _fetchVersionsList({
+        _getVersionsList,
+        _log,
+      });
+
+      await thunk();
+
+      expect(_log.error).toHaveBeenCalled();
+      expect(dispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: getType(actions.loadVersionsList),
+        }),
+      );
+    });
+  });
+
+  describe('createVersionsLists', () => {
+    it('splits a list of versions into listed and unlisted versions', () => {
+      const listedVersions: ExternalVersionsList = [
+        {
+          ...fakeVersionsList[0],
+          channel: 'listed',
+        },
+      ];
+      const unlistedVersions: ExternalVersionsList = [
+        {
+          ...fakeVersionsList[1],
+          channel: 'unlisted',
+        },
+        {
+          ...fakeVersionsList[2],
+          channel: 'unlisted',
+        },
+      ];
+      const versions = [...listedVersions, ...unlistedVersions];
+
+      const { listed, unlisted } = createVersionsLists(versions);
+
+      expect(listed).toHaveLength(listedVersions.length);
+      expect(unlisted).toHaveLength(unlistedVersions.length);
+
+      listedVersions.forEach((version, index) => {
+        expect(listed[index]).toEqual(version);
+      });
+
+      unlistedVersions.forEach((version, index) => {
+        expect(unlisted[index]).toEqual(version);
+      });
     });
   });
 });

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -129,13 +129,13 @@ type VersionsListItem = {
   version: string;
 };
 
-type ExternalVersionsListItem = VersionsListItem;
+export type ExternalVersionsListItem = VersionsListItem;
 
 export type ExternalVersionsList = ExternalVersionsListItem[];
 
 export type VersionsList = VersionsListItem[];
 
-export type VersionsLists = {
+export type VersionsMap = {
   listed: VersionsList;
   unlisted: VersionsList;
 };
@@ -160,7 +160,7 @@ export const actions = {
 
 export type VersionsState = {
   byAddonId: {
-    [addonId: number]: VersionsLists;
+    [addonId: number]: VersionsMap;
   };
   versionInfo: {
     [versionId: number]: Version;
@@ -338,9 +338,9 @@ export const fetchVersionFile = ({
   };
 };
 
-export const createVersionsLists = (
+export const createVersionsMap = (
   versions: ExternalVersionsList,
-): VersionsLists => {
+): VersionsMap => {
   const listed = versions.filter((version) => version.channel === 'listed');
   const unlisted = versions.filter((version) => version.channel === 'unlisted');
 
@@ -433,7 +433,7 @@ const reducer: Reducer<VersionsState, ActionType<typeof actions>> = (
         ...state,
         byAddonId: {
           ...state.byAddonId,
-          [addonId]: createVersionsLists(versions),
+          [addonId]: createVersionsMap(versions),
         },
       };
     }

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -16,6 +16,7 @@ import {
   ExternalVersionEntry,
   ExternalVersionFile,
   ExternalVersionsList,
+  ExternalVersionsListItem,
   VersionEntryType,
 } from './reducers/versions';
 
@@ -147,18 +148,27 @@ export const fakeExternalLinterMessage = Object.freeze({
 
 /* eslint-enable @typescript-eslint/camelcase */
 
+export const fakeVersionsListItem: ExternalVersionsListItem = {
+  id: 1541798,
+  channel: 'unlisted',
+  version: '1.5.0',
+};
+
 export const fakeVersionsList: ExternalVersionsList = [
   {
+    ...fakeVersionsListItem,
     id: 1541798,
     channel: 'unlisted',
     version: '1.5.0',
   },
   {
+    ...fakeVersionsListItem,
     id: 1541794,
     channel: 'listed',
     version: '1.4.0',
   },
   {
+    ...fakeVersionsListItem,
     id: 1541786,
     channel: 'listed',
     version: '1.3.0',

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -15,6 +15,7 @@ import {
   ExternalVersionAddon,
   ExternalVersionEntry,
   ExternalVersionFile,
+  ExternalVersionsList,
   VersionEntryType,
 } from './reducers/versions';
 
@@ -146,7 +147,7 @@ export const fakeExternalLinterMessage = Object.freeze({
 
 /* eslint-enable @typescript-eslint/camelcase */
 
-export const fakeVersions = [
+export const fakeVersionsList: ExternalVersionsList = [
   {
     id: 1541798,
     channel: 'unlisted',

--- a/stories/VersionChooser.stories.tsx
+++ b/stories/VersionChooser.stories.tsx
@@ -1,16 +1,43 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 
+import configureStore from '../src/configureStore';
 import VersionChooser from '../src/components/VersionChooser';
-import { fakeVersions } from '../src/test-helpers';
+import { actions } from '../src/reducers/versions';
+import { fakeVersionsList } from '../src/test-helpers';
+import { renderWithStoreAndRouter } from './utils';
 
 storiesOf('VersionChooser', module).addWithChapters('all variants', {
   chapters: [
     {
       sections: [
         {
-          title: 'default state',
-          sectionFn: () => <VersionChooser versions={fakeVersions} />,
+          title: 'with lists of versions loaded',
+          sectionFn: () => {
+            const addonId = 124;
+
+            const store = configureStore();
+            store.dispatch(
+              actions.loadVersionsList({ addonId, versions: fakeVersionsList }),
+            );
+
+            return renderWithStoreAndRouter(
+              <VersionChooser addonId={addonId} />,
+              store,
+            );
+          },
+        },
+        {
+          title: 'loading state',
+          sectionFn: () => {
+            const addonId = 124;
+            const store = configureStore();
+
+            return renderWithStoreAndRouter(
+              <VersionChooser addonId={addonId} />,
+              store,
+            );
+          },
         },
       ],
     },

--- a/stories/VersionChooser.stories.tsx
+++ b/stories/VersionChooser.stories.tsx
@@ -7,6 +7,10 @@ import { actions } from '../src/reducers/versions';
 import { fakeVersionsList } from '../src/test-helpers';
 import { renderWithStoreAndRouter } from './utils';
 
+const render = ({ addonId = 124, store = configureStore() } = {}) => {
+  return renderWithStoreAndRouter(<VersionChooser addonId={addonId} />, store);
+};
+
 storiesOf('VersionChooser', module).addWithChapters('all variants', {
   chapters: [
     {
@@ -15,29 +19,17 @@ storiesOf('VersionChooser', module).addWithChapters('all variants', {
           title: 'with lists of versions loaded',
           sectionFn: () => {
             const addonId = 124;
-
             const store = configureStore();
             store.dispatch(
               actions.loadVersionsList({ addonId, versions: fakeVersionsList }),
             );
 
-            return renderWithStoreAndRouter(
-              <VersionChooser addonId={addonId} />,
-              store,
-            );
+            return render({ addonId, store });
           },
         },
         {
           title: 'loading state',
-          sectionFn: () => {
-            const addonId = 124;
-            const store = configureStore();
-
-            return renderWithStoreAndRouter(
-              <VersionChooser addonId={addonId} />,
-              store,
-            );
-          },
+          sectionFn: () => render(),
         },
       ],
     },


### PR DESCRIPTION
Fixes #306 
~~⚠️ depends on #305~~

---

This patch adds the logic to fetch, store and give the data to the `VersionChooser` component (cf. #305). We can select versions but it does nothing yet (see #321). The Storybook has been updated to show the two main states of the `VersionChooser` component.

## Screenshots

<img width="1552" alt="screen shot 2019-03-06 at 11 11 03" src="https://user-images.githubusercontent.com/217628/53873379-8d851e80-4000-11e9-9ec3-202ae4e10ddc.png">

<img width="1552" alt="screen shot 2019-03-04 at 17 00 38" src="https://user-images.githubusercontent.com/217628/53745337-2439ca00-3e9f-11e9-85cf-e7c5653debe8.png">
