### PR TITLE
WIP: Store file contents alongside VersionEntries

### DIFF
--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -55,9 +55,12 @@ export const buildFileTree = (
     children: [],
   };
 
+  // Convert the map of entries into an array
+  const entriesArray = Object.keys(entries).map((path) => entries[path]);
+
   // We need to know how depth the tree is because we'll build the Treebeard
   // tree depth by depth.
-  const maxDepth = entries.reduce((max, entry) => {
+  const maxDepth = entriesArray.reduce((max, entry) => {
     if (entry.depth > max) {
       return entry.depth;
     }
@@ -68,7 +71,7 @@ export const buildFileTree = (
   let currentDepth = 0;
   while (currentDepth <= maxDepth) {
     // We find the entries for the current depth.
-    const currentEntries = entries.filter(
+    const currentEntries = entriesArray.filter(
       // eslint-disable-next-line no-loop-func
       (entry) => entry.depth === currentDepth,
     );

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -9,11 +9,9 @@ import { ApiState } from '../../reducers/api';
 import FileTree from '../../components/FileTree';
 import {
   Version,
-  VersionFile,
   fetchVersion,
   fetchVersionFile,
-  getVersionFile,
-  getVersionInfo,
+  getVersion,
 } from '../../reducers/versions';
 import { gettext } from '../../utils';
 import Loading from '../../components/Loading';
@@ -32,7 +30,6 @@ type PropsFromRouter = {
 
 type PropsFromState = {
   apiState: ApiState;
-  file: VersionFile | null | void;
   version: Version;
 };
 
@@ -74,7 +71,7 @@ export class BrowseBase extends React.Component<Props> {
   };
 
   render() {
-    const { file, version } = this.props;
+    const { version } = this.props;
 
     if (!version) {
       return (
@@ -84,9 +81,7 @@ export class BrowseBase extends React.Component<Props> {
       );
     }
 
-    // This is the easy/lazy way of fixing:
-    // https://github.com/mozilla/addons-code-manager/issues/248.
-    const entry = version.entries.find((e) => e.path === version.selectedPath);
+    const entry = version.entries[version.selectedPath];
 
     return (
       <React.Fragment>
@@ -94,8 +89,8 @@ export class BrowseBase extends React.Component<Props> {
           <FileTree version={version} onSelect={this.onSelectFile} />
         </Col>
         <Col md="9">
-          {file && entry ? (
-            <CodeView mimeType={entry.mimeType} content={file.content} />
+          {entry && entry.file ? (
+            <CodeView mimeType={entry.mimeType} content={entry.file.content} />
           ) : (
             <Loading message={gettext('Loading content...')} />
           )}
@@ -110,17 +105,10 @@ const mapStateToProps = (
   ownProps: RouteComponentProps<PropsFromRouter>,
 ): PropsFromState => {
   const { match } = ownProps;
-  const versionId = parseInt(match.params.versionId, 10);
-
-  const version = getVersionInfo(state.versions, versionId);
-  const file = version
-    ? getVersionFile(state.versions, versionId, version.selectedPath)
-    : null;
 
   return {
     apiState: state.api,
-    file,
-    version,
+    version: getVersion(state.versions, parseInt(match.params.versionId, 10)),
   };
 };
 

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -8,7 +8,7 @@ import { ApiState } from '../../reducers/api';
 import FileTree from '../../components/FileTree';
 import DiffView from '../../components/DiffView';
 import Loading from '../../components/Loading';
-import { Version, fetchVersion, getVersionInfo } from '../../reducers/versions';
+import { Version, fetchVersion, getVersion } from '../../reducers/versions';
 import { gettext } from '../../utils';
 import diffWithDeletions from '../../components/DiffView/fixtures/diffWithDeletions';
 
@@ -82,7 +82,7 @@ const mapStateToProps = (
   const { match } = ownProps;
   const baseVersionId = parseInt(match.params.baseVersionId, 10);
 
-  const version = getVersionInfo(state.versions, baseVersionId);
+  const version = getVersion(state.versions, baseVersionId);
 
   return {
     apiState: state.api,

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -12,6 +12,7 @@ import { ExternalUser } from './reducers/users';
 import {
   ExternalVersion,
   ExternalVersionAddon,
+  ExternalVersionEntries,
   ExternalVersionEntry,
   ExternalVersionFile,
   VersionEntryType,
@@ -84,6 +85,25 @@ export const fakeVersion: ExternalVersion = Object.freeze({
   validation_url_json: 'http://example.com/validation/json/',
   version: '1.0',
 });
+
+export const createFakeVersionWithPaths = (paths: string[]) => {
+  const entries: ExternalVersionEntries = {};
+  paths.forEach((path) => {
+    entries[path] = {
+      ...fakeVersionEntry,
+      path,
+    };
+  });
+
+  return {
+    ...fakeVersion,
+    file: {
+      ...fakeVersionFile,
+      entries,
+      selected_file: paths[0],
+    },
+  };
+};
 
 export const fakeUser: ExternalUser = Object.freeze({
   average_addon_rating: 4.3,


### PR DESCRIPTION
Fixes #248 

This ended up being a pretty big patch, but the work is mostly done now, so if we like this approach I think we can move forward with it. I do like the new shape of the reducer, and I think it's a bit friendlier to work with from a consumer standpoint, but the tests have become a bit more complicated.

I can do some work to clean the tests up a bit, perhaps with some helpers if we do decide to go this route.

For now perhaps it's best to just focus on the changes to the reducer and the consumers of the reducer, and if everyone is happy with this approach then we can look at the tests as well.
