### PR TITLE
Add anchors/links on each line of the `CodeView` component

### DIFF
--- a/src/components/CodeView/index.spec.tsx
+++ b/src/components/CodeView/index.spec.tsx
@@ -1,19 +1,54 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
+import { Link } from 'react-router-dom';
+import { Location } from 'history';
+import { mount } from 'enzyme';
 
 import refractor from '../../refractor';
 import { mapWithDepth } from './utils';
 import { getLanguageFromMimeType } from '../../utils';
+import {
+  createContextWithFakeRouter,
+  createFakeLocation,
+  shallowUntilTarget,
+} from '../../test-helpers';
 import styles from './styles.module.scss';
 
-import CodeView from '.';
+import CodeView, { CodeViewBase, PublicProps, scrollToSelectedLine } from '.';
 
 describe(__filename, () => {
+  type RenderParams = Partial<PublicProps> & {
+    location?: Location<{}>;
+  };
+
   const render = ({
-    content = 'some content',
-    mimeType = 'mime/type',
-  } = {}) => {
-    return shallow(<CodeView mimeType={mimeType} content={content} />);
+    location = createFakeLocation(),
+    ...otherProps
+  }: RenderParams = {}) => {
+    const props = {
+      content: 'some content',
+      mimeType: 'mime/type',
+      ...otherProps,
+    };
+
+    return shallowUntilTarget(<CodeView {...props} />, CodeViewBase, {
+      shallowOptions: createContextWithFakeRouter({ location }),
+    });
+  };
+
+  const renderWithMount = ({
+    location = createFakeLocation(),
+    ...otherProps
+  }: RenderParams = {}) => {
+    const props = {
+      content: 'some content',
+      mimeType: 'mime/type',
+      ...otherProps,
+    };
+
+    return mount(
+      <CodeView {...props} />,
+      createContextWithFakeRouter({ location }),
+    );
   };
 
   it('renders plain text code when mime type is not supported', () => {
@@ -64,5 +99,73 @@ describe(__filename, () => {
       contentLines.length,
     );
     expect(root.find(`.${styles.code}`)).toHaveLength(contentLines.length);
+  });
+
+  it('renders an HTML ID for each line', () => {
+    const root = render({ content: 'line 1\nline 2' });
+
+    expect(root.find(`.${styles.line}`)).toHaveLength(2);
+    expect(root.find(`.${styles.line}`).at(0)).toHaveProp('id', 'L1');
+    expect(root.find(`.${styles.line}`).at(1)).toHaveProp('id', 'L2');
+  });
+
+  it('marks a row as selected', () => {
+    const selectedLine = 2;
+    const location = createFakeLocation({ hash: `#L${selectedLine}` });
+
+    const root = render({ content: 'line 1\nline 2', location });
+
+    expect(root.find(`.${styles.selectedLine}`)).toHaveLength(1);
+  });
+
+  it('renders a link for each line number', () => {
+    const root = render({ content: 'single line' });
+
+    expect(root.find(`.${styles.lineNumber}`)).toHaveLength(1);
+    expect(root.find(`.${styles.lineNumber}`).find(Link)).toHaveLength(1);
+    expect(root.find(`.${styles.lineNumber}`).find(Link)).toHaveProp(
+      'to',
+      '#L1',
+    );
+    // This is an anchor on the table row. This is a bit confusing here because
+    // `#` refers to the ID (CSS) selector and not the hash. The ID value is
+    // `L1`.
+    expect(root.find('#L1')).toHaveLength(1);
+  });
+
+  it('calls _scrollToSelectedLine() when rendering a selected line', () => {
+    const selectedLine = 2;
+    const lines = ['first', 'second'];
+    const content = lines.join('\n');
+    const location = createFakeLocation({ hash: `#L${selectedLine}` });
+    const _scrollToSelectedLine = jest.fn();
+
+    // We need `mount()` because `ref` is only used in a DOM environment.
+    const root = renderWithMount({ _scrollToSelectedLine, content, location });
+
+    expect(_scrollToSelectedLine).toHaveBeenCalledWith(
+      root.find(`#L${selectedLine}`).getDOMNode(),
+    );
+  });
+
+  describe('scrollToSelectedLine', () => {
+    it('calls scrollIntoView() when the element is not null', () => {
+      const element = {
+        // Create a HTMLTableRowElement that we can override.
+        ...document.createElement('tr'),
+        id: 'L2',
+        scrollIntoView: jest.fn(),
+      };
+
+      scrollToSelectedLine(element);
+
+      expect(element.scrollIntoView).toHaveBeenCalled();
+    });
+
+    it('does not break when the element is null', () => {
+      const element = null;
+
+      scrollToSelectedLine(element);
+    });
   });
 });

--- a/src/components/CodeView/index.spec.tsx
+++ b/src/components/CodeView/index.spec.tsx
@@ -20,33 +20,33 @@ describe(__filename, () => {
     location?: Location<{}>;
   };
 
-  const render = ({
-    location = createFakeLocation(),
-    ...otherProps
-  }: RenderParams = {}) => {
-    const props = {
+  const getProps = (otherProps = {}) => {
+    return {
       content: 'some content',
       mimeType: 'mime/type',
       ...otherProps,
     };
+  };
 
-    return shallowUntilTarget(<CodeView {...props} />, CodeViewBase, {
-      shallowOptions: createContextWithFakeRouter({ location }),
-    });
+  const render = ({
+    location = createFakeLocation(),
+    ...otherProps
+  }: RenderParams = {}) => {
+    return shallowUntilTarget(
+      <CodeView {...getProps(otherProps)} />,
+      CodeViewBase,
+      {
+        shallowOptions: createContextWithFakeRouter({ location }),
+      },
+    );
   };
 
   const renderWithMount = ({
     location = createFakeLocation(),
     ...otherProps
   }: RenderParams = {}) => {
-    const props = {
-      content: 'some content',
-      mimeType: 'mime/type',
-      ...otherProps,
-    };
-
     return mount(
-      <CodeView {...props} />,
+      <CodeView {...getProps(otherProps)} />,
       createContextWithFakeRouter({ location }),
     );
   };
@@ -116,6 +116,10 @@ describe(__filename, () => {
     const root = render({ content: 'line 1\nline 2', location });
 
     expect(root.find(`.${styles.selectedLine}`)).toHaveLength(1);
+    expect(root.find(`.${styles.selectedLine}`)).toHaveProp(
+      'id',
+      `L${selectedLine}`,
+    );
   });
 
   it('renders a link for each line number', () => {

--- a/src/components/CodeView/index.spec.tsx
+++ b/src/components/CodeView/index.spec.tsx
@@ -157,7 +157,6 @@ describe(__filename, () => {
       const element = {
         // Create a HTMLTableRowElement that we can override.
         ...document.createElement('tr'),
-        id: 'L2',
         scrollIntoView: jest.fn(),
       };
 

--- a/src/components/CodeView/styles.module.scss
+++ b/src/components/CodeView/styles.module.scss
@@ -18,10 +18,29 @@
   width: 100%;
 }
 
+.selectedLine {
+  background-color: $light-gray;
+}
+
 .lineNumber {
   padding-right: $default-padding;
   text-align: right;
   user-select: none;
+
+  a {
+    color: $gray;
+
+    .selectedLine &,
+    &:focus,
+    &:hover {
+      color: darken($gray, 30);
+      font-weight: 500;
+    }
+  }
+}
+
+.code {
+  width: 100%;
 }
 
 .lineNumber,

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -4,6 +4,7 @@
 $border-radius: 0.25rem;
 $default-padding: 10px;
 $light-gray: $gray-200;
+$gray: $gray-500;
 
 // Shared style for the CodeView and DiffView components.
 $code-font-family: Consolas, Courier, monospace;

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -195,7 +195,8 @@ export const createFakeHistory = ({
 
 export const createContextWithFakeRouter = ({
   history = createFakeHistory(),
-  location = null as Location<{}> | null,
+  // We tell TS that `location` is a nullable Location object.
+  location = null as Location | null,
   match = {},
   ...overrides
 } = {}) => {

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -195,7 +195,7 @@ export const createFakeHistory = ({
 
 export const createContextWithFakeRouter = ({
   history = createFakeHistory(),
-  location = null,
+  location = null as Location<{}> | null,
   match = {},
   ...overrides
 } = {}) => {

--- a/stories/CodeView.stories.tsx
+++ b/stories/CodeView.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import CodeView from '../src/components/CodeView';
+import { renderWithStoreAndRouter } from './utils';
 
 const JS = `/**
  * There was an error executing the script.
@@ -39,17 +40,22 @@ storiesOf('CodeView', module).addWithChapters('all variants', {
       sections: [
         {
           title: 'unsupported mime type',
-          sectionFn: () => <CodeView mimeType="" content={JS} />,
+          sectionFn: () =>
+            renderWithStoreAndRouter(<CodeView mimeType="" content={JS} />),
         },
         {
           title: 'application/javascript',
-          sectionFn: () => (
-            <CodeView mimeType="application/javascript" content={JS} />
-          ),
+          sectionFn: () =>
+            renderWithStoreAndRouter(
+              <CodeView mimeType="application/javascript" content={JS} />,
+            ),
         },
         {
           title: 'text/css',
-          sectionFn: () => <CodeView mimeType="text/css" content={CSS} />,
+          sectionFn: () =>
+            renderWithStoreAndRouter(
+              <CodeView mimeType="text/css" content={CSS} />,
+            ),
         },
       ],
     },


### PR DESCRIPTION
Fixes #317

---

This PR adds links on each line number of the `CodeView` component so that we can link to a specific line. This is needed for the outline (#200).

## Screenshots

<img width="1552" alt="screen shot 2019-03-06 at 14 58 43" src="https://user-images.githubusercontent.com/217628/53886506-76562900-4020-11e9-870b-10821cd2e468.png">
<img width="1552" alt="screen shot 2019-03-06 at 14 57 55" src="https://user-images.githubusercontent.com/217628/53886509-76562900-4020-11e9-8d95-4a5b0aa47f63.png">

## Gif

![2019-03-06 14 58 24](https://user-images.githubusercontent.com/217628/53886514-79511980-4020-11e9-860e-9f504a302064.gif)

