### PR TITLE
Use bootstrap column in NotFound component

### DIFF
--- a/src/pages/NotFound/index.tsx
+++ b/src/pages/NotFound/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import { Col } from 'react-bootstrap';
 
 import { gettext } from '../../utils';
 
@@ -8,12 +9,12 @@ type PublicProps = {};
 export class NotFoundBase extends React.Component<PublicProps> {
   render() {
     return (
-      <div>
+      <Col>
         <h1>{gettext('Ooops, page not found!')}</h1>
         <p>
           <Link to="/">{gettext('Take me home')}</Link>
         </p>
-      </div>
+      </Col>
     );
   }
 }


### PR DESCRIPTION
This is a small fix because I stumbled upon this page today and that did not look nice. I don't think it needs a review because it is about replacing a `div` with a `Col` component.

Before:

<img width="1552" alt="screen shot 2019-03-07 at 11 16 44" src="https://user-images.githubusercontent.com/217628/53949556-8e828280-40ca-11e9-8c46-f0a3b0029d98.png">

After:

<img width="1552" alt="screen shot 2019-03-07 at 11 16 30" src="https://user-images.githubusercontent.com/217628/53949546-8aeefb80-40ca-11e9-96b0-79e1ab7c8a3f.png">
