### PR TITLE
Add a quick check to ensure old version is older than the new version

### DIFF
--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -77,15 +77,15 @@ describe(__filename, () => {
   };
 
   type GetRouteParamsParams = {
-    addonId: number;
-    baseVersionId: number;
-    headVersionId: number;
+    addonId?: number;
+    baseVersionId?: number;
+    headVersionId?: number;
   };
 
   const getRouteParams = ({
-    addonId,
-    baseVersionId,
-    headVersionId,
+    addonId = 9999,
+    baseVersionId = 1,
+    headVersionId = 1000,
   }: GetRouteParamsParams) => {
     return {
       addonId: String(addonId),
@@ -142,7 +142,6 @@ describe(__filename, () => {
   it('dispatches fetchVersion() on mount', () => {
     const addonId = 123456;
     const baseVersion = fakeVersion;
-    const headVersion = { ...fakeVersion, id: baseVersion.id + 1 };
 
     const store = configureStore();
     const dispatch = spyOn(store, 'dispatch');
@@ -155,7 +154,6 @@ describe(__filename, () => {
       ...getRouteParams({
         addonId,
         baseVersionId: baseVersion.id,
-        headVersionId: headVersion.id,
       }),
     });
 
@@ -233,7 +231,6 @@ describe(__filename, () => {
   it('dispatches fetchVersion() on update if base version is different', () => {
     const addonId = 123456;
     const baseVersion = fakeVersion;
-    const headVersion = { ...fakeVersion, id: baseVersion.id + 1 };
 
     const store = configureStore();
     const fakeThunk = createFakeThunk();
@@ -245,7 +242,6 @@ describe(__filename, () => {
       ...getRouteParams({
         addonId,
         baseVersionId: baseVersion.id - 10,
-        headVersionId: headVersion.id,
       }),
       store,
     });
@@ -257,7 +253,6 @@ describe(__filename, () => {
         params: getRouteParams({
           addonId,
           baseVersionId: baseVersion.id,
-          headVersionId: headVersion.id,
         }),
       },
     });
@@ -311,7 +306,6 @@ describe(__filename, () => {
   it('dispatches fetchVersion() on update if addon ID is different', () => {
     const addonId = 123456;
     const baseVersion = fakeVersion;
-    const headVersion = { ...fakeVersion, id: baseVersion.id + 1 };
 
     const store = configureStore();
     const fakeThunk = createFakeThunk();
@@ -323,7 +317,6 @@ describe(__filename, () => {
       ...getRouteParams({
         addonId: addonId + 10,
         baseVersionId: baseVersion.id,
-        headVersionId: headVersion.id,
       }),
       store,
     });
@@ -335,7 +328,6 @@ describe(__filename, () => {
         params: getRouteParams({
           addonId,
           baseVersionId: baseVersion.id,
-          headVersionId: headVersion.id,
         }),
       },
     });

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -20,6 +20,7 @@ type PropsFromRouter = {
   addonId: string;
   baseVersionId: string;
   headVersionId: string;
+  lang: string;
 };
 
 type PropsFromState = {
@@ -38,13 +39,25 @@ export class CompareBase extends React.Component<Props> {
   };
 
   componentDidMount() {
-    const { _fetchVersion, dispatch, match } = this.props;
-    const { addonId, baseVersionId } = match.params;
+    const { _fetchVersion, dispatch, history, match } = this.props;
+    const { lang, addonId, baseVersionId, headVersionId } = match.params;
+
+    let oldVersionId = parseInt(baseVersionId, 10);
+    let newVersionId = parseInt(headVersionId, 10);
+
+    // We ensure the new version ID is newer than the old version ID.
+    if (oldVersionId > newVersionId) {
+      history.push(
+        `/${lang}/compare/${addonId}/versions/${headVersionId}...${baseVersionId}/`,
+      );
+      oldVersionId = newVersionId;
+      newVersionId = parseInt(baseVersionId, 10);
+    }
 
     dispatch(
       _fetchVersion({
         addonId: parseInt(addonId, 10),
-        versionId: parseInt(baseVersionId, 10),
+        versionId: oldVersionId,
       }),
     );
   }

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -39,27 +39,47 @@ export class CompareBase extends React.Component<Props> {
   };
 
   componentDidMount() {
-    const { _fetchVersion, dispatch, history, match } = this.props;
+    const { history, match } = this.props;
     const { lang, addonId, baseVersionId, headVersionId } = match.params;
 
-    let oldVersionId = parseInt(baseVersionId, 10);
-    let newVersionId = parseInt(headVersionId, 10);
+    const oldVersionId = parseInt(baseVersionId, 10);
+    const newVersionId = parseInt(headVersionId, 10);
 
     // We ensure the new version ID is newer than the old version ID.
     if (oldVersionId > newVersionId) {
       history.push(
         `/${lang}/compare/${addonId}/versions/${headVersionId}...${baseVersionId}/`,
       );
-      oldVersionId = newVersionId;
-      newVersionId = parseInt(baseVersionId, 10);
+      return;
     }
 
-    dispatch(
-      _fetchVersion({
-        addonId: parseInt(addonId, 10),
-        versionId: oldVersionId,
-      }),
-    );
+    this.loadData();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    this.loadData(prevProps);
+  }
+
+  loadData(prevProps?: Props) {
+    const { match } = this.props;
+    const { addonId, baseVersionId, headVersionId } = match.params;
+
+    if (
+      !prevProps ||
+      addonId !== prevProps.match.params.addonId ||
+      baseVersionId !== prevProps.match.params.baseVersionId ||
+      headVersionId !== prevProps.match.params.headVersionId
+    ) {
+      const { dispatch, _fetchVersion } = this.props;
+      const oldVersionId = parseInt(baseVersionId, 10);
+
+      dispatch(
+        _fetchVersion({
+          addonId: parseInt(addonId, 10),
+          versionId: oldVersionId,
+        }),
+      );
+    }
   }
 
   onSelectFile = () => {};

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -71,12 +71,11 @@ export class CompareBase extends React.Component<Props> {
       headVersionId !== prevProps.match.params.headVersionId
     ) {
       const { dispatch, _fetchVersion } = this.props;
-      const oldVersionId = parseInt(baseVersionId, 10);
 
       dispatch(
         _fetchVersion({
           addonId: parseInt(addonId, 10),
-          versionId: oldVersionId,
+          versionId: parseInt(baseVersionId, 10),
         }),
       );
     }


### PR DESCRIPTION
This will be useful to make sure both #111 and #314 behave correctly. All the other components in `Compare` won't have to deal with the problem of knowing which version is the "old" one and which version is the "new" one. This check happens before any reviewer API calls.

It works because version IDs are integers and newer version IDs get higher numbers (there is some sort of auto-increment). I know we should avoid relying on the auto-increment property of an ID in general, but this is a very simple solution that works well for our purpose. I don't think we'll change the type of version IDs anytime soon (we'll likely always deal with integers) and I don't think we'll change the behavior that currently guarantees that new version IDs have higher numbers than older version IDs. Hence the proposed patch.

The longer version of this (mvp-polish, maybe?) would be to:

- fetch both versions separately (I don't think we need version data in the compare page so it would mean fetching the data only for the comparison)
- compare both versions, but based on what? There is currently no reliable value exposed to perform such a comparison. A `created_at` date could work, if this is something that we store in the database already
- do what's in this patch

If you browse: http://localhost:3000/en-US/compare/502955/versions/1541799...1541798/, this patch detects that the right version is lower than the left version and inverts them + update the URL.

Let me know what you think!