### PR TITLE
Return data required by the file footer from getVersionFile

### DIFF
--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -129,6 +129,7 @@ describe(__filename, () => {
         mimeType: entry.mimetype,
         modified: entry.modified,
         path: entry.path,
+        sha256: entry.sha256,
         type: entry.mime_category,
       });
     });
@@ -180,7 +181,9 @@ describe(__filename, () => {
     it('returns a version file', () => {
       const mimeType = 'mime/type';
       const path = 'test.js';
+      const sha256 = 'some-sha';
       const type = 'text';
+      const versionString = '1.0.1';
       const version = {
         ...fakeVersion,
         file: {
@@ -188,20 +191,26 @@ describe(__filename, () => {
           entries: {
             [path]: {
               ...fakeVersionEntry,
+              filename: path,
               mime_category: type as VersionEntryType,
               mimetype: mimeType,
               path,
+              sha256,
             },
           },
           selected_file: path,
         },
+        version: versionString,
       };
       const state = reducer(undefined, actions.loadVersionInfo({ version }));
 
       expect(getVersionFile(state, version.id, path)).toEqual({
         ...createInternalVersionFile(version.file),
+        filename: path,
         mimeType,
+        sha256,
         type,
+        version: versionString,
       });
     });
     /* eslint-enable @typescript-eslint/camelcase */

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -92,10 +92,13 @@ type InternalVersionFile = {
 export type VersionFile = {
   content: string;
   created: string;
+  filename: string;
   id: number;
   mimeType: string;
+  sha256: string;
   size: number;
   type: VersionEntryType;
+  version: string;
 };
 
 type VersionEntry = {
@@ -104,6 +107,7 @@ type VersionEntry = {
   mimeType: string;
   modified: string;
   path: string;
+  sha256: string;
   type: VersionEntryType;
 };
 
@@ -173,6 +177,7 @@ export const createInternalVersionEntry = (
     mimeType: entry.mimetype,
     modified: entry.modified,
     path: entry.path,
+    sha256: entry.sha256,
     type: entry.mime_category,
   };
 };
@@ -238,8 +243,11 @@ export const getVersionFile = (
     if (file) {
       return {
         ...file,
+        filename: entry.filename,
         mimeType: entry.mimeType,
+        sha256: entry.sha256,
         type: entry.type,
+        version: version.version,
       };
     }
   }


### PR DESCRIPTION
Fixes #347 

Note that this does not implement the download link. I opened #348 as a follow-up.