### PR TITLE
Add `createInternalDiffs` function to `versions` reducer

### DIFF
--- a/src/@types/react-diff-view/index.d.ts
+++ b/src/@types/react-diff-view/index.d.ts
@@ -26,6 +26,8 @@ declare module 'react-diff-view' {
 
   type Hunks = HunkInfo[];
 
+  export type DiffInfoType = 'add' | 'copy' | 'delete' | 'modify' | 'rename';
+
   export type DiffInfo = {
     oldPath: string;
     newPath: string;
@@ -36,7 +38,7 @@ declare module 'react-diff-view' {
     newRevision: string;
     newMode: string;
     oldMode: string;
-    type: string;
+    type: DiffInfoType;
   };
 
   declare function parseDiff(text: string, options?: object): DiffInfo[];

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -698,7 +698,7 @@ describe(__filename, () => {
           externalDiff.new_ending_new_line,
         );
 
-        // These props will be tested later.
+        // These props will be tested in a different test case below.
         expect(diff).toHaveProperty('type');
         expect(diff).toHaveProperty('hunks');
       });
@@ -748,7 +748,7 @@ describe(__filename, () => {
         expect(hunk).toHaveProperty('oldStart', externalHunk.old_start);
         expect(hunk).toHaveProperty('newStart', externalHunk.new_start);
 
-        // This prop will be tested later.
+        // This prop will be tested in a different test case below.
         expect(hunk).toHaveProperty('changes');
       });
     });
@@ -782,7 +782,7 @@ describe(__filename, () => {
           externalChange.new_line_number,
         );
 
-        // These props will be tested later.
+        // These props will be tested in a different test case below.
         expect(change).toHaveProperty('lineNumber');
         expect(change).toHaveProperty('isDelete');
         expect(change).toHaveProperty('isInsert');

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -681,14 +681,22 @@ describe(__filename, () => {
 
       expect(diffs).toHaveLength(externalDiffs.length);
       diffs.forEach((diff, index) => {
+        const externalDiff = externalDiffs[index];
+
         expect(diff).toHaveProperty('oldRevision', String(baseVersionId));
         expect(diff).toHaveProperty('newRevision', String(headVersionId));
-        expect(diff).toHaveProperty('oldMode', externalDiffs[index].mode);
-        expect(diff).toHaveProperty('newMode', externalDiffs[index].mode);
-        expect(diff).toHaveProperty('oldPath', externalDiffs[index].old_path);
-        expect(diff).toHaveProperty('newPath', externalDiffs[index].path);
-        expect(diff).toHaveProperty('oldEndingNewLine', false);
-        expect(diff).toHaveProperty('newEndingNewLine', false);
+        expect(diff).toHaveProperty('oldMode', externalDiff.mode);
+        expect(diff).toHaveProperty('newMode', externalDiff.mode);
+        expect(diff).toHaveProperty('oldPath', externalDiff.old_path);
+        expect(diff).toHaveProperty('newPath', externalDiff.path);
+        expect(diff).toHaveProperty(
+          'oldEndingNewLine',
+          externalDiff.old_ending_new_line,
+        );
+        expect(diff).toHaveProperty(
+          'newEndingNewLine',
+          externalDiff.new_ending_new_line,
+        );
 
         // These props will be tested later.
         expect(diff).toHaveProperty('type');

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -102,6 +102,8 @@ type ExternalDiff = {
   lines_added: number;
   lines_deleted: number;
   mode: string;
+  new_ending_new_line: boolean;
+  old_ending_new_line: boolean;
   old_path: string;
   parent: string;
   path: string;
@@ -478,8 +480,8 @@ export const createInternalDiffs = ({
           oldStart: hunk.old_start,
         })),
         type: GIT_STATUS_TO_TYPE[diff.mode] || GIT_STATUS_TO_TYPE.M,
-        newEndingNewLine: false,
-        oldEndingNewLine: false,
+        newEndingNewLine: diff.new_ending_new_line,
+        oldEndingNewLine: diff.old_ending_new_line,
         newMode: diff.mode,
         oldMode: diff.mode,
         newPath: diff.path,

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -1,7 +1,7 @@
 import { Reducer } from 'redux';
 import { ActionType, createAction, getType } from 'typesafe-actions';
 import log from 'loglevel';
-import { DiffInfo } from 'react-diff-view';
+import { DiffInfo, DiffInfoType } from 'react-diff-view';
 
 import { ThunkActionCreator } from '../configureStore';
 import { getVersion, getVersionsList, isErrorResponse } from '../api';
@@ -433,7 +433,7 @@ export const fetchVersionsList = ({
   };
 };
 
-type CreateInternalDiffParams = {
+type CreateInternalDiffsParams = {
   version: ExternalVersionWithDiff;
   baseVersionId: number;
   headVersionId: number;
@@ -444,8 +444,8 @@ export const createInternalDiffs = ({
   baseVersionId,
   headVersionId,
   version,
-}: CreateInternalDiffParams) => {
-  const GIT_STATUS_TO_TYPE: { [mode: string]: string } = {
+}: CreateInternalDiffsParams) => {
+  const GIT_STATUS_TO_TYPE: { [status: string]: DiffInfoType } = {
     A: 'add',
     C: 'copy',
     D: 'delete',

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -217,6 +217,8 @@ export const fakeExternalDiff = Object.freeze({
   old_path: 'manifest.json',
   parent: '514a8bd3cfb1ccae67dff61e3ea174bb444dfb00',
   hash: '054771578d3a903264bfd16ba71e5b4808a6764b',
+  old_ending_new_line: true,
+  new_ending_new_line: false,
 });
 
 /* eslint-enable @typescript-eslint/camelcase */

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -11,6 +11,7 @@ import configureStore, {
 import { ExternalLinterResult, ExternalLinterMessage } from './reducers/linter';
 import { ExternalUser } from './reducers/users';
 import {
+  ExternalChange,
   ExternalVersionAddon,
   ExternalVersionEntry,
   ExternalVersionFileWithContent,
@@ -145,6 +146,78 @@ export const fakeExternalLinterResult = Object.freeze({
     warnings: 5,
   },
 }) as ExternalLinterResult;
+
+export const fakeExternalDiff = Object.freeze({
+  path: 'manifest.json',
+  size: 172,
+  lines_added: 2,
+  lines_deleted: 2,
+  is_binary: false,
+  mode: 'M',
+  hunks: [
+    {
+      header: '@@ -1,6 +1,6 @@\n',
+      old_start: 1,
+      new_start: 1,
+      old_lines: 6,
+      new_lines: 6,
+      changes: [
+        {
+          content: '{\r\n',
+          type: 'normal' as ExternalChange['type'],
+          old_line_number: 1,
+          new_line_number: 1,
+        },
+        {
+          content: '    "manifest_version": 2,\r\n',
+          type: 'normal' as ExternalChange['type'],
+          old_line_number: 2,
+          new_line_number: 2,
+        },
+        {
+          content: '    "version": "7",\r\n',
+          type: 'delete' as ExternalChange['type'],
+          old_line_number: 3,
+          new_line_number: -1,
+        },
+        {
+          content: '    "version": "8",\r\n',
+          type: 'insert' as ExternalChange['type'],
+          old_line_number: -1,
+          new_line_number: 3,
+        },
+        {
+          content:
+            '    "name": "Awesome Screenshot - Capture, Annotate & More",\r\n',
+          type: 'normal' as ExternalChange['type'],
+          old_line_number: 4,
+          new_line_number: 4,
+        },
+        {
+          content: '    "description": "this is a new description"\r\n',
+          type: 'delete' as ExternalChange['type'],
+          old_line_number: 5,
+          new_line_number: -1,
+        },
+        {
+          content: '    "description": "this is a new version with files"\r\n',
+          type: 'insert' as ExternalChange['type'],
+          old_line_number: -1,
+          new_line_number: 5,
+        },
+        {
+          content: '}\r\n',
+          type: 'normal' as ExternalChange['type'],
+          old_line_number: 6,
+          new_line_number: 6,
+        },
+      ],
+    },
+  ],
+  old_path: 'manifest.json',
+  parent: '514a8bd3cfb1ccae67dff61e3ea174bb444dfb00',
+  hash: '054771578d3a903264bfd16ba71e5b4808a6764b',
+});
 
 /* eslint-enable @typescript-eslint/camelcase */
 


### PR DESCRIPTION
Fixes #359 
~~⚠️ Depends on #356~~

---

This patch adds a function to map the diff part of the Compare API response to the internal representation needed for `react-diff-view`. It needs #356 which adds types.

Only the second commit is relevant here.