### PR TITLE
Fetch and store diffs

### DIFF
--- a/src/components/FileMetadata/index.spec.tsx
+++ b/src/components/FileMetadata/index.spec.tsx
@@ -18,6 +18,12 @@ describe(__filename, () => {
     const store = configureStore();
     const version = fakeVersion;
     store.dispatch(versionActions.loadVersionInfo({ version }));
+    store.dispatch(
+      versionActions.loadVersionFile({
+        path: version.file.selected_file,
+        version,
+      }),
+    );
 
     return {
       ...(getVersionFile(

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -97,6 +97,19 @@ describe(__filename, () => {
     });
   };
 
+  const _loadVersion = ({
+    store = configureStore(),
+    version = fakeVersion,
+  }) => {
+    store.dispatch(versionActions.loadVersionInfo({ version }));
+    store.dispatch(
+      versionActions.loadVersionFile({
+        path: version.file.selected_file,
+        version,
+      }),
+    );
+  };
+
   const renderAndUpdateWithVersion = ({
     store = configureStore(),
     version,
@@ -107,7 +120,7 @@ describe(__filename, () => {
     const fakeThunk = createFakeThunk();
     const _fetchLinterMessages = fakeThunk.createThunk;
 
-    store.dispatch(versionActions.loadVersionInfo({ version }));
+    _loadVersion({ store, version });
     const dispatch = spyOn(store, 'dispatch');
 
     const root = render({
@@ -158,10 +171,13 @@ describe(__filename, () => {
       file: {
         ...fakeVersionFile,
         entries: { [path]: { ...fakeVersionEntry, path } },
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        selected_file: path,
       },
     };
-    store.dispatch(versionActions.loadVersionInfo({ version }));
-    store.dispatch(versionActions.loadVersionFile({ path, version }));
+
+    _loadVersion({ store, version });
+
     // Simulate selecting the file to render.
     store.dispatch(
       versionActions.updateSelectedPath({
@@ -192,7 +208,7 @@ describe(__filename, () => {
     const version = fakeVersion;
 
     const store = configureStore();
-    store.dispatch(versionActions.loadVersionInfo({ version }));
+    _loadVersion({ store, version });
 
     const root = render({ store, versionId: String(version.id) });
 
@@ -207,7 +223,7 @@ describe(__filename, () => {
     const version = fakeVersion;
 
     const store = configureStore();
-    store.dispatch(versionActions.loadVersionInfo({ version }));
+    _loadVersion({ store, version });
 
     const root = render({ store, versionId: String(version.id) });
 
@@ -218,7 +234,7 @@ describe(__filename, () => {
     const version = fakeVersion;
 
     const store = configureStore();
-    store.dispatch(versionActions.loadVersionInfo({ version }));
+    _loadVersion({ store, version });
 
     // The user clicks a different file to view.
     store.dispatch(
@@ -321,7 +337,7 @@ describe(__filename, () => {
     const path = 'some-path';
 
     const store = configureStore();
-    store.dispatch(versionActions.loadVersionInfo({ version }));
+    _loadVersion({ store, version });
 
     const dispatch = spyOn(store, 'dispatch');
     const fakeThunk = createFakeThunk();

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -97,7 +97,7 @@ describe(__filename, () => {
     });
   };
 
-  const _loadVersion = ({
+  const _loadVersionAndFile = ({
     store = configureStore(),
     version = fakeVersion,
   }) => {
@@ -120,7 +120,7 @@ describe(__filename, () => {
     const fakeThunk = createFakeThunk();
     const _fetchLinterMessages = fakeThunk.createThunk;
 
-    _loadVersion({ store, version });
+    _loadVersionAndFile({ store, version });
     const dispatch = spyOn(store, 'dispatch');
 
     const root = render({
@@ -176,7 +176,7 @@ describe(__filename, () => {
       },
     };
 
-    _loadVersion({ store, version });
+    _loadVersionAndFile({ store, version });
 
     // Simulate selecting the file to render.
     store.dispatch(
@@ -208,7 +208,7 @@ describe(__filename, () => {
     const version = fakeVersion;
 
     const store = configureStore();
-    _loadVersion({ store, version });
+    _loadVersionAndFile({ store, version });
 
     const root = render({ store, versionId: String(version.id) });
 
@@ -223,7 +223,7 @@ describe(__filename, () => {
     const version = fakeVersion;
 
     const store = configureStore();
-    _loadVersion({ store, version });
+    _loadVersionAndFile({ store, version });
 
     const root = render({ store, versionId: String(version.id) });
 
@@ -234,7 +234,7 @@ describe(__filename, () => {
     const version = fakeVersion;
 
     const store = configureStore();
-    _loadVersion({ store, version });
+    _loadVersionAndFile({ store, version });
 
     // The user clicks a different file to view.
     store.dispatch(
@@ -337,7 +337,7 @@ describe(__filename, () => {
     const path = 'some-path';
 
     const store = configureStore();
-    _loadVersion({ store, version });
+    _loadVersionAndFile({ store, version });
 
     const dispatch = spyOn(store, 'dispatch');
     const fakeThunk = createFakeThunk();

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -1003,21 +1003,6 @@ describe(__filename, () => {
       expect(dispatch).toHaveBeenCalledWith(actions.beginFetchDiff());
     });
 
-    it('dispatches updateSelectedPath() if a path is supplied', async () => {
-      const headVersionId = 123;
-      const path = 'some/path.js';
-
-      const { dispatch, thunk } = _fetchDiff({ headVersionId, path });
-      await thunk();
-
-      expect(dispatch).toHaveBeenCalledWith(
-        actions.updateSelectedPath({
-          selectedPath: path,
-          versionId: headVersionId,
-        }),
-      );
-    });
-
     it('calls getDiff()', async () => {
       const version = fakeVersionWithDiff;
       const _getDiff = jest.fn().mockReturnValue(Promise.resolve(version));

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -231,10 +231,10 @@ export type VersionsState = {
   byAddonId: {
     [addonId: number]: VersionsMap;
   };
-  // `CompareInfo`: data successfully loaded
-  // `null`: an error has occured
-  // `undefined`: data not fetched yet
-  compareInfo: CompareInfo | null | undefined;
+  compareInfo:
+    | CompareInfo // data successfully loaded
+    | null // an error has occured
+    | undefined; // data not fetched yet
   versionInfo: {
     [versionId: number]: Version;
   };
@@ -540,15 +540,6 @@ export const fetchDiff = ({
     const { api: apiState } = getState();
 
     dispatch(actions.beginFetchDiff());
-
-    if (path) {
-      dispatch(
-        actions.updateSelectedPath({
-          selectedPath: path,
-          versionId: headVersionId,
-        }),
-      );
-    }
 
     const response = await _getDiff({
       addonId,

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -4,7 +4,7 @@ import log from 'loglevel';
 import { DiffInfo, DiffInfoType } from 'react-diff-view';
 
 import { ThunkActionCreator } from '../configureStore';
-import { getVersion, getVersionsList, isErrorResponse } from '../api';
+import { getDiff, getVersion, getVersionsList, isErrorResponse } from '../api';
 import { LocalizedStringMap } from '../utils';
 
 type VersionId = number;
@@ -191,14 +191,20 @@ export type VersionsMap = {
   unlisted: VersionsList;
 };
 
+export type CompareInfo = {
+  diffs: DiffInfo[];
+  mimeType: string;
+};
+
 export const actions = {
   loadVersionFile: createAction('LOAD_VERSION_FILE', (resolve) => {
     return (payload: { path: string; version: ExternalVersionWithContent }) =>
       resolve(payload);
   }),
   loadVersionInfo: createAction('LOAD_VERSION_INFO', (resolve) => {
-    return (payload: { version: ExternalVersionWithContent }) =>
-      resolve(payload);
+    return (payload: {
+      version: ExternalVersionWithContent | ExternalVersionWithDiff;
+    }) => resolve(payload);
   }),
   updateSelectedPath: createAction('UPDATE_SELECTED_PATH', (resolve) => {
     return (payload: { selectedPath: string; versionId: VersionId }) =>
@@ -208,12 +214,27 @@ export const actions = {
     return (payload: { addonId: number; versions: ExternalVersionsList }) =>
       resolve(payload);
   }),
+  beginFetchDiff: createAction('BEGIN_FETCH_DIFF'),
+  abortFetchDiff: createAction('ABORT_FETCH_DIFF'),
+  loadDiff: createAction('LOAD_DIFF', (resolve) => {
+    return (payload: {
+      addonId: number;
+      baseVersionId: number;
+      headVersionId: number;
+      version: ExternalVersionWithDiff;
+      path?: string;
+    }) => resolve(payload);
+  }),
 };
 
 export type VersionsState = {
   byAddonId: {
     [addonId: number]: VersionsMap;
   };
+  // `CompareInfo`: data successfully loaded
+  // `null`: an error has occured
+  // `undefined`: data not fetched yet
+  compareInfo: CompareInfo | null | undefined;
   versionInfo: {
     [versionId: number]: Version;
   };
@@ -226,8 +247,9 @@ export type VersionsState = {
 
 export const initialState: VersionsState = {
   byAddonId: {},
-  versionInfo: {},
+  compareInfo: undefined,
   versionFiles: {},
+  versionInfo: {},
 };
 
 export const createInternalVersionFile = (
@@ -267,7 +289,7 @@ export const createInternalVersionAddon = (
 };
 
 export const createInternalVersion = (
-  version: ExternalVersionWithContent,
+  version: ExternalVersionWithContent | ExternalVersionWithDiff,
 ): Version => {
   return {
     addon: createInternalVersionAddon(version.addon),
@@ -358,6 +380,12 @@ export const fetchVersion = ({
       _log.error(`TODO: handle this error response: ${response.error}`);
     } else {
       dispatch(actions.loadVersionInfo({ version: response }));
+      dispatch(
+        actions.loadVersionFile({
+          version: response,
+          path: response.file.selected_file,
+        }),
+      );
     }
   };
 };
@@ -491,9 +519,67 @@ export const createInternalDiffs = ({
   );
 };
 
+type FetchDiffParams = {
+  _getDiff?: typeof getDiff;
+  _log?: typeof log;
+  addonId: number;
+  baseVersionId: number;
+  headVersionId: number;
+  path?: string;
+};
+
+export const fetchDiff = ({
+  _getDiff = getDiff,
+  _log = log,
+  addonId,
+  baseVersionId,
+  headVersionId,
+  path,
+}: FetchDiffParams): ThunkActionCreator => {
+  return async (dispatch, getState) => {
+    const { api: apiState } = getState();
+
+    dispatch(actions.beginFetchDiff());
+
+    if (path) {
+      dispatch(
+        actions.updateSelectedPath({
+          selectedPath: path,
+          versionId: headVersionId,
+        }),
+      );
+    }
+
+    const response = await _getDiff({
+      addonId,
+      apiState,
+      baseVersionId,
+      headVersionId,
+      path,
+    });
+
+    if (isErrorResponse(response)) {
+      _log.error(`TODO: handle this error response: ${response.error}`);
+      dispatch(actions.abortFetchDiff());
+    } else {
+      dispatch(actions.loadVersionInfo({ version: response }));
+      dispatch(
+        actions.loadDiff({
+          addonId,
+          baseVersionId,
+          headVersionId,
+          path,
+          version: response,
+        }),
+      );
+    }
+  };
+};
+
 const reducer: Reducer<VersionsState, ActionType<typeof actions>> = (
   state = initialState,
   action,
+  { _log = log } = {},
 ): VersionsState => {
   switch (action.type) {
     case getType(actions.loadVersionInfo): {
@@ -504,14 +590,6 @@ const reducer: Reducer<VersionsState, ActionType<typeof actions>> = (
         versionInfo: {
           ...state.versionInfo,
           [version.id]: createInternalVersion(version),
-        },
-        versionFiles: {
-          [version.id]: {
-            ...state.versionFiles[version.id],
-            [version.file.selected_file]: createInternalVersionFile(
-              version.file,
-            ),
-          },
         },
       };
     }
@@ -551,6 +629,41 @@ const reducer: Reducer<VersionsState, ActionType<typeof actions>> = (
         byAddonId: {
           ...state.byAddonId,
           [addonId]: createVersionsMap(versions),
+        },
+      };
+    }
+    case getType(actions.beginFetchDiff): {
+      return {
+        ...state,
+        compareInfo: undefined,
+      };
+    }
+    case getType(actions.abortFetchDiff): {
+      return {
+        ...state,
+        compareInfo: null,
+      };
+    }
+    case getType(actions.loadDiff): {
+      const { baseVersionId, headVersionId, version } = action.payload;
+
+      const { entries, selectedPath } = getVersionInfo(state, headVersionId);
+      const entry = entries.find((e) => e.path === selectedPath);
+
+      if (!entry) {
+        _log.debug(`Entry missing for headVersionId: ${headVersionId}`);
+        return state;
+      }
+
+      return {
+        ...state,
+        compareInfo: {
+          diffs: createInternalDiffs({
+            baseVersionId,
+            headVersionId,
+            version,
+          }),
+          mimeType: entry.mimeType,
         },
       };
     }

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -16,6 +16,7 @@ import {
   ExternalVersionEntry,
   ExternalVersionFileWithContent,
   ExternalVersionWithContent,
+  ExternalVersionWithDiff,
   ExternalVersionsList,
   ExternalVersionsListItem,
   VersionEntryType,
@@ -225,6 +226,14 @@ export const fakeExternalDiff = Object.freeze({
 });
 
 /* eslint-enable @typescript-eslint/camelcase */
+
+export const fakeVersionWithDiff: ExternalVersionWithDiff = {
+  ...fakeVersion,
+  file: {
+    ...fakeVersion.file,
+    diff: [fakeExternalDiff],
+  },
+};
 
 export const fakeVersionsListItem: ExternalVersionsListItem = {
   id: 1541798,

--- a/stories/FileMetadata.stories.tsx
+++ b/stories/FileMetadata.stories.tsx
@@ -14,6 +14,12 @@ storiesOf('FileMetadata', module).add('default', () => {
   const version = fakeVersion;
   const store = configureStore();
   store.dispatch(versionActions.loadVersionInfo({ version }));
+  store.dispatch(
+    versionActions.loadVersionFile({
+      path: version.file.selected_file,
+      version,
+    }),
+  );
 
   const versionFile = getVersionFile(
     store.getState().versions,


### PR DESCRIPTION
Fixes #360
~~⚠️ depends on #361 and #375~~

---

This PR adds the logic to fetch and store a compare data (`diffs` and `mimeType`, which are both required in `DiffView`). ~~Only the last commit is relevant here.~~

I tried to bring the begin/abort actions we want to use in the near future. I have a patch for the UI in #385, which uses this patch and updates the UI for 3 cases: when an error has occurred, when fetching/loading data and when everything went well.

There is a change that impact the rest of the app: `loadVersionInfo()` does not load a "version file" implicitly. `loadVersionFile` must be called. This is needed to be able to reuse `loadVersionInfo` with a version with content (for the browse page) *or* with diff (for the compare page).

I store data for at most one file (similar to the linter results) because it was much easier to deal with. My very first patch had support for multiple files but it's hard and because we have a default file coming from the API, it was tricky to handle this case as well as the case where a user selected a file. I believe once we put the current file in the URL (query string param?), things would be slightly better.