### PR TITLE
Pass DiffInfo[] to DiffView

### DIFF
--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -7,7 +7,6 @@ import {
   Hunk,
   HunkInfo,
   getChangeKey,
-  parseDiff,
   tokenize,
 } from 'react-diff-view';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
@@ -18,7 +17,7 @@ import styles from './styles.module.scss';
 import 'react-diff-view/style/index.css';
 
 export type PublicProps = {
-  diff: string;
+  diffs: DiffInfo[];
   mimeType: string;
 };
 
@@ -101,9 +100,8 @@ export class DiffViewBase extends React.Component<Props> {
   };
 
   render() {
-    const { _tokenize, diff, mimeType, viewType, location } = this.props;
+    const { _tokenize, diffs, mimeType, viewType, location } = this.props;
 
-    const files = parseDiff(diff);
     const options = {
       highlight: true,
       language: getLanguageFromMimeType(mimeType),
@@ -116,12 +114,12 @@ export class DiffViewBase extends React.Component<Props> {
 
     return (
       <div className={styles.DiffView}>
-        {files.map((file) => {
-          const { oldRevision, newRevision, hunks, type } = file;
+        {diffs.map((diff) => {
+          const { oldRevision, newRevision, hunks, type } = diff;
 
           return (
             <React.Fragment key={`${oldRevision}-${newRevision}`}>
-              {this.renderHeader(file)}
+              {this.renderHeader(diff)}
 
               <Diff
                 className={styles.diff}

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Col, Row } from 'react-bootstrap';
 import { RouteComponentProps } from 'react-router-dom';
 import { connect } from 'react-redux';
+import { parseDiff } from 'react-diff-view';
 
 import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
 import FileTree from '../../components/FileTree';
@@ -107,7 +108,10 @@ export class CompareBase extends React.Component<Props> {
           </Row>
           <Row>
             <Col>
-              <DiffView diff={diffWithDeletions} mimeType="text/javascript" />
+              <DiffView
+                diffs={parseDiff(diffWithDeletions)}
+                mimeType="text/javascript"
+              />
             </Col>
           </Row>
         </Col>

--- a/stories/DiffView.stories.tsx
+++ b/stories/DiffView.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { parseDiff } from 'react-diff-view';
 
 import DiffView from '../src/components/DiffView';
 import diffWithDeletions from '../src/components/DiffView/fixtures/diffWithDeletions';
@@ -7,6 +8,9 @@ import { renderWithStoreAndRouter } from './utils';
 
 storiesOf('DiffView', module).add('default', () =>
   renderWithStoreAndRouter(
-    <DiffView diff={diffWithDeletions} mimeType="application/javascript" />,
+    <DiffView
+      diffs={parseDiff(diffWithDeletions)}
+      mimeType="application/javascript"
+    />,
   ),
 );


### PR DESCRIPTION
Supports #111 

---

This patch has been extracted from #374 to reduce the size of the patch. The `DiffView` component should take a list of `DiffInfo` instead of a raw git diff. That's what this PR does. Everything else remains the same.