### PR TITLE
Show global linter messages in file viewer

### DIFF
--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -191,7 +191,6 @@ describe(__filename, () => {
 
     const store = configureStore();
     store.dispatch(versionActions.loadVersionInfo({ version }));
-    spyOn(store, 'dispatch');
 
     const root = render({ store, versionId: String(version.id) });
 

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -14,6 +14,7 @@ import {
 import configureStore from '../../configureStore';
 import {
   ExternalLinterMessage,
+  ExternalLinterResult,
   actions as linterActions,
   createInternalMessage,
 } from '../../reducers/linter';
@@ -121,18 +122,20 @@ describe(__filename, () => {
   };
 
   const renderWithMessages = ({
+    externalMessages = [],
     file,
-    externalMessages,
+    result,
     versionId,
   }: {
+    externalMessages?: ExternalLinterMessage[];
     file: string;
-    externalMessages: ExternalLinterMessage[];
+    result?: ExternalLinterResult;
     versionId?: string;
   }) => {
     const store = configureStore();
 
     // Prepare a result with all messages for the selected file.
-    const externalResult = {
+    const externalResult = result || {
       ...fakeExternalLinterResult,
       validation: {
         ...fakeExternalLinterResult.validation,
@@ -388,6 +391,28 @@ describe(__filename, () => {
       externalMessages: [globalExternalMessage({ file })],
       // Render an unrelated version.
       versionId: '432132',
+    });
+
+    const message = root.find(LinterMessage);
+    expect(message).toHaveLength(0);
+  });
+
+  it('ignores global messages for the wrong file', () => {
+    const result = {
+      ...fakeExternalLinterResult,
+      validation: {
+        ...fakeExternalLinterResult.validation,
+        messages: [
+          // Define a message for an unrelated file.
+          globalExternalMessage({ file: 'scripts/background.js' }),
+        ],
+      },
+    };
+
+    const root = renderWithMessages({
+      // Render this as the selected file.
+      file: 'lib/react.js',
+      result,
     });
 
     const message = root.find(LinterMessage);

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -76,16 +76,8 @@ describe(__filename, () => {
     _log,
     addonId = '999',
     versionId = '123',
-    store,
+    store = configureStore(),
   }: RenderParams = {}) => {
-    let safeStore = store;
-    if (!safeStore) {
-      safeStore = configureStore();
-      // TODO: Don't execute thunks by default.
-      // See https://github.com/mozilla/addons-code-manager/issues/368
-      spyOn(safeStore, 'dispatch');
-    }
-
     const props = {
       ...createFakeRouteComponentProps({ params: { addonId, versionId } }),
       _fetchLinterMessages,
@@ -96,7 +88,7 @@ describe(__filename, () => {
 
     return shallowUntilTarget(<Browse {...props} />, BrowseBase, {
       shallowOptions: {
-        context: { store: safeStore },
+        context: { store },
       },
     });
   };
@@ -212,7 +204,6 @@ describe(__filename, () => {
 
     const store = configureStore();
     store.dispatch(versionActions.loadVersionInfo({ version }));
-    spyOn(store, 'dispatch');
 
     const root = render({ store, versionId: String(version.id) });
 
@@ -232,7 +223,6 @@ describe(__filename, () => {
         versionId: version.id,
       }),
     );
-    spyOn(store, 'dispatch');
 
     const root = render({ store, versionId: String(version.id) });
 

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -346,10 +346,7 @@ describe(__filename, () => {
 
   it('renders a global LinterMessage', () => {
     const file = 'lib/react.js';
-    const externalMessage = globalExternalMessage({
-      file,
-      message: 'This is a known third party library',
-    });
+    const externalMessage = globalExternalMessage({ file });
 
     const root = renderWithMessages({
       file,

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -40,7 +40,7 @@ type PropsFromRouter = {
 type PropsFromState = {
   apiState: ApiState;
   file: VersionFile | null | void;
-  linterMessages: undefined | null | LinterMessageMap;
+  linterMessages: LinterMessageMap | null | void;
   linterMessagesAreLoading: boolean;
   version: Version;
 };


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/376

<img width="1038" alt="Screenshot 2019-03-11 11 02 21" src="https://user-images.githubusercontent.com/55398/54144384-98bdbd00-43f9-11e9-8861-3135ca8f8c36.png">
<img width="1038" alt="Screenshot 2019-03-11 11 01 30" src="https://user-images.githubusercontent.com/55398/54144388-9a878080-43f9-11e9-89d7-c1f81042223b.png">
