### PR TITLE
Support empty list of diffs in `DiffView`

### DIFF
--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -38,6 +38,14 @@ describe(__filename, () => {
     );
   };
 
+  it('renders with no differences', () => {
+    const root = render({ diffs: [] });
+
+    expect(root.find(Diff)).toHaveLength(0);
+    expect(root.find(`.${styles.header}`)).toHaveLength(1);
+    expect(root.find(`.${styles.noDiffs}`)).toIncludeText('no differences');
+  });
+
   it('defaults the viewType to unified', () => {
     const root = render();
 

--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -43,7 +43,7 @@ describe(__filename, () => {
 
     expect(root.find(Diff)).toHaveLength(0);
     expect(root.find(`.${styles.header}`)).toHaveLength(1);
-    expect(root.find(`.${styles.noDiffs}`)).toIncludeText('no differences');
+    expect(root.find(`.${styles.noDiffs}`)).toIncludeText('No differences');
   });
 
   it('defaults the viewType to unified', () => {

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -10,9 +10,10 @@ import {
   tokenize,
 } from 'react-diff-view';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
+import makeClassName from 'classnames';
 
 import refractor from '../../refractor';
-import { getLanguageFromMimeType } from '../../utils';
+import { getLanguageFromMimeType, gettext } from '../../utils';
 import styles from './styles.module.scss';
 import 'react-diff-view/style/index.css';
 
@@ -114,6 +115,15 @@ export class DiffViewBase extends React.Component<Props> {
 
     return (
       <div className={styles.DiffView}>
+        {diffs.length === 0 && (
+          <React.Fragment>
+            <div className={styles.header} />
+            <div className={makeClassName(styles.diff, styles.noDiffs)}>
+              {gettext('no differences')}
+            </div>
+          </React.Fragment>
+        )}
+
         {diffs.map((diff) => {
           const { oldRevision, newRevision, hunks, type } = diff;
 

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -119,7 +119,7 @@ export class DiffViewBase extends React.Component<Props> {
           <React.Fragment>
             <div className={styles.header} />
             <div className={makeClassName(styles.diff, styles.noDiffs)}>
-              {gettext('no differences')}
+              {gettext('No differences')}
             </div>
           </React.Fragment>
         )}

--- a/src/components/DiffView/styles.module.scss
+++ b/src/components/DiffView/styles.module.scss
@@ -42,6 +42,11 @@
   text-align: center;
 }
 
+.noDiffs {
+  padding: $default-padding;
+  text-align: center;
+}
+
 :global {
   .diff-code,
   .diff-gutter {

--- a/stories/DiffView.stories.tsx
+++ b/stories/DiffView.stories.tsx
@@ -6,11 +6,30 @@ import DiffView from '../src/components/DiffView';
 import diffWithDeletions from '../src/components/DiffView/fixtures/diffWithDeletions';
 import { renderWithStoreAndRouter } from './utils';
 
-storiesOf('DiffView', module).add('default', () =>
-  renderWithStoreAndRouter(
-    <DiffView
-      diffs={parseDiff(diffWithDeletions)}
-      mimeType="application/javascript"
-    />,
-  ),
-);
+storiesOf('DiffView', module).addWithChapters('all variants', {
+  chapters: [
+    {
+      sections: [
+        {
+          title: 'diff with additions and deletions',
+          sectionFn: () => {
+            return renderWithStoreAndRouter(
+              <DiffView
+                diffs={parseDiff(diffWithDeletions)}
+                mimeType="application/javascript"
+              />,
+            );
+          },
+        },
+        {
+          title: 'no differences',
+          sectionFn: () => {
+            return renderWithStoreAndRouter(
+              <DiffView diffs={[]} mimeType="application/javascript" />,
+            );
+          },
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Supports #111 
~~⚠️ depends on #375~~

---

The API returns an empty list of differences sometimes. We should support this case in `DiffView`. This patch has been extracted from #374. There is an empty header for now so that it is similar to when there are differences. In the future, we might want to add the filename (path) to this header, in both cases.

## Screenshot

![Screen Shot 2019-03-12 at 11 17 44](https://user-images.githubusercontent.com/217628/54192601-aa19ce80-44b8-11e9-927c-02017a5c07b2.png)

In context:

![Screen Shot 2019-03-12 at 11 27 43](https://user-images.githubusercontent.com/217628/54193207-e4d03680-44b9-11e9-9c88-37e726ee1aa4.png)

