### PR TITLE
Render diffs in Compare page

### DIFF
--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -5,30 +5,49 @@ import { History } from 'history';
 import {
   createFakeHistory,
   createFakeThunk,
-  fakeVersion,
+  fakeVersionWithDiff,
   shallowUntilTarget,
   spyOn,
 } from '../../test-helpers';
 import configureStore from '../../configureStore';
 import {
-  actions as versionActions,
+  actions as versionsActions,
+  createInternalDiffs,
   createInternalVersion,
 } from '../../reducers/versions';
 import FileTree from '../../components/FileTree';
 import DiffView from '../../components/DiffView';
 import Loading from '../../components/Loading';
+import VersionChooser from '../../components/VersionChooser';
+import styles from './styles.module.scss';
 
 import Compare, { CompareBase, PublicProps } from '.';
 
 describe(__filename, () => {
+  type GetRouteParamsParams = {
+    addonId?: number;
+    baseVersionId?: number;
+    headVersionId?: number;
+    lang?: string;
+  };
+
+  const getRouteParams = ({
+    addonId = 9999,
+    baseVersionId = 1,
+    headVersionId = 1000,
+    lang = 'fr',
+  }: GetRouteParamsParams = {}) => {
+    return {
+      addonId: String(addonId),
+      baseVersionId: String(baseVersionId),
+      headVersionId: String(headVersionId),
+      lang,
+    };
+  };
+
   const createFakeRouteComponentProps = ({
     history = createFakeHistory(),
-    params = {
-      addonId: '999',
-      baseVersionId: '1',
-      headVersionId: '2',
-      lang: 'fr',
-    },
+    params = getRouteParams(),
   } = {}) => {
     return {
       history,
@@ -43,7 +62,7 @@ describe(__filename, () => {
   };
 
   type RenderParams = {
-    _fetchVersion?: PublicProps['_fetchVersion'];
+    _fetchDiff?: PublicProps['_fetchDiff'];
     addonId?: string;
     baseVersionId?: string;
     headVersionId?: string;
@@ -53,7 +72,7 @@ describe(__filename, () => {
   };
 
   const render = ({
-    _fetchVersion,
+    _fetchDiff,
     addonId = '999',
     baseVersionId = '1',
     headVersionId = '2',
@@ -66,7 +85,7 @@ describe(__filename, () => {
         history,
         params: { lang, addonId, baseVersionId, headVersionId },
       }),
-      _fetchVersion,
+      _fetchDiff,
     };
 
     return shallowUntilTarget(<Compare {...props} />, CompareBase, {
@@ -76,266 +95,326 @@ describe(__filename, () => {
     });
   };
 
-  type GetRouteParamsParams = {
-    addonId?: number;
-    baseVersionId?: number;
-    headVersionId?: number;
+  const _loadDiff = ({
+    addonId = 1,
+    baseVersionId = 2,
+    headVersionId = 3,
+    store = configureStore(),
+    version = fakeVersionWithDiff,
+  }) => {
+    store.dispatch(versionsActions.loadVersionInfo({ version }));
+    store.dispatch(
+      versionsActions.loadDiff({
+        addonId,
+        baseVersionId,
+        headVersionId,
+        version,
+      }),
+    );
   };
 
-  const getRouteParams = ({
-    addonId = 9999,
-    baseVersionId = 1,
-    headVersionId = 1000,
-  }: GetRouteParamsParams) => {
-    return {
-      addonId: String(addonId),
-      baseVersionId: String(baseVersionId),
-      headVersionId: String(headVersionId),
-    };
-  };
+  it('renders loading messages when no diff has been loaded', () => {
+    const addonId = 123;
+    const root = render({ addonId: String(addonId) });
 
-  it('renders a page with a loading message', () => {
-    const root = render();
-
-    expect(root.find(Loading)).toHaveLength(1);
-    expect(root.find(Loading)).toHaveProp('message', 'Loading version...');
+    expect(root.find(Loading)).toHaveLength(2);
+    expect(root.find(Loading).at(0)).toHaveProp(
+      'message',
+      'Loading file tree...',
+    );
+    expect(root.find(Loading).at(1)).toHaveProp('message', 'Loading diff...');
+    // This component is always displayed.
+    expect(root.find(VersionChooser)).toHaveLength(1);
+    expect(root.find(VersionChooser)).toHaveProp('addonId', addonId);
   });
 
-  it('renders a FileTree component when a version has been loaded', () => {
-    const baseVersion = fakeVersion;
-    const headVersion = { ...fakeVersion, id: baseVersion.id + 1 };
+  it('renders a FileTree component when a diff has been loaded', () => {
+    const addonId = 9999;
+    const baseVersionId = 1;
+    const version = { ...fakeVersionWithDiff, id: baseVersionId + 1 };
 
     const store = configureStore();
-    store.dispatch(versionActions.loadVersionInfo({ version: baseVersion }));
-    store.dispatch(versionActions.loadVersionInfo({ version: headVersion }));
+    _loadDiff({
+      addonId,
+      baseVersionId,
+      headVersionId: version.id,
+      store,
+      version,
+    });
 
     const root = render({
       store,
-      baseVersionId: String(baseVersion.id),
-      headVersionId: String(headVersion.id),
+      baseVersionId: String(baseVersionId),
+      headVersionId: String(version.id),
     });
 
     expect(root.find(FileTree)).toHaveLength(1);
     expect(root.find(FileTree)).toHaveProp(
       'version',
-      createInternalVersion(baseVersion),
+      createInternalVersion(version),
     );
   });
 
   it('renders a DiffView', () => {
-    const baseVersion = fakeVersion;
-    const headVersion = { ...fakeVersion, id: baseVersion.id + 1 };
+    const addonId = 999;
+    const baseVersionId = 1;
+    const path = 'manifest.json';
+    const mimeType = 'mime/type';
+
+    const version = {
+      ...fakeVersionWithDiff,
+      id: baseVersionId + 1,
+      file: {
+        ...fakeVersionWithDiff.file,
+        entries: {
+          ...fakeVersionWithDiff.file.entries,
+          [path]: {
+            ...fakeVersionWithDiff.file.entries[path],
+            mimetype: mimeType,
+          },
+        },
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        selected_file: path,
+      },
+    };
 
     const store = configureStore();
-    store.dispatch(versionActions.loadVersionInfo({ version: baseVersion }));
-    store.dispatch(versionActions.loadVersionInfo({ version: headVersion }));
+    _loadDiff({
+      addonId,
+      baseVersionId,
+      headVersionId: version.id,
+      store,
+      version,
+    });
 
     const root = render({
       store,
-      baseVersionId: String(baseVersion.id),
-      headVersionId: String(headVersion.id),
+      baseVersionId: String(baseVersionId),
+      headVersionId: String(version.id),
     });
 
     expect(root.find(DiffView)).toHaveLength(1);
+    expect(root.find(DiffView)).toHaveProp(
+      'diffs',
+      createInternalDiffs({
+        baseVersionId,
+        headVersionId: version.id,
+        version,
+      }),
+    );
+    expect(root.find(DiffView)).toHaveProp('mimeType', mimeType);
   });
 
-  it('dispatches fetchVersion() on mount', () => {
-    const addonId = 123456;
-    const baseVersion = fakeVersion;
+  it('renders an error when fetching a diff has failed', () => {
+    const store = configureStore();
+    store.dispatch(versionsActions.abortFetchDiff());
+
+    const root = render({ store });
+
+    expect(root.find(`.${styles.error}`)).toHaveLength(2);
+  });
+
+  it('dispatches fetchDiff() on mount', () => {
+    const addonId = 9999;
+    const baseVersionId = 1;
+    const headVersionId = baseVersionId + 1;
 
     const store = configureStore();
     const dispatch = spyOn(store, 'dispatch');
     const fakeThunk = createFakeThunk();
-    const _fetchVersion = fakeThunk.createThunk;
+    const _fetchDiff = fakeThunk.createThunk;
 
     render({
-      _fetchVersion,
+      ...getRouteParams({ addonId, baseVersionId, headVersionId }),
+      _fetchDiff,
       store,
-      ...getRouteParams({
-        addonId,
-        baseVersionId: baseVersion.id,
-      }),
     });
 
     expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(_fetchVersion).toHaveBeenCalledWith({
+    expect(_fetchDiff).toHaveBeenCalledWith({
       addonId,
-      versionId: baseVersion.id,
+      baseVersionId,
+      headVersionId,
     });
   });
 
   it('redirects to a new compare url when the "old" version is newer than the "new" version', () => {
     const addonId = 123456;
-    const baseVersion = fakeVersion;
-    const headVersion = { ...fakeVersion, id: baseVersion.id - 1 };
+    const baseVersionId = 2;
+    const headVersionId = baseVersionId - 1;
     const lang = 'es';
 
     const store = configureStore();
     const dispatch = spyOn(store, 'dispatch');
     const fakeThunk = createFakeThunk();
-    const _fetchVersion = fakeThunk.createThunk;
+    const _fetchDiff = fakeThunk.createThunk;
     const history = createFakeHistory();
     const push = spyOn(history, 'push');
 
     render({
-      _fetchVersion,
-      store,
-      ...getRouteParams({
-        addonId,
-        baseVersionId: baseVersion.id,
-        headVersionId: headVersion.id,
-      }),
+      ...getRouteParams({ addonId, baseVersionId, headVersionId }),
+      _fetchDiff,
       history,
       lang,
+      store,
     });
 
     expect(push).toHaveBeenCalledWith(
-      `/${lang}/compare/${addonId}/versions/${headVersion.id}...${
-        baseVersion.id
-      }/`,
+      `/${lang}/compare/${addonId}/versions/${headVersionId}...${baseVersionId}/`,
     );
     expect(dispatch).not.toHaveBeenCalled();
   });
 
-  it('does not dispatch fetchVersion() on update if no parameter has changed', () => {
+  it('does not dispatch fetchDiff() on update if no parameter has changed', () => {
     const addonId = 123456;
-    const baseVersion = fakeVersion;
-    const headVersion = { ...fakeVersion, id: baseVersion.id + 1 };
+    const baseVersionId = 1;
+    const headVersionId = baseVersionId + 1;
+    const params = getRouteParams({ addonId, baseVersionId, headVersionId });
 
     const store = configureStore();
     const fakeThunk = createFakeThunk();
     const dispatch = spyOn(store, 'dispatch');
 
     const root = render({
-      _fetchVersion: fakeThunk.createThunk,
-      addonId: String(addonId),
-      baseVersionId: String(baseVersion.id),
-      headVersionId: String(headVersion.id),
+      ...params,
+      _fetchDiff: fakeThunk.createThunk,
       store,
     });
 
     dispatch.mockClear();
-    root.setProps({
-      match: {
-        params: {
-          addonId: String(addonId),
-          baseVersionId: String(baseVersion.id),
-          headVersionId: String(headVersion.id),
-        },
-      },
-    });
+    root.setProps({ match: { params } });
 
     expect(dispatch).not.toHaveBeenCalled();
   });
 
-  it('dispatches fetchVersion() on update if base version is different', () => {
+  it('dispatches fetchDiff() on update if base version is different', () => {
     const addonId = 123456;
-    const baseVersion = fakeVersion;
+    const baseVersionId = 10;
+    const headVersionId = baseVersionId + 1;
 
     const store = configureStore();
     const fakeThunk = createFakeThunk();
-    const _fetchVersion = fakeThunk.createThunk;
+    const _fetchDiff = fakeThunk.createThunk;
     const dispatch = spyOn(store, 'dispatch');
 
     const root = render({
-      _fetchVersion,
       ...getRouteParams({
         addonId,
-        baseVersionId: baseVersion.id - 10,
+        baseVersionId: baseVersionId - 1,
+        headVersionId,
       }),
+      _fetchDiff,
       store,
     });
 
     dispatch.mockClear();
-    _fetchVersion.mockClear();
+    _fetchDiff.mockClear();
     root.setProps({
       match: {
-        params: getRouteParams({
-          addonId,
-          baseVersionId: baseVersion.id,
-        }),
+        params: getRouteParams({ addonId, baseVersionId, headVersionId }),
       },
     });
 
     expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(_fetchVersion).toHaveBeenCalledWith({
+    expect(_fetchDiff).toHaveBeenCalledWith({
       addonId,
-      versionId: baseVersion.id,
+      baseVersionId,
+      headVersionId,
     });
   });
 
-  it('dispatches fetchVersion() on update if head version is different', () => {
+  it('dispatches fetchDiff() on update if head version is different', () => {
     const addonId = 123456;
-    const baseVersion = fakeVersion;
-    const headVersion = { ...fakeVersion, id: baseVersion.id + 1 };
+    const baseVersionId = 1;
+    const headVersionId = baseVersionId + 1;
 
     const store = configureStore();
     const fakeThunk = createFakeThunk();
-    const _fetchVersion = fakeThunk.createThunk;
+    const _fetchDiff = fakeThunk.createThunk;
     const dispatch = spyOn(store, 'dispatch');
 
     const root = render({
-      _fetchVersion,
       ...getRouteParams({
         addonId,
-        baseVersionId: baseVersion.id,
-        headVersionId: headVersion.id + 10,
+        baseVersionId,
+        headVersionId: headVersionId + 1,
       }),
+      _fetchDiff,
       store,
     });
 
     dispatch.mockClear();
-    _fetchVersion.mockClear();
+    _fetchDiff.mockClear();
     root.setProps({
       match: {
-        params: getRouteParams({
-          addonId,
-          baseVersionId: baseVersion.id,
-          headVersionId: headVersion.id,
-        }),
+        params: getRouteParams({ addonId, baseVersionId, headVersionId }),
       },
     });
 
     expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(_fetchVersion).toHaveBeenCalledWith({
+    expect(_fetchDiff).toHaveBeenCalledWith({
       addonId,
-      versionId: baseVersion.id,
+      baseVersionId,
+      headVersionId,
     });
   });
 
-  it('dispatches fetchVersion() on update if addon ID is different', () => {
+  it('dispatches fetchDiff() on update if addon ID is different', () => {
     const addonId = 123456;
-    const baseVersion = fakeVersion;
+    const baseVersionId = 1;
+    const headVersionId = baseVersionId + 1;
 
     const store = configureStore();
     const fakeThunk = createFakeThunk();
-    const _fetchVersion = fakeThunk.createThunk;
+    const _fetchDiff = fakeThunk.createThunk;
     const dispatch = spyOn(store, 'dispatch');
 
     const root = render({
-      _fetchVersion,
+      _fetchDiff,
       ...getRouteParams({
         addonId: addonId + 10,
-        baseVersionId: baseVersion.id,
       }),
       store,
     });
 
     dispatch.mockClear();
-    _fetchVersion.mockClear();
+    _fetchDiff.mockClear();
     root.setProps({
       match: {
-        params: getRouteParams({
-          addonId,
-          baseVersionId: baseVersion.id,
-        }),
+        params: getRouteParams({ addonId, baseVersionId, headVersionId }),
       },
     });
 
     expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(_fetchVersion).toHaveBeenCalledWith({
+    expect(_fetchDiff).toHaveBeenCalledWith({
       addonId,
-      versionId: baseVersion.id,
+      baseVersionId,
+      headVersionId,
     });
+  });
+
+  it('dispatches updateSelectedPath() when a file is selected', () => {
+    const version = fakeVersionWithDiff;
+    const headVersionId = version.id;
+    const path = 'new-path.js';
+
+    const store = configureStore();
+    _loadDiff({ headVersionId, store, version });
+
+    const dispatch = spyOn(store, 'dispatch');
+
+    const root = render({ ...getRouteParams({ headVersionId }), store });
+
+    dispatch.mockClear();
+
+    const onSelectFile = root.find(FileTree).prop('onSelect');
+    onSelectFile(path);
+
+    expect(dispatch).toHaveBeenCalledWith(
+      versionsActions.updateSelectedPath({
+        selectedPath: path,
+        versionId: headVersionId,
+      }),
+    );
   });
 });

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -417,4 +417,27 @@ describe(__filename, () => {
       }),
     );
   });
+
+  it('does not dispatch fetchDiff() twice for the default file', () => {
+    const addonId = 123456;
+    const baseVersionId = 1;
+    const headVersionId = baseVersionId + 1;
+    const params = getRouteParams({ addonId, baseVersionId, headVersionId });
+
+    const store = configureStore();
+    const fakeThunk = createFakeThunk();
+    const dispatch = spyOn(store, 'dispatch');
+
+    const root = render({
+      ...params,
+      _fetchDiff: fakeThunk.createThunk,
+      store,
+    });
+    // Once the default file is loaded (without `path` defined), there is an
+    // update with `path` being set to the default file.
+    root.setProps({ path: fakeVersionWithDiff.file.selected_file });
+
+    expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -75,7 +75,7 @@ export class CompareBase extends React.Component<Props> {
 
     if (
       !prevProps ||
-      path !== prevProps.path ||
+      (prevProps.path && path !== prevProps.path) ||
       addonId !== prevProps.match.params.addonId ||
       baseVersionId !== prevProps.match.params.baseVersionId ||
       headVersionId !== prevProps.match.params.headVersionId

--- a/src/pages/Index/index.tsx
+++ b/src/pages/Index/index.tsx
@@ -14,7 +14,7 @@ export class IndexBase extends React.Component<PublicProps> {
             browsing this add-on version
           </Link>{' '}
           or{' '}
-          <Link to="/en-US/compare/502955/versions/1541798...1541798/">
+          <Link to="/en-US/compare/502955/versions/1541794...1541798/">
             look at this compare view.
           </Link>
         </p>


### PR DESCRIPTION
Fixes #292 
Fixes #362 
~~⚠️ depends on #374~~

---

This patch adds the logic for rendering diffs between two versions of an add-on. It handles errors and loading state.

## Gif

![2019-03-13 13 24 33](https://user-images.githubusercontent.com/217628/54278723-78c20100-4593-11e9-9c44-52a684dac3f4.gif)




