### PR TITLE
Fix test logic for the linter reducer

### DIFF
--- a/src/reducers/linter.spec.tsx
+++ b/src/reducers/linter.spec.tsx
@@ -127,7 +127,7 @@ describe(__filename, () => {
       let state;
       state = linterReducer(
         state,
-        actions.abortFetchLinterResult({ versionId }),
+        actions.abortFetchLinterResult({ versionId: versionId + 1 }),
       );
       state = linterReducer(
         state,
@@ -146,7 +146,7 @@ describe(__filename, () => {
       );
       state = linterReducer(
         state,
-        actions.beginFetchLinterResult({ versionId }),
+        actions.abortFetchLinterResult({ versionId }),
       );
 
       expect(state).toMatchObject({ forVersionId: versionId });


### PR DESCRIPTION
This is a follow-up to https://github.com/mozilla/addons-code-manager/pull/371 which fixed https://github.com/mozilla/addons-code-manager/issues/370