### PR TITLE
Show inline linter messages in code files

### DIFF
--- a/src/components/CodeView/styles.module.scss
+++ b/src/components/CodeView/styles.module.scss
@@ -53,3 +53,7 @@
 .highlightedCode {
   margin: 0;
 }
+
+.linterMessages {
+  padding-top: 16px;
+}

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -126,12 +126,12 @@ describe(__filename, () => {
 
   const renderWithMessages = ({
     externalMessages = [],
-    file,
+    path,
     result,
     versionId,
   }: {
     externalMessages?: ExternalLinterMessage[];
-    file: string;
+    path: string;
     result?: ExternalLinterResult;
     versionId?: string;
   }) => {
@@ -142,11 +142,11 @@ describe(__filename, () => {
       result ||
       createFakeExternalLinterResult({
         messages: externalMessages.map((msg) => {
-          if (msg.file !== file) {
+          if (msg.file !== path) {
             throw new Error(
               `message uid:${msg.uid} has file "${
                 msg.file
-              }" but needs to have "${file}"`,
+              }" but needs to have "${path}"`,
             );
           }
           return msg;
@@ -157,21 +157,15 @@ describe(__filename, () => {
       ...fakeVersion,
       file: {
         ...fakeVersionFile,
-        entries: {
-          [file]: {
-            ...fakeVersionEntry,
-            filename: file,
-            path: file,
-          },
-        },
+        entries: { [path]: { ...fakeVersionEntry, path } },
       },
     };
     store.dispatch(versionActions.loadVersionInfo({ version }));
-    store.dispatch(versionActions.loadVersionFile({ path: file, version }));
+    store.dispatch(versionActions.loadVersionFile({ path, version }));
     // Simulate selecting the file to render.
     store.dispatch(
       versionActions.updateSelectedPath({
-        selectedPath: file,
+        selectedPath: path,
         versionId: version.id,
       }),
     );
@@ -355,11 +349,11 @@ describe(__filename, () => {
   });
 
   it('renders a global LinterMessage', () => {
-    const file = 'lib/react.js';
-    const externalMessage = globalExternalMessage({ file });
+    const path = 'lib/react.js';
+    const externalMessage = globalExternalMessage({ file: path });
 
     const root = renderWithMessages({
-      file,
+      path,
       externalMessages: [externalMessage],
     });
 
@@ -375,12 +369,12 @@ describe(__filename, () => {
     const firstUid = 'first-uid';
     const secondUid = 'second-uid';
 
-    const file = 'lib/react.js';
+    const path = 'lib/react.js';
     const root = renderWithMessages({
-      file,
+      path,
       externalMessages: [
-        globalExternalMessage({ uid: firstUid, file }),
-        globalExternalMessage({ uid: secondUid, file }),
+        globalExternalMessage({ uid: firstUid, file: path }),
+        globalExternalMessage({ uid: secondUid, file: path }),
       ],
     });
 
@@ -391,11 +385,11 @@ describe(__filename, () => {
   });
 
   it('ignores global messages for the wrong version', () => {
-    const file = 'lib/react.js';
+    const path = 'lib/react.js';
 
     const root = renderWithMessages({
-      file,
-      externalMessages: [globalExternalMessage({ file })],
+      path,
+      externalMessages: [globalExternalMessage({ file: path })],
       // Render an unrelated version.
       versionId: '432132',
     });
@@ -413,8 +407,8 @@ describe(__filename, () => {
     });
 
     const root = renderWithMessages({
-      // Render this as the selected file.
-      file: 'lib/react.js',
+      // Render this as the selected file path.
+      path: 'lib/react.js',
       result,
     });
 
@@ -423,10 +417,10 @@ describe(__filename, () => {
   });
 
   it('passes LinterMessagesByLine to CodeView', () => {
-    const file = 'lib/react.js';
+    const path = 'lib/react.js';
     const externalMessage = {
       ...fakeExternalLinterMessage,
-      file,
+      file: path,
       line: 1,
     };
 
@@ -434,13 +428,13 @@ describe(__filename, () => {
       messages: [externalMessage],
     });
 
-    const root = renderWithMessages({ file, result });
+    const root = renderWithMessages({ path, result });
 
     const code = root.find(CodeView);
     expect(code).toHaveLength(1);
     expect(code).toHaveProp(
       'linterMessagesByLine',
-      getMessageMap(result)[file].byLine,
+      getMessageMap(result)[path].byLine,
     );
   });
 
@@ -457,8 +451,8 @@ describe(__filename, () => {
     });
 
     const root = renderWithMessages({
-      // Render this as the selected file.
-      file: 'lib/react.js',
+      // Render this as the selected file path.
+      path: 'lib/react.js',
       result,
     });
 

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -7,9 +7,9 @@ import log from 'loglevel';
 import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
 import { ApiState } from '../../reducers/api';
 import {
+  LinterMessageMap,
   fetchLinterMessages,
   selectMessageMap,
-  LinterMessageMap,
 } from '../../reducers/linter';
 import FileTree from '../../components/FileTree';
 import LinterMessage from '../../components/LinterMessage';
@@ -113,11 +113,14 @@ export class BrowseBase extends React.Component<Props> {
       );
     }
 
-    let globalMessages;
+    let messageMap;
     if (linterMessages && version) {
-      globalMessages =
-        linterMessages[version.selectedPath] &&
-        linterMessages[version.selectedPath].global;
+      messageMap = linterMessages[version.selectedPath];
+    }
+
+    let globalMessages;
+    if (messageMap) {
+      globalMessages = messageMap.global;
     }
 
     return (
@@ -131,7 +134,11 @@ export class BrowseBase extends React.Component<Props> {
               return <LinterMessage key={message.uid} message={message} />;
             })}
           {file ? (
-            <CodeView mimeType={file.mimeType} content={file.content} />
+            <CodeView
+              linterMessagesByLine={messageMap && messageMap.byLine}
+              mimeType={file.mimeType}
+              content={file.content}
+            />
           ) : (
             <Loading message={gettext('Loading content...')} />
           )}

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -118,19 +118,14 @@ export class BrowseBase extends React.Component<Props> {
       messageMap = linterMessages[version.selectedPath];
     }
 
-    let globalMessages;
-    if (messageMap) {
-      globalMessages = messageMap.global;
-    }
-
     return (
       <React.Fragment>
         <Col md="3">
           <FileTree version={version} onSelect={this.onSelectFile} />
         </Col>
         <Col md="9">
-          {globalMessages &&
-            globalMessages.map((message) => {
+          {messageMap &&
+            messageMap.global.map((message) => {
               return <LinterMessage key={message.uid} message={message} />;
             })}
           {file ? (

--- a/src/reducers/linter.spec.tsx
+++ b/src/reducers/linter.spec.tsx
@@ -2,6 +2,7 @@
 import log from 'loglevel';
 
 import {
+  createFakeExternalLinterResult,
   fakeExternalLinterResult,
   fakeExternalLinterMessage,
   getFakeLogger,
@@ -22,15 +23,7 @@ describe(__filename, () => {
   const createExternalLinterResult = (
     messages: Partial<ExternalLinterMessage>[] = [fakeExternalLinterMessage],
   ) => {
-    return {
-      ...fakeExternalLinterResult,
-      validation: {
-        ...fakeExternalLinterResult.validation,
-        messages: messages.map((msg) => {
-          return { ...fakeExternalLinterMessage, ...msg };
-        }),
-      },
-    };
+    return createFakeExternalLinterResult({ messages });
   };
 
   const _getMessageMap = (

--- a/src/reducers/linter.tsx
+++ b/src/reducers/linter.tsx
@@ -60,11 +60,15 @@ export const createInternalMessage = (
   };
 };
 
+export type LinterMessagesByLine = {
+  [line: number]: LinterMessage[];
+};
+
 export type LinterMessageMap = {
   // The 'path' key matches the key of ExternalVersionFile['entries']
   [path: string]: {
     global: LinterMessage[];
-    byLine: { [line: number]: LinterMessage[] };
+    byLine: LinterMessagesByLine;
   };
 };
 

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -24,10 +24,13 @@ import {
 
 export const fakeVersionEntry: ExternalVersionEntry = Object.freeze({
   depth: 0,
+  // This is always the base filename, no subdirectories.
   filename: 'manifest.json',
   mime_category: 'text' as VersionEntryType,
   mimetype: 'application/json',
   modified: '2017-08-15T12:01:13Z',
+  // This is the complete relative path. For example, it might include
+  // subdirectories like scripts/background.js
   path: 'manifest.json',
   sha256: 'some-sha',
   size: 123,

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -175,6 +175,22 @@ export const fakeVersionsList: ExternalVersionsList = [
   },
 ];
 
+export const createFakeExternalLinterResult = ({
+  messages,
+}: {
+  messages: Partial<ExternalLinterMessage>[];
+}) => {
+  return {
+    ...fakeExternalLinterResult,
+    validation: {
+      ...fakeExternalLinterResult.validation,
+      messages: messages.map((msg) => {
+        return { ...fakeExternalLinterMessage, ...msg };
+      }),
+    },
+  };
+};
+
 export const createFakeLocation = (props = {}): Location<{}> => {
   return {
     hash: '',

--- a/stories/CodeView.stories.tsx
+++ b/stories/CodeView.stories.tsx
@@ -1,8 +1,12 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 
-import CodeView from '../src/components/CodeView';
+import CodeView, {
+  PublicProps as CodeViewProps,
+} from '../src/components/CodeView';
+import { LinterMessage, getMessageMap } from '../src/reducers/linter';
 import { renderWithStoreAndRouter } from './utils';
+import { createFakeExternalLinterResult } from '../src/test-helpers';
 
 const JS = `/**
  * There was an error executing the script.
@@ -34,30 +38,129 @@ const CSS = `html, body {
   display: none;
 }`;
 
-storiesOf('CodeView', module).addWithChapters('all variants', {
-  chapters: [
-    {
-      sections: [
-        {
-          title: 'unsupported mime type',
-          sectionFn: () =>
-            renderWithStoreAndRouter(<CodeView mimeType="" content={JS} />),
-        },
-        {
-          title: 'application/javascript',
-          sectionFn: () =>
-            renderWithStoreAndRouter(
-              <CodeView mimeType="application/javascript" content={JS} />,
-            ),
-        },
-        {
-          title: 'text/css',
-          sectionFn: () =>
-            renderWithStoreAndRouter(
-              <CodeView mimeType="text/css" content={CSS} />,
-            ),
-        },
-      ],
-    },
-  ],
-});
+const render = (moreProps = {}) => {
+  const props = {
+    content: JS,
+    linterMessagesByLine: undefined,
+    mimeType: 'application/javascript',
+    ...moreProps,
+  };
+  return renderWithStoreAndRouter(<CodeView {...props} />);
+};
+
+const renderJSWithMessages = (
+  messages: Partial<LinterMessage>[],
+  moreProps: Partial<CodeViewProps> = {},
+) => {
+  const stubFile = 'lib/some-file.js';
+  const map = getMessageMap(
+    createFakeExternalLinterResult({
+      messages: messages.map((msg) => {
+        return {
+          ...msg,
+          file: stubFile,
+        };
+      }),
+    }),
+  );
+
+  return render({
+    content: JS,
+    mimeType: 'application/javascript',
+    linterMessagesByLine: map[stubFile].byLine,
+    ...moreProps,
+  });
+};
+
+storiesOf('CodeView', module)
+  .addWithChapters('mime types', {
+    chapters: [
+      {
+        sections: [
+          {
+            title: 'unsupported mime type',
+            sectionFn: () => render({ mimeType: '', content: JS }),
+          },
+          {
+            title: 'application/javascript',
+            sectionFn: () =>
+              render({ mimeType: 'application/javascript', content: JS }),
+          },
+          {
+            title: 'text/css',
+            sectionFn: () => render({ mimeType: 'text/css', content: CSS }),
+          },
+        ],
+      },
+    ],
+  })
+  .addWithChapters('linter messages', {
+    chapters: [
+      {
+        sections: [
+          {
+            title: 'one message on one line',
+            sectionFn: () => {
+              return renderJSWithMessages([
+                {
+                  line: 7,
+                  message: 'document.querySelector() detected',
+                  description: [
+                    'Pretty sweet call to document.querySelector(). Nice.',
+                  ],
+                  type: 'notice',
+                },
+              ]);
+            },
+          },
+          {
+            title: 'multiple messages on one line',
+            sectionFn: () => {
+              const line = 7;
+              return renderJSWithMessages([
+                {
+                  line,
+                  message: 'document.querySelector() detected',
+                  description: [
+                    'Pretty sweet call to document.querySelector(). Nice.',
+                  ],
+                  type: 'notice',
+                },
+                {
+                  line,
+                  message: 'classList.remove() considered harmful',
+                  description: [
+                    'Calling element.classList.remove() is harmful but not really.',
+                  ],
+                  type: 'error',
+                },
+              ]);
+            },
+          },
+          {
+            title: 'multiple messages on multiple lines',
+            sectionFn: () => {
+              return renderJSWithMessages([
+                {
+                  line: 7,
+                  message: 'document.querySelector() detected',
+                  description: [
+                    'Pretty sweet call to document.querySelector(). Nice.',
+                  ],
+                  type: 'notice',
+                },
+                {
+                  line: 18,
+                  message: 'browser.tabs.executeScript() is deprecated',
+                  description: [
+                    'browser.tabs.executeScript() will not be supported in the near future. Just kidding.',
+                  ],
+                  type: 'warning',
+                },
+              ]);
+            },
+          },
+        ],
+      },
+    ],
+  });


### PR DESCRIPTION
This is the last puzzle piece to fix https://github.com/mozilla/addons-code-manager/issues/41

The UX isn't great. It accomplishes the bare minimum of showing an inline linter message. I have some ideas to make it better but I'll defer those to follow-ups.

Examples:

<hr>

<img width="969" alt="Screenshot 2019-03-12 14 15 05" src="https://user-images.githubusercontent.com/55398/54240306-b3705e80-44eb-11e9-9de8-260488d63c33.png">

<hr>

<img width="959" alt="Screenshot 2019-03-12 14 13 06" src="https://user-images.githubusercontent.com/55398/54240309-b5d2b880-44eb-11e9-80d8-60b3b32ba29f.png">
