### PR TITLE
Fix changes content

### DIFF
--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -892,7 +892,10 @@ describe(__filename, () => {
       firstHunk.changes.forEach((change, index) => {
         const externalChange = firstExternalHunk.changes[index];
 
-        expect(change).toHaveProperty('content', externalChange.content);
+        expect(change).toHaveProperty(
+          'content',
+          externalChange.content.replace(/\n$/, ''),
+        );
         expect(change).toHaveProperty('type', externalChange.type);
         expect(change).toHaveProperty(
           'oldLineNumber',

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -976,6 +976,17 @@ describe(__filename, () => {
       expect(change).toHaveProperty('isNormal', true);
       expect(change).toHaveProperty('lineNumber', oldLineNumber);
     });
+
+    it('only removes the trailing newline', () => {
+      const version = createVersionWithChange({
+        content: 'This\nis a line with two newlines\n',
+      });
+
+      const diff = _createInternalDiffs({ version })[0];
+      const change = diff.hunks[0].changes[0];
+
+      expect(change.content).toEqual('This\nis a line with two newlines');
+    });
   });
 
   describe('fetchDiff', () => {

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -488,7 +488,7 @@ export const createInternalDiffs = ({
         oldRevision: String(baseVersionId),
         hunks: diff.hunks.map((hunk: ExternalHunk) => ({
           changes: hunk.changes.map((change: ExternalChange) => ({
-            content: change.content,
+            content: change.content.replace(/\n$/, ''),
             isDelete: change.type === 'delete',
             isInsert: change.type === 'insert',
             isNormal: change.type === 'normal',

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -488,6 +488,8 @@ export const createInternalDiffs = ({
         oldRevision: String(baseVersionId),
         hunks: diff.hunks.map((hunk: ExternalHunk) => ({
           changes: hunk.changes.map((change: ExternalChange) => ({
+            // TODO: remove the call to `replace()` once the API is fixed.
+            // See: https://github.com/mozilla/addons-server/issues/10932
             content: change.content.replace(/\n$/, ''),
             isDelete: change.type === 'delete',
             isInsert: change.type === 'insert',


### PR DESCRIPTION
This is a fix for https://github.com/mozilla/addons-server/issues/10932 so that we can have correct data in the frontend (until the API gets fixed).

## Screenshots

The diff is on the `version` of the `manifest.json`.

Before:

![Screen Shot 2019-03-14 at 15 28 05](https://user-images.githubusercontent.com/217628/54364748-ce6adc00-466d-11e9-9f3d-b5d167702538.png)

After:

![Screen Shot 2019-03-14 at 15 27 54](https://user-images.githubusercontent.com/217628/54364769-d62a8080-466d-11e9-9341-5e0c32b32fac.png)