### PR TITLE
Add icons related to linter messages in FileTreeNode

### DIFF
--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -361,8 +361,15 @@ describe(__filename, () => {
     const render = ({
       onSelect = jest.fn(),
       version = getVersion(fakeVersion),
+      linterMessages = {},
     } = {}) => {
-      return shallow(<FileTree version={version} onSelect={onSelect} />);
+      return shallow(
+        <FileTree
+          version={version}
+          linterMessages={linterMessages}
+          onSelect={onSelect}
+        />,
+      );
     };
 
     it('renders a ListGroup component with a Treefold', () => {
@@ -405,6 +412,21 @@ describe(__filename, () => {
       expect(shallow(<div>{node}</div>).find(FileTreeNode)).toHaveProp(
         'version',
         version,
+      );
+    });
+
+    it('passes the linterMessages prop to FileTreeNode', () => {
+      const linterMessages = {};
+
+      const root = render({ linterMessages });
+
+      const node = (root.instance() as FileTree).renderNode(
+        getTreefoldRenderProps(),
+      );
+
+      expect(shallow(<div>{node}</div>).find(FileTreeNode)).toHaveProp(
+        'linterMessages',
+        linterMessages,
       );
     });
   });

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -6,6 +6,7 @@ import FileTreeNode, {
   PublicProps as FileTreeNodeProps,
 } from '../FileTreeNode';
 import { Version } from '../../reducers/versions';
+import { LinterMessageMap } from '../../reducers/linter';
 import { getLocalizedString } from '../../utils';
 
 type FileNode = {
@@ -129,15 +130,25 @@ export const buildFileTree = (
 };
 
 type PublicProps = {
+  linterMessages: LinterMessageMap | void;
   onSelect: FileTreeNodeProps['onSelect'];
   version: Version;
 };
 
-export class FileTreeBase extends React.Component<PublicProps> {
-  renderNode = (props: TreefoldRenderProps<TreeNode>) => {
-    const { onSelect, version } = this.props;
+type Props = PublicProps;
 
-    return <FileTreeNode {...props} onSelect={onSelect} version={version} />;
+export class FileTreeBase extends React.Component<Props> {
+  renderNode = (props: TreefoldRenderProps<TreeNode>) => {
+    const { linterMessages, onSelect, version } = this.props;
+
+    return (
+      <FileTreeNode
+        {...props}
+        linterMessages={linterMessages}
+        onSelect={onSelect}
+        version={version}
+      />
+    );
   };
 
   render() {

--- a/src/components/FileTreeNode/index.spec.tsx
+++ b/src/components/FileTreeNode/index.spec.tsx
@@ -284,13 +284,14 @@ describe(__filename, () => {
     (type, className, icon) => {
       const message = {
         ...fakeExternalLinterMessage,
-        file: 'manifest.json',
+        file: 'src',
         type: type as ExternalLinterMessage['type'],
       };
 
       const root = renderWithLinterMessage({
         message,
         treefoldRenderProps: {
+          id: message.file,
           isFolder: true,
         },
       });

--- a/src/components/FileTreeNode/index.spec.tsx
+++ b/src/components/FileTreeNode/index.spec.tsx
@@ -3,10 +3,15 @@ import { shallow } from 'enzyme';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { createInternalVersion } from '../../reducers/versions';
-import { fakeVersion } from '../../test-helpers';
+import { ExternalLinterMessage, getMessageMap } from '../../reducers/linter';
+import {
+  createFakeExternalLinterResult,
+  fakeExternalLinterMessage,
+  fakeVersion,
+} from '../../test-helpers';
 import styles from './styles.module.scss';
 
-import FileTreeNode, { PublicProps } from '.';
+import FileTreeNode, { PublicProps, findMostSevereTypeForPath } from '.';
 
 const fakeGetToggleProps = () => ({
   onClick: jest.fn(),
@@ -45,15 +50,40 @@ describe(__filename, () => {
 
   const render = ({
     version = createInternalVersion(fakeVersion),
+    linterMessages,
     ...props
   }: RenderParams = {}) => {
     const allProps = {
       version,
+      linterMessages,
       ...getTreefoldRenderProps(),
       ...props,
     };
 
     return shallow(<FileTreeNode {...allProps} />);
+  };
+
+  const _getMessageMap = (
+    messages: Partial<ExternalLinterMessage>[] = [fakeExternalLinterMessage],
+  ) => {
+    return getMessageMap(createFakeExternalLinterResult({ messages }));
+  };
+
+  const renderWithLinterMessage = ({
+    version = createInternalVersion(fakeVersion),
+    message = fakeExternalLinterMessage,
+    treefoldRenderProps = {},
+  }) => {
+    const renderProps = getTreefoldRenderProps({
+      id: version.selectedPath,
+      ...treefoldRenderProps,
+    });
+
+    return render({
+      ...renderProps,
+      linterMessages: _getMessageMap([message]),
+      version,
+    });
   };
 
   it('renders a simple directory node', () => {
@@ -215,5 +245,201 @@ describe(__filename, () => {
     });
 
     expect(root.find(`.${styles.selected}`)).toHaveLength(0);
+  });
+
+  it.each([
+    ['error', `.${styles.hasLinterErrors}`, 'times-circle'],
+    ['notice', `.${styles.hasLinterMessages}`, 'info-circle'],
+    ['warning', `.${styles.hasLinterWarnings}`, 'exclamation-triangle'],
+  ])('renders a file node that has linter %ss', (type, className, icon) => {
+    const message = {
+      ...fakeExternalLinterMessage,
+      file: 'manifest.json',
+      type: type as ExternalLinterMessage['type'],
+    };
+
+    const root = renderWithLinterMessage({
+      message,
+      treefoldRenderProps: {
+        isFolder: false,
+      },
+    });
+
+    expect(root.find(className)).toHaveLength(1);
+
+    const nodeIcons = root.find(`.${styles.nodeIcons}`);
+    expect(nodeIcons).toHaveLength(1);
+    expect(nodeIcons.find(FontAwesomeIcon)).toHaveProp('icon', icon);
+    expect(nodeIcons.find(FontAwesomeIcon).prop('title')).toMatch(
+      new RegExp(`file contains linter ${type}s`),
+    );
+  });
+
+  it.each([
+    ['error', `.${styles.hasLinterErrors}`, 'times-circle'],
+    ['notice', `.${styles.hasLinterMessages}`, 'info-circle'],
+    ['warning', `.${styles.hasLinterWarnings}`, 'exclamation-triangle'],
+  ])(
+    'renders a directory node that has linter %ss',
+    (type, className, icon) => {
+      const message = {
+        ...fakeExternalLinterMessage,
+        file: 'manifest.json',
+        type: type as ExternalLinterMessage['type'],
+      };
+
+      const root = renderWithLinterMessage({
+        message,
+        treefoldRenderProps: {
+          isFolder: true,
+        },
+      });
+
+      expect(root.find(className)).toHaveLength(1);
+
+      const nodeIcons = root.find(`.${styles.nodeIcons}`);
+      expect(nodeIcons).toHaveLength(1);
+      expect(nodeIcons.find(FontAwesomeIcon)).toHaveProp('icon', icon);
+      expect(nodeIcons.find(FontAwesomeIcon).prop('title')).toMatch(
+        new RegExp(`contains files with linter ${type}s`),
+      );
+    },
+  );
+
+  it('ignores linter messages unrelated to the current node', () => {
+    const message = {
+      ...fakeExternalLinterMessage,
+      file: 'manifest.json',
+    };
+
+    const root = renderWithLinterMessage({
+      message,
+      treefoldRenderProps: {
+        id: 'some/other/file.js',
+      },
+    });
+
+    expect(root.find(`.${styles.hasLinterMessages}`)).toHaveLength(0);
+  });
+
+  it('indicates when a directory node contains a file that has linter messages', () => {
+    const message = {
+      ...fakeExternalLinterMessage,
+      file: 'src/manifest.json',
+    };
+
+    const root = renderWithLinterMessage({
+      message,
+      treefoldRenderProps: {
+        id: 'src/',
+        isFolder: true,
+      },
+    });
+
+    expect(root.find(`.${styles.hasLinterMessages}`)).toHaveLength(1);
+  });
+
+  describe('findMostSevereTypeForPath', () => {
+    it('returns null when the map is empty', () => {
+      const path = 'file.js';
+      const map = _getMessageMap([]);
+
+      const type = findMostSevereTypeForPath(map, path);
+
+      expect(type).toEqual(null);
+    });
+
+    it('returns the type of the message when there is only one message and a path', () => {
+      const path = 'file.js';
+      const message = { ...fakeExternalLinterMessage, file: path };
+      const map = _getMessageMap([message]);
+
+      const type = findMostSevereTypeForPath(map, path);
+
+      expect(type).toEqual(message.type);
+    });
+
+    it('returns null when the path is not found', () => {
+      const path = 'file.js';
+      const message = { ...fakeExternalLinterMessage, file: path };
+      const map = _getMessageMap([message]);
+
+      const type = findMostSevereTypeForPath(map, 'other-path');
+
+      expect(type).toEqual(null);
+    });
+
+    it('returns the most severe type given a directory path', () => {
+      const path = 'src';
+      const message = { ...fakeExternalLinterMessage, file: `${path}/file.js` };
+      const map = _getMessageMap([message]);
+
+      const type = findMostSevereTypeForPath(map, path);
+
+      expect(type).toEqual(message.type);
+    });
+
+    it('returns the most severe type given a map of messages and a directory path', () => {
+      const path = 'src';
+      const messages = [
+        {
+          ...fakeExternalLinterMessage,
+          file: `${path}/file-1.js`,
+          type: 'warning',
+        },
+        {
+          ...fakeExternalLinterMessage,
+          file: `${path}/file-2.js`,
+          type: 'error',
+        },
+      ] as ExternalLinterMessage[];
+      const map = _getMessageMap(messages);
+
+      const type = findMostSevereTypeForPath(map, path);
+
+      expect(type).toEqual(messages[1].type);
+    });
+
+    it('returns the most severe type given a map of messages for the same exact path', () => {
+      const path = 'src/file-1.js';
+      const messages = [
+        {
+          ...fakeExternalLinterMessage,
+          file: path,
+          type: 'warning',
+        },
+        {
+          ...fakeExternalLinterMessage,
+          file: path,
+          type: 'error',
+        },
+      ] as ExternalLinterMessage[];
+      const map = _getMessageMap(messages);
+
+      const type = findMostSevereTypeForPath(map, path);
+
+      expect(type).toEqual(messages[1].type);
+    });
+
+    it('returns the most severe type given a map of messages and a fully qualified file path', () => {
+      const path = 'src/file-1.js';
+      const messages = [
+        {
+          ...fakeExternalLinterMessage,
+          file: path,
+          type: 'warning',
+        },
+        {
+          ...fakeExternalLinterMessage,
+          file: `src/file-2.js`,
+          type: 'error',
+        },
+      ] as ExternalLinterMessage[];
+      const map = _getMessageMap(messages);
+
+      const type = findMostSevereTypeForPath(map, path);
+
+      expect(type).toEqual(messages[0].type);
+    });
   });
 });

--- a/src/components/FileTreeNode/index.tsx
+++ b/src/components/FileTreeNode/index.tsx
@@ -134,23 +134,17 @@ class FileTreeNodeBase<TreeNodeType> extends React.Component<PublicProps> {
       <React.Fragment>
         <ListGroup.Item {...listGroupItemProps}>
           <span
-            className={styles.nodeName}
-            style={{ paddingLeft: `${level * 20}px` }}
+            className={styles.nodeItem}
+            style={{ paddingLeft: `${level * 12}px` }}
           >
             {isFolder ? (
-              <React.Fragment>
-                <FontAwesomeIcon icon={isExpanded ? 'folder-open' : 'folder'} />
-                &nbsp;{node.name}
-              </React.Fragment>
+              <FontAwesomeIcon icon={isExpanded ? 'folder-open' : 'folder'} />
             ) : (
-              <React.Fragment>
-                <FontAwesomeIcon icon="file" />
-                &nbsp;{node.name}
-              </React.Fragment>
+              <FontAwesomeIcon icon="file" />
             )}
+            <span className={styles.nodeName}>{node.name}</span>
+            {nodeIcons}
           </span>
-
-          {nodeIcons}
         </ListGroup.Item>
 
         {isExpanded &&

--- a/src/components/FileTreeNode/index.tsx
+++ b/src/components/FileTreeNode/index.tsx
@@ -7,11 +7,75 @@ import makeClassName from 'classnames';
 import { gettext } from '../../utils';
 import { TreeNode } from '../FileTree';
 import { Version } from '../../reducers/versions';
+import { LinterMessage, LinterMessageMap } from '../../reducers/linter';
 import styles from './styles.module.scss';
 
 export type PublicProps = TreefoldRenderProps<TreeNode> & {
+  linterMessages: LinterMessageMap | void;
   onSelect: (id: string) => void;
   version: Version;
+};
+
+type MessageType = LinterMessage['type'];
+
+export const findMostSevereTypeForPath = (
+  linterMessageMap: LinterMessageMap,
+  targetPath: string,
+): MessageType | null => {
+  const allTypes = Object.keys(linterMessageMap).reduce(
+    (types, path: string) => {
+      if (!path.startsWith(targetPath)) {
+        return types;
+      }
+
+      const map = linterMessageMap[path];
+      types.push(...map.global.map((message) => message.type));
+
+      Object.keys(map.byLine).forEach((key) => {
+        types.push(...map.byLine[parseInt(key, 10)].map((m) => m.type));
+      });
+
+      return types;
+    },
+    [] as LinterMessage['type'][],
+  );
+
+  const orderedTypes: MessageType[] = ['error', 'warning', 'notice'];
+  for (const type of orderedTypes) {
+    if (allTypes.includes(type)) {
+      return type;
+    }
+  }
+
+  return null;
+};
+
+const getTitleForType = (type: string | null, isFolder: boolean) => {
+  switch (type) {
+    case 'error':
+      return isFolder
+        ? gettext('This folder contains files with linter errors')
+        : gettext('This file contains linter errors');
+    case 'warning':
+      return isFolder
+        ? gettext('This folder contains files with linter warnings')
+        : gettext('This file contains linter warnings');
+    default:
+      return isFolder
+        ? gettext('This folder contains files with linter notices')
+        : gettext('This file contains linter notices');
+  }
+};
+
+const getIconForType = (type: string | null) => {
+  switch (type) {
+    case 'error':
+      return 'times-circle';
+    case 'warning':
+      return 'exclamation-triangle';
+    default:
+      return 'info-circle';
+  }
 };
 
 class FileTreeNodeBase<TreeNodeType> extends React.Component<PublicProps> {
@@ -22,16 +86,39 @@ class FileTreeNodeBase<TreeNodeType> extends React.Component<PublicProps> {
       isExpanded,
       isFolder,
       level,
+      linterMessages,
       node,
       onSelect,
       renderChildNodes,
       version,
     } = this.props;
 
+    const hasLinterMessages =
+      linterMessages &&
+      Object.keys(linterMessages).some((path) => path.startsWith(node.id));
+
+    let nodeIcons = null;
+    let linterType = null;
+    if (linterMessages && hasLinterMessages) {
+      linterType = findMostSevereTypeForPath(linterMessages, node.id);
+
+      nodeIcons = (
+        <span className={styles.nodeIcons}>
+          <FontAwesomeIcon
+            icon={getIconForType(linterType)}
+            title={getTitleForType(linterType, isFolder)}
+          />
+        </span>
+      );
+    }
+
     let listGroupItemProps = {
       className: makeClassName(styles.node, {
         [styles.directoryNode]: isFolder,
         [styles.selected]: version.selectedPath === node.id,
+        [styles.hasLinterMessages]: hasLinterMessages,
+        [styles.hasLinterErrors]: linterType === 'error',
+        [styles.hasLinterWarnings]: linterType === 'warning',
       }),
       onClick: () => onSelect(node.id),
     };
@@ -46,7 +133,10 @@ class FileTreeNodeBase<TreeNodeType> extends React.Component<PublicProps> {
     return (
       <React.Fragment>
         <ListGroup.Item {...listGroupItemProps}>
-          <span style={{ paddingLeft: `${level * 20}px` }}>
+          <span
+            className={styles.nodeName}
+            style={{ paddingLeft: `${level * 20}px` }}
+          >
             {isFolder ? (
               <React.Fragment>
                 <FontAwesomeIcon icon={isExpanded ? 'folder-open' : 'folder'} />
@@ -59,6 +149,8 @@ class FileTreeNodeBase<TreeNodeType> extends React.Component<PublicProps> {
               </React.Fragment>
             )}
           </span>
+
+          {nodeIcons}
         </ListGroup.Item>
 
         {isExpanded &&

--- a/src/components/FileTreeNode/styles.module.scss
+++ b/src/components/FileTreeNode/styles.module.scss
@@ -9,8 +9,29 @@
   padding: 0.5rem 1.25rem;
 }
 
+.nodeItem {
+  align-items: flex-start;
+  display: flex;
+  line-height: 1;
+  width: 100%;
+}
+
+.nodeName,
+.nodeIcons {
+  margin-left: 0.5rem;
+  width: 100%;
+}
+
 .nodeName {
-  word-break: break-all;
+  overflow: hidden;
+  padding-bottom: 0.2rem;
+  text-overflow: ellipsis;
+  white-space: wrap;
+}
+
+.nodeIcons {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .selected {
@@ -27,7 +48,4 @@
   &.hasLinterWarnings {
     color: $orange;
   }
-}
-
-.nodeIcons {
 }

--- a/src/components/FileTreeNode/styles.module.scss
+++ b/src/components/FileTreeNode/styles.module.scss
@@ -2,9 +2,32 @@
 
 .node {
   cursor: pointer;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: space-between;
   padding: 0.5rem 1.25rem;
+}
+
+.nodeName {
+  word-break: break-all;
 }
 
 .selected {
   background-color: $light-gray;
+}
+
+.hasLinterMessages {
+  font-weight: 500;
+
+  &.hasLinterErrors {
+    color: $red;
+  }
+
+  &.hasLinterWarnings {
+    color: $orange;
+  }
+}
+
+.nodeIcons {
 }

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -42,7 +42,7 @@ type PropsFromRouter = {
 type PropsFromState = {
   apiState: ApiState;
   file: VersionFile | null | void;
-  linterMessages: LinterMessageMap | null | void;
+  linterMessages: LinterMessageMap | void;
   linterMessagesAreLoading: boolean;
   version: Version;
 };
@@ -125,7 +125,11 @@ export class BrowseBase extends React.Component<Props> {
         <Col md="3">
           <Row>
             <Col>
-              <FileTree version={version} onSelect={this.onSelectFile} />
+              <FileTree
+                linterMessages={linterMessages}
+                onSelect={this.onSelectFile}
+                version={version}
+              />
             </Col>
           </Row>
           {file && (

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -31,7 +31,7 @@ type PropsFromRouter = {
 
 type PropsFromState = {
   addonId: number;
-  compareInfo: CompareInfo | null | undefined;
+  compareInfo: CompareInfo | null | void;
   isLoading: boolean;
   path: string | void;
   version: Version;

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -31,7 +31,7 @@ type PropsFromRouter = {
 
 type PropsFromState = {
   addonId: number;
-  compareInfo: CompareInfo | null | void;
+  compareInfo: CompareInfo | null | undefined;
   isLoading: boolean;
   path: string | void;
   version: Version;
@@ -127,7 +127,11 @@ export class CompareBase extends React.Component<Props> {
       <React.Fragment>
         <Col md="3">
           {version ? (
-            <FileTree version={version} onSelect={this.onSelectFile} />
+            <FileTree
+              linterMessages={undefined}
+              onSelect={this.onSelectFile}
+              version={version}
+            />
           ) : (
             this.renderLoadingMessageOrError(gettext('Loading file tree...'))
           )}

--- a/stories/FileTree.stories.tsx
+++ b/stories/FileTree.stories.tsx
@@ -64,5 +64,9 @@ const onSelectFile = (path: string) => {
 };
 
 storiesOf('FileTree', module).add('default', () => (
-  <FileTree version={version} onSelect={onSelectFile} />
+  <FileTree
+    linterMessages={undefined}
+    onSelect={onSelectFile}
+    version={version}
+  />
 ));

--- a/stories/FileTreeNode.stories.tsx
+++ b/stories/FileTreeNode.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
-import FileTreeNode from '../src/components/FileTreeNode';
+import FileTreeNode, { PublicProps } from '../src/components/FileTreeNode';
 import { createInternalVersion } from '../src/reducers/versions';
 import { fakeVersion } from '../src/test-helpers';
 
@@ -13,6 +13,7 @@ const getProps = ({
   nodeName = 'node name',
   nodeId = 'node-id',
   renderChildNodes = () => ({}),
+  linterMessages = undefined as PublicProps['linterMessages'],
   version = createInternalVersion(fakeVersion),
 } = {}) => {
   return {
@@ -31,6 +32,7 @@ const getProps = ({
       name: nodeName,
     },
     renderChildNodes,
+    linterMessages,
     onSelect: () => {},
     version,
   };


### PR DESCRIPTION
Fixes #329 
Fixes #330 

~~⚠️ depends on #400~~

---

This patch adds icons/colors to indicate when a file has linter messages. Directories containing such files are also marked with icons/colors.

Additional notes:

- only the most severe linter message type is shown
- HTML titles are used to give more information about the icons
- the "error" type is usually not used because errors block the submission of a version (admins can override this behavior, though)
- the first two screenshots show a yellow color for the warnings but it has been change to orange to be more readable
- I imagine that #115 could also be implemented with an icon (and some more style probably) **UPDATE:** see https://github.com/mozilla/addons-code-manager/pull/418/commits/04cac0a2ab0f23e38540787f7cdfc44a87a82a18

## Screenshot

With warning and notice messages shown. Because warnings are more severe than notices, the `chrome` folder has the "warning" icon:

![Screen Shot 2019-03-15 at 13 34 17](https://user-images.githubusercontent.com/217628/54436277-806bdc00-4732-11e9-8b97-1629299eddb7.png)

With error messages (please see the additional notes above):

<img width="1392" alt="Screen Shot 2019-03-19 at 11 47 50" src="https://user-images.githubusercontent.com/217628/54600382-edd28200-4a3c-11e9-8596-68f31558903f.png">

Updated color for the warnings:

![Screen Shot 2019-03-19 at 13 42 10](https://user-images.githubusercontent.com/217628/54607272-45c5b480-4a4e-11e9-868c-e390af7527cb.png)