### PR TITLE
Show global linter messages in compare view

### DIFF
--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -277,7 +277,7 @@ describe(__filename, () => {
     // Simulate an update.
     root.setProps({});
 
-    expect(_loadData).toHaveBeenCalled();
+    expect(_loadData).toHaveBeenCalledWith();
   });
 
   it('dispatches fetchLinterMessages when linterMessages is undefined', () => {

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -220,7 +220,7 @@ export class DiffViewBase extends React.Component<Props> {
 
 const mapStateToProps = (
   state: ApplicationState,
-  ownProps: Props,
+  ownProps: PublicProps,
 ): PropsFromState => {
   const { version } = ownProps;
 

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -67,6 +67,7 @@ export class DiffViewBase extends React.Component<Props> {
 
   constructor(props: Props) {
     super(props);
+    // Allow dependency injection to test all the ways loadData() gets executed.
     this.loadData = props._loadData || this._loadData;
   }
 

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -98,7 +98,7 @@ export class DiffViewBase extends React.Component<Props> {
       linterMessagesAreLoading,
     } = this.props;
 
-    if (version && linterMessages === undefined && !linterMessagesAreLoading) {
+    if (linterMessages === undefined && !linterMessagesAreLoading) {
       dispatch(
         _fetchLinterMessages({
           versionId: version.id,

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { connect } from 'react-redux';
 import {
   Decoration,
   Diff,
@@ -12,35 +13,66 @@ import {
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import makeClassName from 'classnames';
 
+import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
+import LinterMessage from '../LinterMessage';
 import refractor from '../../refractor';
+import {
+  LinterMessagesByPath,
+  fetchLinterMessages,
+  selectMessageMap,
+} from '../../reducers/linter';
+import { Version } from '../../reducers/versions';
 import { getLanguageFromMimeType, gettext } from '../../utils';
 import styles from './styles.module.scss';
 import 'react-diff-view/style/index.css';
 
+type LoadData = () => void;
+
 export type PublicProps = {
+  _loadData?: LoadData;
   diffs: DiffInfo[];
   mimeType: string;
+  version: Version;
 };
 
 export type DefaultProps = {
   _document: typeof document;
+  _fetchLinterMessages: typeof fetchLinterMessages;
   _tokenize: typeof tokenize;
   viewType: DiffProps['viewType'];
 };
 
+type PropsFromState = {
+  linterMessages: LinterMessagesByPath | null | void;
+  linterMessagesAreLoading: boolean;
+};
+
 export type RouterProps = RouteComponentProps<{}>;
 
-type Props = PublicProps & DefaultProps & RouterProps;
+export type Props = PublicProps &
+  DefaultProps &
+  PropsFromState &
+  RouterProps &
+  ConnectedReduxProps;
 
 export class DiffViewBase extends React.Component<Props> {
+  loadData: LoadData;
+
   static defaultProps: DefaultProps = {
     _document: document,
+    _fetchLinterMessages: fetchLinterMessages,
     _tokenize: tokenize,
     viewType: 'unified',
   };
 
+  constructor(props: Props) {
+    super(props);
+    this.loadData = props._loadData || this._loadData;
+  }
+
   componentDidMount() {
     const { _document, location } = this.props;
+    this.loadData();
 
     if (!location.hash.length) {
       return;
@@ -52,6 +84,29 @@ export class DiffViewBase extends React.Component<Props> {
       element.scrollIntoView();
     }
   }
+
+  componentDidUpdate() {
+    this.loadData();
+  }
+
+  _loadData = () => {
+    const {
+      _fetchLinterMessages,
+      dispatch,
+      version,
+      linterMessages,
+      linterMessagesAreLoading,
+    } = this.props;
+
+    if (version && linterMessages === undefined && !linterMessagesAreLoading) {
+      dispatch(
+        _fetchLinterMessages({
+          versionId: version.id,
+          url: version.validationURL,
+        }),
+      );
+    }
+  };
 
   renderHeader({ hunks }: DiffInfo) {
     const { additions, deletions } = hunks.reduce(
@@ -101,7 +156,14 @@ export class DiffViewBase extends React.Component<Props> {
   };
 
   render() {
-    const { _tokenize, diffs, mimeType, viewType, location } = this.props;
+    const {
+      _tokenize,
+      diffs,
+      linterMessages,
+      mimeType,
+      viewType,
+      location,
+    } = this.props;
 
     const options = {
       highlight: true,
@@ -123,6 +185,11 @@ export class DiffViewBase extends React.Component<Props> {
             </div>
           </React.Fragment>
         )}
+
+        {linterMessages &&
+          linterMessages.global.map((message) => {
+            return <LinterMessage key={message.uid} message={message} />;
+          })}
 
         {diffs.map((diff) => {
           const { oldRevision, newRevision, hunks, type } = diff;
@@ -151,6 +218,27 @@ export class DiffViewBase extends React.Component<Props> {
   }
 }
 
-export default withRouter(DiffViewBase) as React.ComponentType<
-  PublicProps & Partial<DefaultProps>
->;
+const mapStateToProps = (
+  state: ApplicationState,
+  ownProps: Props,
+): PropsFromState => {
+  const { version } = ownProps;
+
+  let linterMessages;
+  const map = selectMessageMap(state.linter, version.id);
+  if (map) {
+    linterMessages = map[version.selectedPath]
+      ? map[version.selectedPath]
+      : // No messages exist for this path.
+        null;
+  }
+
+  return {
+    linterMessages,
+    linterMessagesAreLoading: state.linter.isLoading,
+  };
+};
+
+export default withRouter<PublicProps & Partial<DefaultProps> & RouterProps>(
+  connect(mapStateToProps)(DiffViewBase),
+) as React.ComponentType<PublicProps & Partial<DefaultProps>>;

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -193,8 +193,9 @@ describe(__filename, () => {
       headVersionId: String(version.id),
     });
 
-    expect(root.find(DiffView)).toHaveLength(1);
-    expect(root.find(DiffView)).toHaveProp(
+    const diffView = root.find(DiffView);
+    expect(diffView).toHaveLength(1);
+    expect(diffView).toHaveProp(
       'diffs',
       createInternalDiffs({
         baseVersionId,
@@ -202,7 +203,8 @@ describe(__filename, () => {
         version,
       }),
     );
-    expect(root.find(DiffView)).toHaveProp('mimeType', mimeType);
+    expect(diffView).toHaveProp('mimeType', mimeType);
+    expect(diffView).toHaveProp('version', createInternalVersion(version));
   });
 
   it('renders an error when fetching a diff has failed', () => {

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -143,6 +143,7 @@ export class CompareBase extends React.Component<Props> {
                 <DiffView
                   diffs={compareInfo.diffs}
                   mimeType={compareInfo.mimeType}
+                  version={version}
                 />
               ) : (
                 this.renderLoadingMessageOrError(gettext('Loading diff...'))

--- a/src/reducers/linter.tsx
+++ b/src/reducers/linter.tsx
@@ -64,12 +64,14 @@ export type LinterMessagesByLine = {
   [line: number]: LinterMessage[];
 };
 
+export type LinterMessagesByPath = {
+  global: LinterMessage[];
+  byLine: LinterMessagesByLine;
+};
+
 export type LinterMessageMap = {
   // The 'path' key matches the key of ExternalVersionFile['entries']
-  [path: string]: {
-    global: LinterMessage[];
-    byLine: LinterMessagesByLine;
-  };
+  [path: string]: LinterMessagesByPath;
 };
 
 export const getMessageMap = (

--- a/stories/DiffView.stories.tsx
+++ b/stories/DiffView.stories.tsx
@@ -2,34 +2,144 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { parseDiff } from 'react-diff-view';
 
-import DiffView from '../src/components/DiffView';
+import configureStore from '../src/configureStore';
+import DiffView, {
+  PublicProps as DiffViewProps,
+} from '../src/components/DiffView';
+import basicDiff from '../src/components/DiffView/fixtures/basicDiff';
 import diffWithDeletions from '../src/components/DiffView/fixtures/diffWithDeletions';
+import { LinterMessage, actions } from '../src/reducers/linter';
+import { createInternalVersion } from '../src/reducers/versions';
+import {
+  createFakeExternalLinterResult,
+  fakeVersion,
+  fakeVersionEntry,
+  fakeVersionFile,
+} from '../src/test-helpers';
 import { renderWithStoreAndRouter } from './utils';
 
-storiesOf('DiffView', module).addWithChapters('all variants', {
-  chapters: [
-    {
-      sections: [
-        {
-          title: 'diff with additions and deletions',
-          sectionFn: () => {
-            return renderWithStoreAndRouter(
-              <DiffView
-                diffs={parseDiff(diffWithDeletions)}
-                mimeType="application/javascript"
-              />,
-            );
-          },
-        },
-        {
-          title: 'no differences',
-          sectionFn: () => {
-            return renderWithStoreAndRouter(
-              <DiffView diffs={[]} mimeType="application/javascript" />,
-            );
-          },
-        },
-      ],
+// eslint-disable-next-line no-var
+var uid = 0;
+
+const newUID = () => {
+  // This helps make message keys for the storybook React page.
+  uid++;
+  return `msg-${uid}`;
+};
+
+const render = (
+  moreProps: Partial<DiffViewProps> = {},
+  store = configureStore(),
+) => {
+  const props: DiffViewProps = {
+    diffs: parseDiff(basicDiff),
+    mimeType: 'application/javascript',
+    version: createInternalVersion(fakeVersion),
+    ...moreProps,
+  };
+
+  return renderWithStoreAndRouter(<DiffView {...props} />, store);
+};
+
+const renderWithMessages = (
+  messages: Partial<LinterMessage>[],
+  moreProps: Partial<DiffViewProps> = {},
+) => {
+  const path = 'lib/some-file.js';
+  const result = createFakeExternalLinterResult({
+    messages: messages.map((msg) => {
+      return { uid: newUID(), ...msg, file: path };
+    }),
+  });
+
+  const store = configureStore();
+  const version = createInternalVersion({
+    ...fakeVersion,
+    file: {
+      ...fakeVersionFile,
+      entries: { [path]: { ...fakeVersionEntry, path } },
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      selected_file: path,
     },
-  ],
-});
+  });
+
+  store.dispatch(actions.loadLinterResult({ versionId: version.id, result }));
+
+  const props: DiffViewProps = {
+    diffs: parseDiff(basicDiff),
+    mimeType: 'application/javascript',
+    version,
+    ...moreProps,
+  };
+
+  return render(props, store);
+};
+
+storiesOf('DiffView', module)
+  .addWithChapters('all diffs', {
+    chapters: [
+      {
+        sections: [
+          {
+            title: 'diff with additions and deletions',
+            sectionFn: () => {
+              return render({ diffs: parseDiff(diffWithDeletions) });
+            },
+          },
+          {
+            title: 'no differences',
+            sectionFn: () => {
+              return render({ diffs: [] });
+            },
+          },
+        ],
+      },
+    ],
+  })
+  .addWithChapters('linter messages', {
+    chapters: [
+      {
+        sections: [
+          {
+            title: 'one global message',
+            sectionFn: () => {
+              return renderWithMessages([
+                {
+                  line: null,
+                  message:
+                    'The &#34;update_url&#34; property is not used by Firefox.',
+                  description: [
+                    'The &#34;update_url&#34; is not used by Firefox in the root of a manifest; your add-on will be updated via the Add-ons site and not your &#34;update_url&#34;.',
+                  ],
+                  type: 'warning',
+                },
+              ]);
+            },
+          },
+          {
+            title: 'multiple global messages',
+            sectionFn: () => {
+              return renderWithMessages([
+                {
+                  line: null,
+                  message:
+                    'The &#34;update_url&#34; property is not used by Firefox.',
+                  description: [
+                    'The &#34;update_url&#34; is not used by Firefox in the root of a manifest; your add-on will be updated via the Add-ons site and not your &#34;update_url&#34;.',
+                  ],
+                  type: 'warning',
+                },
+                {
+                  line: null,
+                  message:
+                    '/permissions: Unknown permissions &#34;unlimitedStorage&#34; at 8.',
+                  description: ['See ... for more information.'],
+                  type: 'notice',
+                },
+              ]);
+            },
+          },
+        ],
+      },
+    ],
+  });

--- a/stories/DiffView.stories.tsx
+++ b/stories/DiffView.stories.tsx
@@ -18,8 +18,7 @@ import {
 } from '../src/test-helpers';
 import { renderWithStoreAndRouter } from './utils';
 
-// eslint-disable-next-line no-var
-var uid = 0;
+let uid = 0;
 
 const newUID = () => {
   // This helps make message keys for the storybook React page.


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/409

**NOTE**: There is some duplication here between how `pages/Browse` and `components/CodeView` handle [linter messages](https://github.com/mozilla/addons-code-manager/blob/ed2f053714c09230b55ff10eb93de98d9240b1e5/src/pages/Browse/index.tsx#L82-L89). To keep this patch small-ish, I'm going to address that in a follow-up issue (https://github.com/mozilla/addons-code-manager/issues/414). The `Browse` component was doing it in an awkward way so the fixup will be slightly more involved.

<img width="1053" alt="Screenshot 2019-03-18 09 54 08" src="https://user-images.githubusercontent.com/55398/54539266-d1aee200-4963-11e9-8cc4-2a3dc5e841a3.png">
