### PR TITLE
Show inline linter messages in the compare view

### DIFF
--- a/src/@types/react-diff-view/index.d.ts
+++ b/src/@types/react-diff-view/index.d.ts
@@ -45,6 +45,8 @@ declare module 'react-diff-view' {
 
   type ViewType = 'split' | 'unified';
 
+  export type WidgetMap = { [changeKey: string]: ReactNode };
+
   type DiffProps = {
     children: (hunks: HunkInfo[]) => ReactNode;
     className?: string;
@@ -55,6 +57,7 @@ declare module 'react-diff-view' {
     gutterType?: 'default' | 'anchor' | 'none';
     generateAnchorID?: (change: ChangeInfo) => string;
     selectedChanges?: string[];
+    widgets?: WidgetMap;
   };
 
   // eslint-disable-next-line no-undef

--- a/src/components/CodeView/styles.module.scss
+++ b/src/components/CodeView/styles.module.scss
@@ -55,5 +55,5 @@
 }
 
 .linterMessages {
-  padding-top: 16px;
+  padding-top: 1rem;
 }

--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -482,7 +482,7 @@ describe(__filename, () => {
     );
   });
 
-  it('only renders messages per line', () => {
+  it('renders just the right amount of widgets', () => {
     const store = configureStore();
 
     const externalMessages = [
@@ -500,8 +500,10 @@ describe(__filename, () => {
       store,
       version,
     });
-    // Make sure we have truthy React nodes for exactly the same
-    // number of messages.
+
+    // As a sanity check on how the widgets are mapped,
+    // make sure we have truthy React nodes for exactly the same
+    // number of lines containing messages.
     expect(getWidgetNodes(widgets).length).toEqual(externalMessages.length);
   });
 

--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -1,6 +1,12 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import React from 'react';
-import { Diff, parseDiff, getChangeKey } from 'react-diff-view';
+import {
+  Diff,
+  Hunks,
+  WidgetMap,
+  parseDiff,
+  getChangeKey,
+} from 'react-diff-view';
 import { Store } from 'redux';
 import { shallow } from 'enzyme';
 import { Location } from 'history';
@@ -29,7 +35,12 @@ import {
 } from '../../test-helpers';
 import styles from './styles.module.scss';
 
-import DiffView, { DiffViewBase, DefaultProps, PublicProps } from '.';
+import DiffView, {
+  DiffViewBase,
+  DefaultProps,
+  PublicProps,
+  getAllHunkChanges,
+} from '.';
 
 describe(__filename, () => {
   type RenderParams = { store?: Store; location?: Location } & Partial<
@@ -82,12 +93,14 @@ describe(__filename, () => {
     return { _fetchLinterMessages, dispatch, root, fakeThunk };
   };
 
-  const setUpLinterMessagesForPath = ({
+  const dispatchLinterMessages = ({
     messages,
     path = 'lib/react.js',
+    store,
   }: {
     messages: Partial<ExternalLinterMessage>[];
     path?: string;
+    store: Store;
   }) => {
     const version = createInternalVersion({
       ...fakeVersion,
@@ -97,13 +110,52 @@ describe(__filename, () => {
         selected_file: path,
       },
     });
+
     const linterResult = createFakeExternalLinterResult({
       messages: messages.map((msg) => {
         return { ...msg, file: path };
       }),
     });
 
+    store.dispatch(
+      linterActions.loadLinterResult({
+        versionId: version.id,
+        result: linterResult,
+      }),
+    );
+
     return { linterResult, version };
+  };
+
+  const renderAndGetWidgets = (params: RenderParams): WidgetMap => {
+    const root = render(params);
+
+    const diffView = root.find(Diff);
+    expect(diffView).toHaveProp('widgets');
+
+    const widgets = diffView.prop('widgets');
+    if (!widgets) {
+      throw new Error('The widgets prop was falsy');
+    }
+
+    return widgets;
+  };
+
+  const renderWidget = (hunks: Hunks, widgets: WidgetMap, line: number) => {
+    const result = getAllHunkChanges(hunks).filter(
+      (change) => change.lineNumber === line,
+    );
+    if (result.length !== 1) {
+      throw new Error(`Could not find a change at line ${line}`);
+    }
+
+    const key = getChangeKey(result[0]);
+    return shallow(<div>{widgets[key]}</div>);
+  };
+
+  const getWidgetNodes = (widgets: WidgetMap) => {
+    // Return a list of truthy React nodes in arbitrary order.
+    return Object.values(widgets).filter(Boolean);
   };
 
   it('renders with no differences', () => {
@@ -313,16 +365,10 @@ describe(__filename, () => {
 
   it('does not dispatch fetchLinterMessages after they have loaded', () => {
     const store = configureStore();
-    const { linterResult, version } = setUpLinterMessagesForPath({
+    const { version } = dispatchLinterMessages({
+      store,
       messages: [{ uid: 'some-message-uid' }],
     });
-
-    store.dispatch(
-      linterActions.loadLinterResult({
-        versionId: version.id,
-        result: linterResult,
-      }),
-    );
 
     const { dispatch } = renderWithVersion({ store, version });
 
@@ -371,21 +417,15 @@ describe(__filename, () => {
     const globalMessageUid1 = 'first';
     const globalMessageUid2 = 'second';
 
-    const { linterResult, version } = setUpLinterMessagesForPath({
+    const { version } = dispatchLinterMessages({
+      store,
       messages: [
         { line: null, uid: globalMessageUid1 },
         { line: null, uid: globalMessageUid2 },
       ],
     });
 
-    store.dispatch(
-      linterActions.loadLinterResult({
-        versionId: version.id,
-        result: linterResult,
-      }),
-    );
-
-    const { root } = renderWithVersion({ store, version });
+    const root = render({ store, version });
 
     const messages = root.find(LinterMessage);
     expect(messages).toHaveLength(2);
@@ -401,5 +441,129 @@ describe(__filename, () => {
         uid: globalMessageUid2,
       }),
     );
+  });
+
+  it('renders multiple inline messages', () => {
+    const store = configureStore();
+
+    const externalMessages = [
+      // Add a message to line 9 in the first hunk.
+      { line: 9, uid: 'first' },
+      // Add a message to line 23 in the second hunk.
+      { line: 23, uid: 'second' },
+    ];
+
+    const { version } = dispatchLinterMessages({
+      store,
+      messages: externalMessages,
+    });
+
+    const diffs = parseDiff(diffWithDeletions);
+    const widgets = renderAndGetWidgets({ diffs, store, version });
+
+    const { hunks } = diffs[0];
+
+    const firstRoot = renderWidget(hunks, widgets, externalMessages[0].line);
+    expect(firstRoot.find(LinterMessage)).toHaveLength(1);
+    expect(firstRoot.find(LinterMessage)).toHaveProp(
+      'message',
+      expect.objectContaining({
+        uid: externalMessages[0].uid,
+      }),
+    );
+
+    const secondRoot = renderWidget(hunks, widgets, externalMessages[1].line);
+    expect(secondRoot.find(LinterMessage)).toHaveLength(1);
+    expect(secondRoot.find(LinterMessage)).toHaveProp(
+      'message',
+      expect.objectContaining({
+        uid: externalMessages[1].uid,
+      }),
+    );
+  });
+
+  it('only renders messages per line', () => {
+    const store = configureStore();
+
+    const externalMessages = [
+      { line: 1, uid: 'first' },
+      { line: 2, uid: 'second' },
+    ];
+
+    const { version } = dispatchLinterMessages({
+      store,
+      messages: externalMessages,
+    });
+
+    const widgets = renderAndGetWidgets({
+      diffs: parseDiff(diffWithDeletions),
+      store,
+      version,
+    });
+    // Make sure we have truthy React nodes for exactly the same
+    // number of messages.
+    expect(getWidgetNodes(widgets).length).toEqual(externalMessages.length);
+  });
+
+  it('renders multiple inline messages on the same line', () => {
+    const store = configureStore();
+
+    const line = 9;
+    const externalMessages = [{ line, uid: 'first' }, { line, uid: 'second' }];
+
+    const { version } = dispatchLinterMessages({
+      store,
+      messages: externalMessages,
+    });
+
+    const diffs = parseDiff(diffWithDeletions);
+    const widgets = renderAndGetWidgets({ diffs, store, version });
+
+    const { hunks } = diffs[0];
+
+    const root = renderWidget(hunks, widgets, line);
+    const messages = root.find(LinterMessage);
+
+    expect(messages).toHaveLength(2);
+    expect(messages.at(0)).toHaveProp(
+      'message',
+      expect.objectContaining({
+        uid: externalMessages[0].uid,
+      }),
+    );
+    expect(messages.at(1)).toHaveProp(
+      'message',
+      expect.objectContaining({
+        uid: externalMessages[1].uid,
+      }),
+    );
+  });
+
+  it('does not render widgets without linter messages', () => {
+    const widgets = renderAndGetWidgets({
+      diffs: parseDiff(diffWithDeletions),
+      version: createInternalVersion(fakeVersion),
+    });
+    expect(getWidgetNodes(widgets).length).toEqual(0);
+  });
+
+  describe('getAllHunkChanges', () => {
+    it('returns a flattened list of all changes', () => {
+      const diffs = parseDiff(diffWithDeletions);
+      const changes = getAllHunkChanges(diffs[0].hunks);
+
+      // Check a line from the first hunk:
+      expect(changes.filter((c) => c.lineNumber === 2)[0].content).toEqual(
+        "import { Diff, DiffProps, parseDiff } from 'react-diff-view';",
+      );
+      // Check a line from the second hunk:
+      expect(changes.filter((c) => c.lineNumber === 24)[0].content).toEqual(
+        '    console.log({ hunk });',
+      );
+      // Check a line from the third hunk:
+      expect(changes.filter((c) => c.lineNumber === 50)[0].content).toEqual(
+        '          </Diff>',
+      );
+    });
   });
 });

--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -463,18 +463,18 @@ describe(__filename, () => {
 
     const { hunks } = diffs[0];
 
-    const firstRoot = renderWidget(hunks, widgets, externalMessages[0].line);
-    expect(firstRoot.find(LinterMessage)).toHaveLength(1);
-    expect(firstRoot.find(LinterMessage)).toHaveProp(
+    const firstWidget = renderWidget(hunks, widgets, externalMessages[0].line);
+    expect(firstWidget.find(LinterMessage)).toHaveLength(1);
+    expect(firstWidget.find(LinterMessage)).toHaveProp(
       'message',
       expect.objectContaining({
         uid: externalMessages[0].uid,
       }),
     );
 
-    const secondRoot = renderWidget(hunks, widgets, externalMessages[1].line);
-    expect(secondRoot.find(LinterMessage)).toHaveLength(1);
-    expect(secondRoot.find(LinterMessage)).toHaveProp(
+    const secondWidget = renderWidget(hunks, widgets, externalMessages[1].line);
+    expect(secondWidget.find(LinterMessage)).toHaveLength(1);
+    expect(secondWidget.find(LinterMessage)).toHaveProp(
       'message',
       expect.objectContaining({
         uid: externalMessages[1].uid,

--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -93,7 +93,7 @@ describe(__filename, () => {
     return { _fetchLinterMessages, dispatch, root, fakeThunk };
   };
 
-  const dispatchLinterMessages = ({
+  const _loadLinterResult = ({
     messages,
     path = 'lib/react.js',
     store,
@@ -365,7 +365,7 @@ describe(__filename, () => {
 
   it('does not dispatch fetchLinterMessages after they have loaded', () => {
     const store = configureStore();
-    const { version } = dispatchLinterMessages({
+    const { version } = _loadLinterResult({
       store,
       messages: [{ uid: 'some-message-uid' }],
     });
@@ -417,7 +417,7 @@ describe(__filename, () => {
     const globalMessageUid1 = 'first';
     const globalMessageUid2 = 'second';
 
-    const { version } = dispatchLinterMessages({
+    const { version } = _loadLinterResult({
       store,
       messages: [
         { line: null, uid: globalMessageUid1 },
@@ -453,7 +453,7 @@ describe(__filename, () => {
       { line: 23, uid: 'second' },
     ];
 
-    const { version } = dispatchLinterMessages({
+    const { version } = _loadLinterResult({
       store,
       messages: externalMessages,
     });
@@ -490,7 +490,7 @@ describe(__filename, () => {
       { line: 2, uid: 'second' },
     ];
 
-    const { version } = dispatchLinterMessages({
+    const { version } = _loadLinterResult({
       store,
       messages: externalMessages,
     });
@@ -511,7 +511,7 @@ describe(__filename, () => {
     const line = 9;
     const externalMessages = [{ line, uid: 'first' }, { line, uid: 'second' }];
 
-    const { version } = dispatchLinterMessages({
+    const { version } = _loadLinterResult({
       store,
       messages: externalMessages,
     });

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -125,12 +125,12 @@ export class DiffViewBase extends React.Component<Props> {
       const changeKey = getChangeKey(change);
       const line = change.lineNumber;
 
-      let widget = null;
       let messages;
       if (line && linterMessages) {
         messages = linterMessages.byLine[line];
       }
 
+      let widget = null;
       if (messages && messages.length) {
         widget = (
           <div className={styles.inlineLinterMessages}>

--- a/src/components/DiffView/styles.module.scss
+++ b/src/components/DiffView/styles.module.scss
@@ -60,3 +60,7 @@
     background-color: $light-gray;
   }
 }
+
+.inlineLinterMessages {
+  padding: 16px 16px 0 16px;
+}

--- a/src/components/DiffView/styles.module.scss
+++ b/src/components/DiffView/styles.module.scss
@@ -62,5 +62,5 @@
 }
 
 .inlineLinterMessages {
-  padding: 16px 16px 0 16px;
+  padding: 1rem 1rem 0 1rem;
 }

--- a/stories/DiffView.stories.tsx
+++ b/stories/DiffView.stories.tsx
@@ -138,6 +138,68 @@ storiesOf('DiffView', module)
               ]);
             },
           },
+          {
+            title: 'one message on one line',
+            sectionFn: () => {
+              return renderWithMessages([
+                {
+                  line: 39,
+                  message: 'expect().toHaveProp() detected',
+                  description: [
+                    'Calls to expect().toHaveProp() might lead to your add-on getting approved.',
+                  ],
+                  type: 'warning',
+                },
+              ]);
+            },
+          },
+          {
+            title: 'multiple messages on one line',
+            sectionFn: () => {
+              return renderWithMessages([
+                {
+                  line: 39,
+                  message: 'expect().toHaveProp() detected',
+                  description: [
+                    'Calls to expect().toHaveProp() might lead to your add-on getting approved.',
+                  ],
+                  type: 'warning',
+                },
+                {
+                  line: 39,
+                  message: 'Unsafe call to expect()',
+                  description: [
+                    'Calling expect() like this is unsafe but not really.',
+                  ],
+                  type: 'error',
+                },
+              ]);
+            },
+          },
+          {
+            title: 'multiple messages on multiple lines',
+            sectionFn: () => {
+              return renderWithMessages(
+                [
+                  {
+                    line: 9,
+                    message: 'Third party library detected',
+                    description: ['This add-on may require additional review.'],
+                    type: 'warning',
+                  },
+                  {
+                    line: 24,
+                    message: 'Unsafe call to console.log()',
+                    description: [
+                      'Calling console.log() like this is unsafe but not really.',
+                    ],
+                    type: 'error',
+                  },
+                ],
+                { diffs: parseDiff(diffWithDeletions) },
+              );
+            },
+          },
         ],
       },
     ],


### PR DESCRIPTION
This implements inline linter messages which is the final part to fix https://github.com/mozilla/addons-code-manager/issues/314

In http://localhost:3000/en-US/compare/494431/versions/1532144...1532144/ you can click on `common.js` to see an inline message.

Example from storybook:

<img width="846" alt="Screenshot 2019-03-19 10 05 36" src="https://user-images.githubusercontent.com/55398/54617007-90cfcf80-4a2e-11e9-9e06-8e47c019b6e2.png">


