### PR TITLE
Add icon/title for known JS files

### DIFF
--- a/src/components/FileTreeNode/index.spec.tsx
+++ b/src/components/FileTreeNode/index.spec.tsx
@@ -612,6 +612,22 @@ describe(__filename, () => {
       expect(isKnownLibrary(map, path)).toEqual(false);
     });
 
+    it('returns false when another path is a known library', () => {
+      const path = 'jquery.js';
+      const messages = [
+        {
+          ...fakeExternalLinterMessage,
+          file: path,
+          id: [LINTER_KNOWN_LIBRARY_CODE],
+          line: null,
+          type: 'notice',
+        },
+      ] as ExternalLinterMessage[];
+      const map = _getMessageMap(messages);
+
+      expect(isKnownLibrary(map, 'not-the-same-path')).toEqual(false);
+    });
+
     it('returns true when a path is a known library', () => {
       const path = 'jquery.js';
       const messages = [
@@ -626,6 +642,29 @@ describe(__filename, () => {
       const map = _getMessageMap(messages);
 
       expect(isKnownLibrary(map, path)).toEqual(true);
+    });
+
+    it('throws an error if an extra key is found in the linter message map', () => {
+      const path = 'jquery.js';
+      const messages = [
+        {
+          ...fakeExternalLinterMessage,
+          file: path,
+          id: [LINTER_KNOWN_LIBRARY_CODE],
+          line: null,
+          type: 'notice',
+        },
+      ] as ExternalLinterMessage[];
+      const map = _getMessageMap(messages);
+
+      const unexpectedKey = 'future';
+      // Artifically inject a new key in the message map.
+      // @ts-ignore
+      map[path][unexpectedKey] = {};
+
+      expect(() => {
+        isKnownLibrary(map, path);
+      }).toThrow(new RegExp(`Unexpected key "${unexpectedKey}" found`));
     });
   });
 });

--- a/src/components/FileTreeNode/index.spec.tsx
+++ b/src/components/FileTreeNode/index.spec.tsx
@@ -14,7 +14,12 @@ import {
 } from '../../test-helpers';
 import styles from './styles.module.scss';
 
-import FileTreeNode, { PublicProps, findMostSevereTypeForPath } from '.';
+import FileTreeNode, {
+  LINTER_KNOWN_LIBRARY_CODE,
+  PublicProps,
+  findMostSevereTypeForPath,
+  isKnownLibrary,
+} from '.';
 
 const fakeGetToggleProps = () => ({
   onClick: jest.fn(),
@@ -97,9 +102,9 @@ describe(__filename, () => {
     });
   };
 
-  const renderWithLinterMessage = ({
+  const renderWithLinterMessages = ({
     version = createInternalVersion(fakeVersion),
-    message = fakeExternalLinterMessage,
+    messages = [fakeExternalLinterMessage],
     treefoldRenderProps = {},
   }) => {
     const renderProps = getTreefoldRenderProps({
@@ -108,7 +113,7 @@ describe(__filename, () => {
     });
 
     return renderWithLinterProvider({
-      messageMap: _getMessageMap([message]),
+      messageMap: _getMessageMap(messages),
       version,
       ...renderProps,
     });
@@ -274,9 +279,11 @@ describe(__filename, () => {
       type: type as ExternalLinterMessage['type'],
     };
 
-    const root = renderWithLinterMessage({
-      message,
-      treefoldRenderProps: { isFolder: false },
+    const root = renderWithLinterMessages({
+      messages: [message],
+      treefoldRenderProps: {
+        isFolder: false,
+      },
     });
 
     expect(root.find(className)).toHaveLength(1);
@@ -302,8 +309,8 @@ describe(__filename, () => {
         type: type as ExternalLinterMessage['type'],
       };
 
-      const root = renderWithLinterMessage({
-        message,
+      const root = renderWithLinterMessages({
+        messages: [message],
         treefoldRenderProps: {
           id: message.file,
           isFolder: true,
@@ -327,8 +334,8 @@ describe(__filename, () => {
       file: 'manifest.json',
     };
 
-    const root = renderWithLinterMessage({
-      message,
+    const root = renderWithLinterMessages({
+      messages: [message],
       treefoldRenderProps: {
         id: 'some/other/file.js',
       },
@@ -343,8 +350,8 @@ describe(__filename, () => {
       file: 'src/manifest.json',
     };
 
-    const root = renderWithLinterMessage({
-      message,
+    const root = renderWithLinterMessages({
+      messages: [message],
       treefoldRenderProps: {
         id: 'src/',
         isFolder: true,
@@ -352,6 +359,62 @@ describe(__filename, () => {
     });
 
     expect(root.find(`.${styles.hasLinterMessages}`)).toHaveLength(1);
+  });
+
+  it('renders a file node that is a known library', () => {
+    const message: ExternalLinterMessage = {
+      ...fakeExternalLinterMessage,
+      file: 'jquery.js',
+      id: [LINTER_KNOWN_LIBRARY_CODE],
+      line: null,
+      type: 'notice',
+    };
+
+    const root = renderWithLinterMessages({
+      messages: [message],
+      treefoldRenderProps: {
+        id: message.file,
+        isFolder: false,
+      },
+    });
+
+    expect(root.find(`.${styles.isKnownLibrary}`)).toHaveLength(1);
+
+    const nodeIcons = root.find(`.${styles.nodeIcons}`);
+    expect(nodeIcons).toHaveLength(1);
+    expect(nodeIcons.find(FontAwesomeIcon)).toHaveProp('icon', 'check-circle');
+    expect(nodeIcons.find(FontAwesomeIcon).prop('title')).toMatch(
+      /known library/,
+    );
+  });
+
+  it('does not override a more severe type when a file node is a known library with several linter messages', () => {
+    const file = 'jquery.js';
+    const messages: ExternalLinterMessage[] = [
+      {
+        ...fakeExternalLinterMessage,
+        file,
+        id: [LINTER_KNOWN_LIBRARY_CODE],
+        line: null,
+        type: 'notice',
+      },
+      {
+        ...fakeExternalLinterMessage,
+        file,
+        type: 'error',
+      },
+    ];
+
+    const root = renderWithLinterMessages({
+      messages,
+      treefoldRenderProps: {
+        id: file,
+        isFolder: false,
+      },
+    });
+
+    expect(root.find(`.${styles.isKnownLibrary}`)).toHaveLength(0);
+    expect(root.find(`.${styles.hasLinterErrors}`)).toHaveLength(1);
   });
 
   describe('findMostSevereTypeForPath', () => {
@@ -463,5 +526,106 @@ describe(__filename, () => {
     const root = render({ version });
 
     expect(root.find(LinterProvider)).toHaveProp('version', version);
+  });
+
+  describe('isKnownLibrary', () => {
+    it('returns false when there is no linter message', () => {
+      const path = 'jquery.js';
+      const messages = [] as ExternalLinterMessage[];
+      const map = _getMessageMap(messages);
+
+      expect(isKnownLibrary(map, path)).toEqual(false);
+    });
+
+    it('returns false when there is more than one global message', () => {
+      const path = 'jquery.js';
+      const messages = [
+        {
+          ...fakeExternalLinterMessage,
+          file: path,
+          id: [LINTER_KNOWN_LIBRARY_CODE],
+          line: null,
+          type: 'notice',
+        },
+        {
+          ...fakeExternalLinterMessage,
+          file: path,
+          line: null,
+          type: 'notice',
+        },
+      ] as ExternalLinterMessage[];
+      const map = _getMessageMap(messages);
+
+      expect(isKnownLibrary(map, path)).toEqual(false);
+    });
+
+    it('returns false when there are inlined linter messages', () => {
+      const path = 'jquery.js';
+      const messages = [
+        {
+          ...fakeExternalLinterMessage,
+          file: path,
+          id: [LINTER_KNOWN_LIBRARY_CODE],
+          line: null,
+          type: 'notice',
+        },
+        {
+          ...fakeExternalLinterMessage,
+          file: path,
+          line: 123,
+          type: 'notice',
+        },
+      ] as ExternalLinterMessage[];
+      const map = _getMessageMap(messages);
+
+      expect(isKnownLibrary(map, path)).toEqual(false);
+    });
+
+    it('returns false when there are only inlined linter messages', () => {
+      const path = 'jquery.js';
+      const messages = [
+        {
+          ...fakeExternalLinterMessage,
+          file: path,
+          line: 123,
+          type: 'notice',
+        },
+      ] as ExternalLinterMessage[];
+      const map = _getMessageMap(messages);
+
+      expect(isKnownLibrary(map, path)).toEqual(false);
+    });
+
+    it('returns false when a path is not a known library', () => {
+      const path = 'jquery.js';
+      const messages = [
+        {
+          ...fakeExternalLinterMessage,
+          file: path,
+          id: ['another_code'],
+          line: null,
+          type: 'notice',
+        },
+      ] as ExternalLinterMessage[];
+      const map = _getMessageMap(messages);
+
+      expect(isKnownLibrary(map, path)).toEqual(false);
+    });
+
+    it('returns true when a path is a known library', () => {
+      const path = 'jquery.js';
+      const messages = [
+        {
+          ...fakeExternalLinterMessage,
+          file: path,
+          id: [LINTER_KNOWN_LIBRARY_CODE],
+          line: null,
+          type: 'notice',
+        },
+      ] as ExternalLinterMessage[];
+      const map = _getMessageMap(messages);
+
+      expect(isKnownLibrary(map, path)).toEqual(true);
+    });
   });
 });

--- a/src/components/FileTreeNode/index.tsx
+++ b/src/components/FileTreeNode/index.tsx
@@ -60,7 +60,17 @@ export const isKnownLibrary = (
   }
 
   const m = linterMessageMap[path];
-  if (Object.keys(m.global).length > 1 || Object.keys(m.byLine).length > 0) {
+
+  // This is useful to make sure we do not miss linter messages if
+  // `LinterMessageMap` is updated with new maps of messages.
+  const allowedKeys = ['global', 'byLine'];
+  Object.keys(m).forEach((key) => {
+    if (!allowedKeys.includes(key)) {
+      throw new Error(`Unexpected key "${key}" found.`);
+    }
+  });
+
+  if (m.global.length > 1 || Object.keys(m.byLine).length > 0) {
     return false;
   }
 

--- a/src/components/FileTreeNode/index.tsx
+++ b/src/components/FileTreeNode/index.tsx
@@ -49,6 +49,24 @@ export const findMostSevereTypeForPath = (
   return null;
 };
 
+export const LINTER_KNOWN_LIBRARY_CODE = 'KNOWN_LIBRARY';
+
+export const isKnownLibrary = (
+  linterMessageMap: LinterMessageMap,
+  path: string,
+): boolean => {
+  if (!linterMessageMap[path]) {
+    return false;
+  }
+
+  const m = linterMessageMap[path];
+  if (Object.keys(m.global).length > 1 || Object.keys(m.byLine).length > 0) {
+    return false;
+  }
+
+  return m.global[0].code.includes(LINTER_KNOWN_LIBRARY_CODE);
+};
+
 const getTitleForType = (type: string | null, isFolder: boolean) => {
   switch (type) {
     case 'error':
@@ -72,6 +90,8 @@ const getIconForType = (type: string | null) => {
       return 'times-circle';
     case 'warning':
       return 'exclamation-triangle';
+    case 'known-library':
+      return 'check-circle';
     default:
       return 'info-circle';
   }
@@ -98,14 +118,18 @@ class FileTreeNodeBase<TreeNodeType> extends React.Component<PublicProps> {
     let nodeIcons = null;
     let linterType = null;
     if (messageMap && hasLinterMessages) {
-      linterType = findMostSevereTypeForPath(messageMap, node.id);
+      let title;
+      if (isKnownLibrary(messageMap, node.id)) {
+        linterType = 'known-library';
+        title = gettext('This is a known library');
+      } else {
+        linterType = findMostSevereTypeForPath(messageMap, node.id);
+        title = getTitleForType(linterType, isFolder);
+      }
 
       nodeIcons = (
         <span className={styles.nodeIcons}>
-          <FontAwesomeIcon
-            icon={getIconForType(linterType)}
-            title={getTitleForType(linterType, isFolder)}
-          />
+          <FontAwesomeIcon icon={getIconForType(linterType)} title={title} />
         </span>
       );
     }
@@ -117,6 +141,7 @@ class FileTreeNodeBase<TreeNodeType> extends React.Component<PublicProps> {
         [styles.hasLinterMessages]: hasLinterMessages,
         [styles.hasLinterErrors]: linterType === 'error',
         [styles.hasLinterWarnings]: linterType === 'warning',
+        [styles.isKnownLibrary]: linterType === 'known-library',
       }),
       onClick: () => onSelect(node.id),
     };

--- a/src/components/FileTreeNode/styles.module.scss
+++ b/src/components/FileTreeNode/styles.module.scss
@@ -49,3 +49,7 @@
     color: $orange;
   }
 }
+
+.isKnownLibrary {
+  color: lighten($black, 50);
+}

--- a/src/pages/Index/index.tsx
+++ b/src/pages/Index/index.tsx
@@ -10,7 +10,7 @@ export class IndexBase extends React.Component<PublicProps> {
       <Col>
         <p>
           There is nothing you can do here, but try{' '}
-          <Link to="/en-US/browse/502955/versions/1541798/">
+          <Link to="/en-US/browse/494431/versions/1532144/">
             browsing this add-on version
           </Link>{' '}
           or{' '}

--- a/src/reducers/linter.spec.tsx
+++ b/src/reducers/linter.spec.tsx
@@ -367,6 +367,7 @@ describe(__filename, () => {
     });
 
     it('maps a subset of external fields', () => {
+      const id = ['SOME_CODE'];
       const column = 2;
       const description = ['To prevent vulnerabilities...'];
       const file = 'chrome/content/youtune.js';
@@ -378,6 +379,7 @@ describe(__filename, () => {
       expect(
         createInternalMessage({
           ...fakeExternalLinterMessage,
+          id,
           column,
           description,
           file,
@@ -387,6 +389,7 @@ describe(__filename, () => {
           uid,
         }),
       ).toEqual({
+        code: id,
         column,
         description,
         file,

--- a/src/reducers/linter.tsx
+++ b/src/reducers/linter.tsx
@@ -14,6 +14,8 @@ type LinterMessageBase = {
 };
 
 export type LinterMessage = LinterMessageBase & {
+  // See: https://github.com/mozilla/addons-linter/blob/dfbc613cbbae4e7e3cf6dc1bdbea120a5de105af/docs/rules.md
+  code: string[];
   description: string[];
 };
 
@@ -48,6 +50,7 @@ export const createInternalMessage = (
   message: ExternalLinterMessage,
 ): LinterMessage => {
   return {
+    code: message.id,
     column: message.column,
     description: Array.isArray(message.description)
       ? message.description

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -135,7 +135,7 @@ export const fakeExternalLinterMessage = Object.freeze({
   for_appversions: {
     '{ec8030f7-c20a-464f-9b0e-13a3a9e97384}': ['4.0b1'],
   },
-  id: [],
+  id: ['UNSAFE_VAR_ASSIGNMENT'],
   line: 226,
   message: 'on* attribute being set using setAttribute',
   tier: 3,


### PR DESCRIPTION
Fixes #115
~~:warning: depends on #401~~

---

This patch adds style/visual indication for file that are known (js) libraries.

You can also try this addon/version: http://localhost:3000/en-US/browse/502914/versions/1541734/

## Screenshot

![Screen Shot 2019-03-25 at 12 06 43](https://user-images.githubusercontent.com/217628/54915090-ae051200-4ef6-11e9-8a6d-4af996f24570.png)

![Screen Shot 2019-03-25 at 12 15 50](https://user-images.githubusercontent.com/217628/54915729-1ef8f980-4ef8-11e9-9441-192333706f24.png)

![Screen Shot 2019-03-25 at 12 15 42](https://user-images.githubusercontent.com/217628/54915730-1ef8f980-4ef8-11e9-8140-94097f7fc1b0.png)

![Screen Shot 2019-03-25 at 12 06 43](https://user-images.githubusercontent.com/217628/54915731-1ef8f980-4ef8-11e9-9310-dc0c7c7f47ef.png)
