### PR TITLE
Add code/id linter message in redux

### DIFF
--- a/src/reducers/linter.spec.tsx
+++ b/src/reducers/linter.spec.tsx
@@ -367,6 +367,7 @@ describe(__filename, () => {
     });
 
     it('maps a subset of external fields', () => {
+      const id = ['SOME_CODE'];
       const column = 2;
       const description = ['To prevent vulnerabilities...'];
       const file = 'chrome/content/youtune.js';
@@ -378,6 +379,7 @@ describe(__filename, () => {
       expect(
         createInternalMessage({
           ...fakeExternalLinterMessage,
+          id,
           column,
           description,
           file,
@@ -387,6 +389,7 @@ describe(__filename, () => {
           uid,
         }),
       ).toEqual({
+        code: id,
         column,
         description,
         file,

--- a/src/reducers/linter.tsx
+++ b/src/reducers/linter.tsx
@@ -14,6 +14,8 @@ type LinterMessageBase = {
 };
 
 export type LinterMessage = LinterMessageBase & {
+  // See: https://github.com/mozilla/addons-linter/blob/dfbc613cbbae4e7e3cf6dc1bdbea120a5de105af/docs/rules.md
+  code: string[];
   description: string[];
 };
 
@@ -48,6 +50,7 @@ export const createInternalMessage = (
   message: ExternalLinterMessage,
 ): LinterMessage => {
   return {
+    code: message.id,
     column: message.column,
     description: Array.isArray(message.description)
       ? message.description


### PR DESCRIPTION
I went for `code` instead of `id` in the internal message type because
`id` is very close to `uid` but not unique, and `code` is also used in
the addons-linter.