### PR TITLE
Expose download URL

### DIFF
--- a/src/components/FileMetadata/index.spec.tsx
+++ b/src/components/FileMetadata/index.spec.tsx
@@ -42,6 +42,9 @@ describe(__filename, () => {
     expect(root.find(`.${styles.version}`)).toHaveText(file.version);
     expect(root.find(`.${styles.sha256}`)).toHaveText(file.sha256);
     expect(root.find(`.${styles.mimeType}`)).toHaveText(file.mimeType);
+    expect(root.find(`.${styles.downloadURL}`).html()).toContain(
+      `<a href="${file.downloadURL}">${file.filename}</a>`,
+    );
   });
 
   it('renders a formatted filesize', () => {

--- a/src/components/FileMetadata/index.spec.tsx
+++ b/src/components/FileMetadata/index.spec.tsx
@@ -41,10 +41,11 @@ describe(__filename, () => {
 
     expect(root.find(`.${styles.version}`)).toHaveText(file.version);
     expect(root.find(`.${styles.sha256}`)).toHaveText(file.sha256);
-    expect(root.find(`.${styles.mimeType}`)).toHaveText(file.mimeType);
-    expect(root.find(`.${styles.downloadURL}`).html()).toContain(
-      `<a href="${file.downloadURL}">${file.filename}</a>`,
-    );
+
+    const downloadLink = root.find(`.${styles.downloadURL}`).find('a');
+    expect(downloadLink).toHaveLength(1);
+    expect(downloadLink).toHaveText(file.filename);
+    expect(downloadLink).toHaveProp('href', file.downloadURL);
   });
 
   it('renders a formatted filesize', () => {

--- a/src/components/FileMetadata/index.tsx
+++ b/src/components/FileMetadata/index.tsx
@@ -24,6 +24,14 @@ const FileMetadataBase = ({ file }: PublicProps) => {
         </dd>
         <dt>{gettext('MIME type')}</dt>
         <dd className={styles.mimeType}>{file.mimeType}</dd>
+        {file.downloadURL && (
+          <React.Fragment>
+            <dt>{gettext('Download link')}</dt>
+            <dd className={styles.downloadURL}>
+              <a href={file.downloadURL}>{file.filename}</a>
+            </dd>
+          </React.Fragment>
+        )}
       </dl>
     </div>
   );

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -292,6 +292,7 @@ describe(__filename, () => {
   describe('getVersionFile', () => {
     /* eslint-disable @typescript-eslint/camelcase */
     it('returns a version file', () => {
+      const downloadURL = 'http://example.org/download/file';
       const mimeType = 'mime/type';
       const path = 'test.js';
       const sha256 = 'some-sha';
@@ -301,6 +302,7 @@ describe(__filename, () => {
         ...fakeVersion,
         file: {
           ...fakeVersionFile,
+          download_url: downloadURL,
           entries: {
             [path]: {
               ...fakeVersionEntry,
@@ -320,6 +322,7 @@ describe(__filename, () => {
 
       expect(getVersionFile(state, version.id, path)).toEqual({
         ...createInternalVersionFile(version.file),
+        downloadURL,
         filename: path,
         mimeType,
         sha256,

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -37,6 +37,7 @@ export type ExternalVersionEntry = {
 
 type PartialExternalVersionFile = {
   created: string;
+  download_url: string | null;
   entries: {
     [nodeName: string]: ExternalVersionEntry;
   };
@@ -129,6 +130,7 @@ export type ExternalVersionWithDiff = PartialExternalVersion & {
 type InternalVersionFile = {
   content: string;
   created: string;
+  downloadURL: string | null;
   id: number;
   size: number;
 };
@@ -136,6 +138,7 @@ type InternalVersionFile = {
 export type VersionFile = {
   content: string;
   created: string;
+  downloadURL: string | null;
   filename: string;
   id: number;
   mimeType: string;
@@ -256,6 +259,7 @@ export const createInternalVersionFile = (
   return {
     content: file.content,
     created: file.created,
+    downloadURL: file.download_url,
     id: file.id,
     size: file.size,
   };

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -41,6 +41,7 @@ export const fakeVersionEntry: ExternalVersionEntry = Object.freeze({
 export const fakeVersionFile: ExternalVersionFileWithContent = Object.freeze({
   content: 'some file content',
   created: '2017-08-15T12:01:13Z',
+  download_url: 'https://example.org/download/manifest.json',
   entries: {
     'manifest.json': fakeVersionEntry,
   },


### PR DESCRIPTION
Fixes #353
Fixes #348 

---

This is not working because the API returns a link that requires authentication, but the UI is there. I believe the API will be fixed to return a link that works. If not, we could add some server code to fix the links in this project, but that can be done in a follow-up.

## Screenshot

![Screen Shot 2019-03-21 at 16 30 29](https://user-images.githubusercontent.com/217628/54763668-abed3b80-4bf6-11e9-8ec7-a3836b9d23d3.png)

