### PR TITLE
Add a simple error handling

### DIFF
--- a/src/components/App/index.spec.tsx
+++ b/src/components/App/index.spec.tsx
@@ -185,22 +185,27 @@ describe(__filename, () => {
   });
 
   it('dispatches removeError() when dismissing an error', () => {
-    const error = new Error('version not found');
+    const error1 = new Error('first error');
+    const error2 = new Error('second error');
     const store = configureStore();
-    store.dispatch(errorsActions.addError({ error }));
+    store.dispatch(errorsActions.addError({ error: error1 }));
+    store.dispatch(errorsActions.addError({ error: error2 }));
     const dispatch = spyOn(store, 'dispatch');
 
     const root = render({ store });
 
-    const onClose = root.find(Alert).prop('onClose') as Function;
-    // User clicks the "close" button (it is a cross).
+    // User clicks the "close" button of the first error shown.
+    const onClose = root
+      .find(Alert)
+      .at(0)
+      .prop('onClose') as Function;
     onClose();
 
     const { errors } = store.getState().errors;
-    const lastError = errors[errors.length - 1];
+    const firstError = errors[0];
     expect(dispatch).toHaveBeenCalledWith(
       errorsActions.removeError({
-        id: lastError.id,
+        id: firstError.id,
       }),
     );
   });

--- a/src/components/App/index.spec.tsx
+++ b/src/components/App/index.spec.tsx
@@ -173,8 +173,8 @@ describe(__filename, () => {
     const error1 = new Error('error 1');
     const error2 = new Error('error 2');
     const store = configureStore();
-    store.dispatch(errorsActions.showError({ error: error1 }));
-    store.dispatch(errorsActions.showError({ error: error2 }));
+    store.dispatch(errorsActions.addError({ error: error1 }));
+    store.dispatch(errorsActions.addError({ error: error2 }));
 
     const root = render({ store });
 
@@ -184,10 +184,10 @@ describe(__filename, () => {
     expect(root.find(Alert).at(1)).toIncludeText(error2.message);
   });
 
-  it('dispatches dismissError() when dismissing an error', () => {
+  it('dispatches removeError() when dismissing an error', () => {
     const error = new Error('version not found');
     const store = configureStore();
-    store.dispatch(errorsActions.showError({ error }));
+    store.dispatch(errorsActions.addError({ error }));
     const dispatch = spyOn(store, 'dispatch');
 
     const root = render({ store });
@@ -199,7 +199,7 @@ describe(__filename, () => {
     const { errors } = store.getState().errors;
     const lastError = errors[errors.length - 1];
     expect(dispatch).toHaveBeenCalledWith(
-      errorsActions.dismissError({
+      errorsActions.removeError({
         id: lastError.id,
       }),
     );

--- a/src/components/App/index.spec.tsx
+++ b/src/components/App/index.spec.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Container } from 'react-bootstrap';
+import { Alert, Container } from 'react-bootstrap';
 import { Store } from 'redux';
 import { Route } from 'react-router-dom';
 
 import styles from './styles.module.scss';
 import configureStore from '../../configureStore';
 import { actions as apiActions } from '../../reducers/api';
+import { actions as errorsActions } from '../../reducers/errors';
 import { actions as userActions } from '../../reducers/users';
 import {
   createContextWithFakeRouter,
@@ -160,5 +161,47 @@ describe(__filename, () => {
     root.setProps({ apiState, dispatch });
 
     expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('does not render application errors when there is no error', () => {
+    const root = render();
+
+    expect(root.find(`.${styles.errors}`)).toHaveLength(0);
+  });
+
+  it('renders application errors', () => {
+    const error1 = new Error('error 1');
+    const error2 = new Error('error 2');
+    const store = configureStore();
+    store.dispatch(errorsActions.showError({ error: error1 }));
+    store.dispatch(errorsActions.showError({ error: error2 }));
+
+    const root = render({ store });
+
+    expect(root.find(`.${styles.errors}`)).toHaveLength(1);
+    expect(root.find(Alert)).toHaveLength(2);
+    expect(root.find(Alert).at(0)).toIncludeText(error1.message);
+    expect(root.find(Alert).at(1)).toIncludeText(error2.message);
+  });
+
+  it('dispatches dismissError() when dismissing an error', () => {
+    const error = new Error('version not found');
+    const store = configureStore();
+    store.dispatch(errorsActions.showError({ error }));
+    const dispatch = spyOn(store, 'dispatch');
+
+    const root = render({ store });
+
+    const onClose = root.find(Alert).prop('onClose') as Function;
+    // User clicks the "close" button (it is a cross).
+    onClose();
+
+    const { errors } = store.getState().errors;
+    const lastError = errors[errors.length - 1];
+    expect(dispatch).toHaveBeenCalledWith(
+      errorsActions.dismissError({
+        id: lastError.id,
+      }),
+    );
   });
 });

--- a/src/components/App/index.spec.tsx
+++ b/src/components/App/index.spec.tsx
@@ -178,7 +178,6 @@ describe(__filename, () => {
 
     const root = render({ store });
 
-    expect(root.find(`.${styles.errors}`)).toHaveLength(1);
     expect(root.find(Alert)).toHaveLength(2);
     expect(root.find(Alert).at(0)).toIncludeText(error1.message);
     expect(root.find(Alert).at(1)).toIncludeText(error2.message);

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Container, Row } from 'react-bootstrap';
+import { Alert, Container, Col, Row } from 'react-bootstrap';
 import {
   Route,
   RouteComponentProps,
@@ -14,6 +14,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
 import styles from './styles.module.scss';
 import { ApiState, actions as apiActions } from '../../reducers/api';
+import {
+  ApplicationError,
+  actions as errorsActions,
+} from '../../reducers/errors';
 import {
   User,
   currentUserIsLoading,
@@ -38,6 +42,7 @@ export type DefaultProps = {
 
 type PropsFromState = {
   apiState: ApiState;
+  errors: ApplicationError[];
   loading: boolean;
   user: User | null;
 };
@@ -122,6 +127,38 @@ export class AppBase extends React.Component<Props> {
     });
   }
 
+  dismissError = (errorId: number) => {
+    const { dispatch } = this.props;
+
+    dispatch(errorsActions.dismissError({ id: errorId }));
+  };
+
+  renderErrors() {
+    const { errors } = this.props;
+
+    if (errors.length === 0) {
+      return null;
+    }
+
+    return this.renderRow(
+      <Col>
+        {errors.map((error) => (
+          <Alert
+            dismissible
+            key={error.id}
+            onClose={() => this.dismissError(error.id)}
+            variant="danger"
+          >
+            {error.message}
+          </Alert>
+        ))}
+      </Col>,
+      {
+        className: styles.errors,
+      },
+    );
+  }
+
   render() {
     const { loading } = this.props;
 
@@ -129,6 +166,7 @@ export class AppBase extends React.Component<Props> {
       <React.Fragment>
         {!loading && <Navbar />}
         <Container className={styles.container} fluid>
+          {this.renderErrors()}
           {this.renderContent()}
         </Container>
       </React.Fragment>
@@ -139,6 +177,7 @@ export class AppBase extends React.Component<Props> {
 const mapStateToProps = (state: ApplicationState): PropsFromState => {
   return {
     apiState: state.api,
+    errors: state.errors.errors,
     loading: currentUserIsLoading(state.users),
     user: selectCurrentUser(state.users),
   };

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -127,10 +127,10 @@ export class AppBase extends React.Component<Props> {
     });
   }
 
-  dismissError = (errorId: number) => {
+  removeError = (errorId: number) => {
     const { dispatch } = this.props;
 
-    dispatch(errorsActions.dismissError({ id: errorId }));
+    dispatch(errorsActions.removeError({ id: errorId }));
   };
 
   renderErrors() {
@@ -146,7 +146,7 @@ export class AppBase extends React.Component<Props> {
           <Alert
             dismissible
             key={error.id}
-            onClose={() => this.dismissError(error.id)}
+            onClose={() => this.removeError(error.id)}
             variant="danger"
           >
             {error.message}

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -127,7 +127,7 @@ export class AppBase extends React.Component<Props> {
     });
   }
 
-  removeError = (errorId: number) => {
+  dismissError = (errorId: number) => {
     const { dispatch } = this.props;
 
     dispatch(errorsActions.removeError({ id: errorId }));
@@ -146,7 +146,7 @@ export class AppBase extends React.Component<Props> {
           <Alert
             dismissible
             key={error.id}
-            onClose={() => this.removeError(error.id)}
+            onClose={() => this.dismissError(error.id)}
             variant="danger"
           >
             {error.message}

--- a/src/components/App/styles.module.scss
+++ b/src/components/App/styles.module.scss
@@ -1,8 +1,4 @@
 .container {
-}
-
-.content {
-  min-height: 100vh;
   padding-top: 15px;
 }
 
@@ -14,6 +10,7 @@
   font-size: 1.2em;
   font-weight: 500;
   justify-content: center;
+  min-height: 100vh;
   text-align: center;
 
   p {

--- a/src/configureStore.spec.tsx
+++ b/src/configureStore.spec.tsx
@@ -6,6 +6,7 @@ describe(__filename, () => {
 
     expect(Object.keys(store.getState())).toEqual([
       'api',
+      'errors',
       'linter',
       'users',
       'versions',

--- a/src/configureStore.tsx
+++ b/src/configureStore.tsx
@@ -16,12 +16,14 @@ import thunk, {
 } from 'redux-thunk';
 
 import api, { ApiState } from './reducers/api';
+import errors, { ErrorsState } from './reducers/errors';
 import linter, { LinterState } from './reducers/linter';
 import users, { UsersState } from './reducers/users';
 import versions, { VersionsState } from './reducers/versions';
 
 export type ApplicationState = {
   api: ApiState;
+  errors: ErrorsState;
   linter: LinterState;
   users: UsersState;
   versions: VersionsState;
@@ -45,7 +47,13 @@ export type ConnectedReduxProps<A extends Action = AnyAction> = {
 };
 
 const createRootReducer = () => {
-  return combineReducers<ApplicationState>({ api, linter, users, versions });
+  return combineReducers<ApplicationState>({
+    api,
+    errors,
+    linter,
+    users,
+    versions,
+  });
 };
 
 const configureStore = (

--- a/src/pages/Index/index.tsx
+++ b/src/pages/Index/index.tsx
@@ -12,10 +12,14 @@ export class IndexBase extends React.Component<PublicProps> {
           There is nothing you can do here, but try{' '}
           <Link to="/en-US/browse/494431/versions/1532144/">
             browsing this add-on version
-          </Link>{' '}
-          or{' '}
+          </Link>
+          {', '}
           <Link to="/en-US/compare/502955/versions/1541794...1541798/">
-            look at this compare view.
+            look at this compare view
+          </Link>{' '}
+          or go to this{' '}
+          <Link to="/en-US/browse/502955/versions/1000000/">
+            page that will generate an error.
           </Link>
         </p>
       </Col>

--- a/src/reducers/errors.spec.tsx
+++ b/src/reducers/errors.spec.tsx
@@ -6,7 +6,7 @@ describe(__filename, () => {
       const message = 'oops, I am an error';
       const error = new Error(message);
 
-      const state = reducer(undefined, actions.showError({ error }));
+      const state = reducer(undefined, actions.addError({ error }));
 
       expect(state).toMatchObject({
         errors: [{ id: initialState.nextErrorId, message }],
@@ -16,7 +16,7 @@ describe(__filename, () => {
     it('increments the next error ID when storing a new error', () => {
       let state = reducer(
         undefined,
-        actions.showError({ error: new Error('Bad Request') }),
+        actions.addError({ error: new Error('Bad Request') }),
       );
       expect(state).toMatchObject({
         nextErrorId: initialState.nextErrorId + 1,
@@ -24,17 +24,17 @@ describe(__filename, () => {
 
       state = reducer(
         state,
-        actions.showError({ error: new Error('Bad Request, again') }),
+        actions.addError({ error: new Error('Bad Request, again') }),
       );
       expect(state).toMatchObject({
         nextErrorId: initialState.nextErrorId + 2,
       });
     });
 
-    it('removes an error when dismissed', () => {
+    it('removes an error', () => {
       let state = reducer(
         undefined,
-        actions.showError({ error: new Error('Bad Request') }),
+        actions.addError({ error: new Error('Bad Request') }),
       );
 
       expect(state.errors.length).toEqual(1);
@@ -42,25 +42,25 @@ describe(__filename, () => {
       const { errors } = state;
       const lastError = errors[errors.length - 1];
 
-      state = reducer(state, actions.dismissError({ id: lastError.id }));
+      state = reducer(state, actions.removeError({ id: lastError.id }));
       expect(state.errors.length).toEqual(0);
     });
 
-    it('does not remove other errors when one is dismissed', () => {
+    it('does not remove other errors when one error is removed', () => {
       let state = reducer(
         undefined,
-        actions.showError({ error: new Error('Bad Request') }),
+        actions.addError({ error: new Error('Bad Request') }),
       );
 
       const error2 = new Error('Bad Request, again');
-      state = reducer(state, actions.showError({ error: error2 }));
+      state = reducer(state, actions.addError({ error: error2 }));
 
       expect(state.errors.length).toEqual(2);
 
       const { errors } = state;
       const firstError = errors[0];
 
-      state = reducer(state, actions.dismissError({ id: firstError.id }));
+      state = reducer(state, actions.removeError({ id: firstError.id }));
       expect(state.errors).toEqual([
         {
           id: expect.any(Number),
@@ -69,15 +69,15 @@ describe(__filename, () => {
       ]);
     });
 
-    it('does not update the next error ID when dismissing an error', () => {
+    it('does not update the next error ID when removing an error', () => {
       const prevState = reducer(
         undefined,
-        actions.showError({ error: new Error('Bad Request') }),
+        actions.addError({ error: new Error('Bad Request') }),
       );
 
       const newState = reducer(
         prevState,
-        actions.dismissError({ id: prevState.errors[0].id }),
+        actions.removeError({ id: prevState.errors[0].id }),
       );
 
       expect(newState).toMatchObject({ nextErrorId: prevState.nextErrorId });

--- a/src/reducers/errors.spec.tsx
+++ b/src/reducers/errors.spec.tsx
@@ -1,0 +1,63 @@
+import reducer, { actions, initialState } from './errors';
+
+describe(__filename, () => {
+  describe('reducer', () => {
+    it('stores an error to show', () => {
+      const message = 'oops, I am an error';
+      const error = new Error(message);
+
+      const state = reducer(undefined, actions.showError({ error }));
+
+      expect(state).toMatchObject({
+        errors: [{ id: initialState.nextErrorId, message }],
+      });
+    });
+
+    it('increments the next error ID when storing a new error', () => {
+      let state = reducer(
+        undefined,
+        actions.showError({ error: new Error('Bad Request') }),
+      );
+      expect(state).toMatchObject({
+        nextErrorId: initialState.nextErrorId + 1,
+      });
+
+      state = reducer(
+        state,
+        actions.showError({ error: new Error('Bad Request, again') }),
+      );
+      expect(state).toMatchObject({
+        nextErrorId: initialState.nextErrorId + 2,
+      });
+    });
+
+    it('removes an error when dismissed', () => {
+      let state = reducer(
+        undefined,
+        actions.showError({ error: new Error('Bad Request') }),
+      );
+
+      expect(state.errors.length).toEqual(1);
+
+      const { errors } = state;
+      const lastError = errors[errors.length - 1];
+
+      state = reducer(state, actions.dismissError({ id: lastError.id }));
+      expect(state.errors.length).toEqual(0);
+    });
+
+    it('does not update the next error ID when dismissing an error', () => {
+      const prevState = reducer(
+        undefined,
+        actions.showError({ error: new Error('Bad Request') }),
+      );
+
+      const newState = reducer(
+        prevState,
+        actions.dismissError({ id: prevState.errors[0].id }),
+      );
+
+      expect(newState).toMatchObject({ nextErrorId: prevState.nextErrorId });
+    });
+  });
+});

--- a/src/reducers/errors.spec.tsx
+++ b/src/reducers/errors.spec.tsx
@@ -46,6 +46,29 @@ describe(__filename, () => {
       expect(state.errors.length).toEqual(0);
     });
 
+    it('does not remove other errors when one is dismissed', () => {
+      let state = reducer(
+        undefined,
+        actions.showError({ error: new Error('Bad Request') }),
+      );
+
+      const error2 = new Error('Bad Request, again');
+      state = reducer(state, actions.showError({ error: error2 }));
+
+      expect(state.errors.length).toEqual(2);
+
+      const { errors } = state;
+      const firstError = errors[0];
+
+      state = reducer(state, actions.dismissError({ id: firstError.id }));
+      expect(state.errors).toEqual([
+        {
+          id: expect.any(Number),
+          message: error2.message,
+        },
+      ]);
+    });
+
     it('does not update the next error ID when dismissing an error', () => {
       const prevState = reducer(
         undefined,

--- a/src/reducers/errors.spec.tsx
+++ b/src/reducers/errors.spec.tsx
@@ -68,19 +68,5 @@ describe(__filename, () => {
         },
       ]);
     });
-
-    it('does not update the next error ID when removing an error', () => {
-      const prevState = reducer(
-        undefined,
-        actions.addError({ error: new Error('Bad Request') }),
-      );
-
-      const newState = reducer(
-        prevState,
-        actions.removeError({ id: prevState.errors[0].id }),
-      );
-
-      expect(newState).toMatchObject({ nextErrorId: prevState.nextErrorId });
-    });
   });
 });

--- a/src/reducers/errors.tsx
+++ b/src/reducers/errors.tsx
@@ -1,0 +1,53 @@
+import { Reducer } from 'redux';
+import { ActionType, createAction, getType } from 'typesafe-actions';
+
+export type ApplicationError = {
+  id: number;
+  message: string;
+};
+
+export type ErrorsState = {
+  errors: ApplicationError[];
+  nextErrorId: number;
+};
+
+export const initialState: ErrorsState = {
+  errors: [],
+  // This is a sequence to give each error a unique ID.
+  nextErrorId: 1,
+};
+
+export const actions = {
+  showError: createAction('SHOW_ERROR', (resolve) => {
+    return (payload: { error: Error }) => resolve(payload);
+  }),
+  dismissError: createAction('DISMISS_ERROR', (resolve) => {
+    return (payload: { id: number }) => resolve(payload);
+  }),
+};
+
+const reducer: Reducer<ErrorsState, ActionType<typeof actions>> = (
+  state = initialState,
+  action,
+): ErrorsState => {
+  switch (action.type) {
+    case getType(actions.showError):
+      return {
+        ...state,
+        errors: state.errors.concat({
+          id: state.nextErrorId,
+          message: action.payload.error.message,
+        }),
+        nextErrorId: state.nextErrorId + 1,
+      };
+    case getType(actions.dismissError):
+      return {
+        ...state,
+        errors: state.errors.filter(({ id }) => id !== action.payload.id),
+      };
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/src/reducers/errors.tsx
+++ b/src/reducers/errors.tsx
@@ -18,10 +18,10 @@ export const initialState: ErrorsState = {
 };
 
 export const actions = {
-  showError: createAction('SHOW_ERROR', (resolve) => {
+  addError: createAction('ADD_ERROR', (resolve) => {
     return (payload: { error: Error }) => resolve(payload);
   }),
-  dismissError: createAction('DISMISS_ERROR', (resolve) => {
+  removeError: createAction('REMOVE_ERROR', (resolve) => {
     return (payload: { id: number }) => resolve(payload);
   }),
 };
@@ -31,7 +31,7 @@ const reducer: Reducer<ErrorsState, ActionType<typeof actions>> = (
   action,
 ): ErrorsState => {
   switch (action.type) {
-    case getType(actions.showError):
+    case getType(actions.addError):
       return {
         ...state,
         errors: state.errors.concat({
@@ -40,7 +40,7 @@ const reducer: Reducer<ErrorsState, ActionType<typeof actions>> = (
         }),
         nextErrorId: state.nextErrorId + 1,
       };
-    case getType(actions.dismissError):
+    case getType(actions.removeError):
       return {
         ...state,
         errors: state.errors.filter(({ id }) => id !== action.payload.id),

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -1,5 +1,6 @@
 import { getType } from 'typesafe-actions';
 
+import { actions as errorsActions } from './errors';
 import reducer, {
   ExternalVersionWithDiff,
   ExternalVersionsList,
@@ -500,14 +501,9 @@ describe(__filename, () => {
       );
     });
 
-    it('logs an error when API response is not successful', async () => {
-      const _log = createFakeLogger();
-
-      const _getVersion = jest.fn().mockReturnValue(
-        Promise.resolve({
-          error: new Error('Bad Request'),
-        }),
-      );
+    it('dispatches showError when API response is not successful', async () => {
+      const error = new Error('Bad Request');
+      const _getVersion = jest.fn().mockReturnValue(Promise.resolve({ error }));
 
       const addonId = 123;
       const versionId = 456;
@@ -516,7 +512,6 @@ describe(__filename, () => {
         createThunk: () =>
           fetchVersion({
             _getVersion,
-            _log,
             addonId,
             versionId,
           }),
@@ -524,8 +519,7 @@ describe(__filename, () => {
 
       await thunk();
 
-      expect(_log.error).toHaveBeenCalled();
-      expect(dispatch).not.toHaveBeenCalled();
+      expect(dispatch).toHaveBeenCalledWith(errorsActions.showError({ error }));
     });
   });
 

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -501,7 +501,7 @@ describe(__filename, () => {
       );
     });
 
-    it('dispatches showError when API response is not successful', async () => {
+    it('dispatches addError when API response is not successful', async () => {
       const error = new Error('Bad Request');
       const _getVersion = jest.fn().mockReturnValue(Promise.resolve({ error }));
 
@@ -519,7 +519,7 @@ describe(__filename, () => {
 
       await thunk();
 
-      expect(dispatch).toHaveBeenCalledWith(errorsActions.showError({ error }));
+      expect(dispatch).toHaveBeenCalledWith(errorsActions.addError({ error }));
     });
   });
 

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -373,7 +373,7 @@ export const fetchVersion = ({
     });
 
     if (isErrorResponse(response)) {
-      dispatch(errorsActions.showError({ error: response.error }));
+      dispatch(errorsActions.addError({ error: response.error }));
     } else {
       dispatch(actions.loadVersionInfo({ version: response }));
       dispatch(

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -6,6 +6,7 @@ import { DiffInfo, DiffInfoType } from 'react-diff-view';
 import { ThunkActionCreator } from '../configureStore';
 import { getDiff, getVersion, getVersionsList, isErrorResponse } from '../api';
 import { LocalizedStringMap } from '../utils';
+import { actions as errorsActions } from './errors';
 
 type VersionCompatibility = {
   [appName: string]: {
@@ -359,7 +360,6 @@ type FetchVersionParams = {
 
 export const fetchVersion = ({
   _getVersion = getVersion,
-  _log = log,
   addonId,
   versionId,
 }: FetchVersionParams): ThunkActionCreator => {
@@ -373,7 +373,7 @@ export const fetchVersion = ({
     });
 
     if (isErrorResponse(response)) {
-      _log.error(`TODO: handle this error response: ${response.error}`);
+      dispatch(errorsActions.showError({ error: response.error }));
     } else {
       dispatch(actions.loadVersionInfo({ version: response }));
       dispatch(


### PR DESCRIPTION
Fixes #182

---

The idea is to have a reducer responsible for storing errors. Given that we focus on API errors, the action currently receives an `Error` object and the reducer extracts this message (could be done in a `createInternalError()` function, that's an implementation detail).

Each error gets an ID assigned to it, unique and predictable given that the next ID is stored into the state. Having such IDs and the increment logic into the reducer avoids complicated unique ID generation and multiple errors for the same component. We never decrement the ID to avoid collisions.

Having an ID on each error allows to "hide" them when the user clicks the "close" button. We do not have an automated way of closing such error messages yet. In the future, we could maybe add a `context` prop to an `ApplicationError`, which would group errors from the same component/page and when trying to reload a page, the `fetch` action would send a `clearErrorsForContext()` action that would automatically remove all the errors for a given context.

**Note:** I applied the logic to the `fetchVersion` thunk only. I'll replace the other `TODO` in a follow-up patch to keep this one concise.

## Gif

![2019-03-25 14 19 04](https://user-images.githubusercontent.com/217628/54922834-486e5100-4f09-11e9-918e-38bdc03d1fa9.gif)

