### PR TITLE
Remove `\n` hack on `changes[].content` in `versions` reducer

### DIFF
--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -895,10 +895,7 @@ describe(__filename, () => {
       firstHunk.changes.forEach((change, index) => {
         const externalChange = firstExternalHunk.changes[index];
 
-        expect(change).toHaveProperty(
-          'content',
-          externalChange.content.replace(/\n$/, ''),
-        );
+        expect(change).toHaveProperty('content', externalChange.content);
         expect(change).toHaveProperty('type', externalChange.type);
         expect(change).toHaveProperty(
           'oldLineNumber',
@@ -978,17 +975,6 @@ describe(__filename, () => {
       expect(change).toHaveProperty('isInsert', false);
       expect(change).toHaveProperty('isNormal', true);
       expect(change).toHaveProperty('lineNumber', oldLineNumber);
-    });
-
-    it('only removes the trailing newline', () => {
-      const version = createVersionWithChange({
-        content: 'This\nis a line with two newlines\n',
-      });
-
-      const diff = _createInternalDiffs({ version })[0];
-      const change = diff.hunks[0].changes[0];
-
-      expect(change.content).toEqual('This\nis a line with two newlines');
     });
   });
 

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -484,9 +484,7 @@ export const createInternalDiffs = ({
         oldRevision: String(baseVersionId),
         hunks: diff.hunks.map((hunk: ExternalHunk) => ({
           changes: hunk.changes.map((change: ExternalChange) => ({
-            // TODO: remove the call to `replace()` once the API is fixed.
-            // See: https://github.com/mozilla/addons-server/issues/10932
-            content: change.content.replace(/\n$/, ''),
+            content: change.content,
             isDelete: change.type === 'delete',
             isInsert: change.type === 'insert',
             isNormal: change.type === 'normal',

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -161,57 +161,57 @@ export const fakeExternalDiff = Object.freeze({
   mode: 'M',
   hunks: [
     {
-      header: '@@ -1,6 +1,6 @@\n',
+      header: '@@ -1,6 +1,6 @@',
       old_start: 1,
       new_start: 1,
       old_lines: 6,
       new_lines: 6,
       changes: [
         {
-          content: '{\r\n',
+          content: '{',
           type: 'normal' as ExternalChange['type'],
           old_line_number: 1,
           new_line_number: 1,
         },
         {
-          content: '    "manifest_version": 2,\r\n',
+          content: '    "manifest_version": 2,',
           type: 'normal' as ExternalChange['type'],
           old_line_number: 2,
           new_line_number: 2,
         },
         {
-          content: '    "version": "7",\r\n',
+          content: '    "version": "7",',
           type: 'delete' as ExternalChange['type'],
           old_line_number: 3,
           new_line_number: -1,
         },
         {
-          content: '    "version": "8",\r\n',
+          content: '    "version": "8",',
           type: 'insert' as ExternalChange['type'],
           old_line_number: -1,
           new_line_number: 3,
         },
         {
           content:
-            '    "name": "Awesome Screenshot - Capture, Annotate & More",\r\n',
+            '    "name": "Awesome Screenshot - Capture, Annotate & More",',
           type: 'normal' as ExternalChange['type'],
           old_line_number: 4,
           new_line_number: 4,
         },
         {
-          content: '    "description": "this is a new description"\r\n',
+          content: '    "description": "this is a new description"',
           type: 'delete' as ExternalChange['type'],
           old_line_number: 5,
           new_line_number: -1,
         },
         {
-          content: '    "description": "this is a new version with files"\r\n',
+          content: '    "description": "this is a new version with files"',
           type: 'insert' as ExternalChange['type'],
           old_line_number: -1,
           new_line_number: 5,
         },
         {
-          content: '}\r\n',
+          content: '}',
           type: 'normal' as ExternalChange['type'],
           old_line_number: 6,
           new_line_number: 6,


### PR DESCRIPTION
Fixes #419

---

Now that the API has been fixed, this hack is not useful anymore.