### PR TITLE
Continue to the initial URL after login

### DIFF
--- a/src/components/LoginButton/index.spec.tsx
+++ b/src/components/LoginButton/index.spec.tsx
@@ -1,22 +1,34 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
 import { Button } from 'react-bootstrap';
 
-import LoginButton from '.';
+import {
+  createContextWithFakeRouter,
+  createFakeLocation,
+  shallowUntilTarget,
+} from '../../test-helpers';
+
+import LoginButton, { LoginButtonBase } from '.';
 
 describe(__filename, () => {
   it('renders a login button', () => {
     const apiVersion = 'api-version';
     const fxaConfig = 'some-fxa-config';
+    const pathname = '/en-US/browse/491343/versions/1527716/';
 
-    const root = shallow(
+    const root = shallowUntilTarget(
       <LoginButton fxaConfig={fxaConfig} apiVersion={apiVersion} />,
+      LoginButtonBase,
+      {
+        shallowOptions: createContextWithFakeRouter({
+          location: createFakeLocation({ pathname }),
+        }),
+      },
     );
 
     expect(root.find(Button)).toHaveLength(1);
     expect(root.find(Button)).toHaveProp(
       'href',
-      `/api/${apiVersion}/accounts/login/start/?config=${fxaConfig}&to=/`,
+      `/api/${apiVersion}/accounts/login/start/?config=${fxaConfig}&to=${pathname}`,
     );
   });
 });

--- a/src/components/LoginButton/index.tsx
+++ b/src/components/LoginButton/index.tsx
@@ -1,24 +1,31 @@
 import * as React from 'react';
 import { Button } from 'react-bootstrap';
+import { withRouter, RouteComponentProps } from 'react-router-dom';
 
 import { gettext } from '../../utils';
 import styles from './styles.module.scss';
 
-type PublicProps = {
+type PublicProps = {};
+
+type DefaultProps = {
   apiVersion: string;
   fxaConfig: string;
 };
 
-export class LoginButtonBase extends React.Component<PublicProps> {
-  static defaultProps = {
-    apiVersion: process.env.REACT_APP_DEFAULT_API_VERSION,
-    fxaConfig: process.env.REACT_APP_FXA_CONFIG,
+type Props = PublicProps & DefaultProps & RouteComponentProps;
+
+export class LoginButtonBase extends React.Component<Props> {
+  static defaultProps: DefaultProps = {
+    apiVersion: process.env.REACT_APP_DEFAULT_API_VERSION as string,
+    fxaConfig: process.env.REACT_APP_FXA_CONFIG as string,
   };
 
   getFxaURL() {
-    const { apiVersion, fxaConfig } = this.props;
+    const { apiVersion, fxaConfig, location } = this.props;
 
-    return `/api/${apiVersion}/accounts/login/start/?config=${fxaConfig}&to=/`;
+    return `/api/${apiVersion}/accounts/login/start/?config=${fxaConfig}&to=${
+      location.pathname
+    }`;
   }
 
   render() {
@@ -30,4 +37,6 @@ export class LoginButtonBase extends React.Component<PublicProps> {
   }
 }
 
-export default LoginButtonBase;
+export default withRouter(LoginButtonBase) as React.ComponentType<
+  PublicProps & Partial<DefaultProps>
+>;

--- a/stories/LoginButton.stories.tsx
+++ b/stories/LoginButton.stories.tsx
@@ -2,5 +2,8 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import LoginButton from '../src/components/LoginButton';
+import { renderWithStoreAndRouter } from './utils';
 
-storiesOf('LoginButton', module).add('default', () => <LoginButton />);
+storiesOf('LoginButton', module).add('default', () =>
+  renderWithStoreAndRouter(<LoginButton />),
+);


### PR DESCRIPTION
Fixes #354

---

This patch passes the current relative URL to FxA so that the user is
redirected to the right page after login.