### PR TITLE
Improve inlined linter message style

### DIFF
--- a/src/components/CodeView/index.tsx
+++ b/src/components/CodeView/index.tsx
@@ -110,7 +110,11 @@ export const CodeViewBase = ({
                         >
                           {selectedMessageMap.byLine[line].map((msg) => {
                             return (
-                              <LinterMessage key={msg.uid} message={msg} />
+                              <LinterMessage
+                                inline
+                                key={msg.uid}
+                                message={msg}
+                              />
                             );
                           })}
                         </td>

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -84,7 +84,7 @@ export class DiffViewBase extends React.Component<Props> {
         widget = (
           <div className={styles.inlineLinterMessages}>
             {messages.map((msg) => {
-              return <LinterMessage key={msg.uid} message={msg} />;
+              return <LinterMessage key={msg.uid} message={msg} inline />;
             })}
           </div>
         );

--- a/src/components/LinterMessage/index.spec.tsx
+++ b/src/components/LinterMessage/index.spec.tsx
@@ -9,6 +9,13 @@ import styles from './styles.module.scss';
 import LinterMessage, { decodeHtmlEntities } from '.';
 
 describe(__filename, () => {
+  const render = ({
+    message = createInternalMessage(fakeExternalLinterMessage),
+    inline = false,
+  } = {}) => {
+    return shallow(<LinterMessage message={message} inline={inline} />);
+  };
+
   const renderMessage = (attributes = {}) => {
     const message = createInternalMessage({
       ...fakeExternalLinterMessage,
@@ -19,7 +26,8 @@ describe(__filename, () => {
       type: 'error',
       ...attributes,
     });
-    return shallow(<LinterMessage message={message} />);
+
+    return render({ message });
   };
 
   it.each([
@@ -27,10 +35,10 @@ describe(__filename, () => {
     ['warning', 'warning'],
     ['secondary', 'notice'],
   ])('renders the Alert variant "%s" for "%s"', (alertVariant, messageType) => {
-    expect(renderMessage({ type: messageType }).find(Alert)).toHaveProp(
-      'variant',
-      alertVariant,
-    );
+    const root = renderMessage({ type: messageType });
+
+    expect(root.find(Alert)).toHaveProp('variant', alertVariant);
+    expect(root).toHaveClassName(`.${styles[alertVariant]}`);
   });
 
   it('renders a message and description', () => {
@@ -128,6 +136,12 @@ describe(__filename, () => {
     expect(root.find(`.${styles.description}`).html()).toContain(
       description[0],
     );
+  });
+
+  it('can be marked as an inline message', () => {
+    const root = render({ inline: true });
+
+    expect(root).toHaveClassName(`.${styles.inline}`);
   });
 
   describe('decodeHtmlEntities', () => {

--- a/src/components/LinterMessage/index.tsx
+++ b/src/components/LinterMessage/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import purify from 'dompurify';
 import he from 'he';
 import { Alert } from 'react-bootstrap';
+import makeClassName from 'classnames';
 
 import styles from './styles.module.scss';
 import { LinterMessage } from '../../reducers/linter';
@@ -58,14 +59,20 @@ const renderDescription = (description: LinterMessage['description']) => {
 };
 
 type PublicProps = {
+  inline?: boolean;
   message: LinterMessage;
 };
 
-const LinterMessageBase = (props: PublicProps) => {
-  const { description, message, type } = props.message;
+const LinterMessageBase = ({ message, inline = false }: PublicProps) => {
+  const { description, message: linterMessage, type } = message;
+  const variant = getAlertVariant(type);
+
   return (
-    <Alert variant={getAlertVariant(type)}>
-      <Alert.Heading>{decodeHtmlEntities(message)}</Alert.Heading>
+    <Alert
+      className={makeClassName(styles[variant], { [styles.inline]: inline })}
+      variant={variant}
+    >
+      <Alert.Heading>{decodeHtmlEntities(linterMessage)}</Alert.Heading>
       <p className={styles.description}>{renderDescription(description)}</p>
     </Alert>
   );

--- a/src/components/LinterMessage/styles.module.scss
+++ b/src/components/LinterMessage/styles.module.scss
@@ -1,3 +1,43 @@
+$top-arrow-width: 10px;
+$top-arrow-height: 20px;
+
+.inline:first-child {
+  &:after,
+  &:before {
+    border-color: transparent;
+    border-style: solid;
+    content: '';
+    display: block;
+    height: 0;
+    left: 10px;
+    position: absolute;
+    width: 0;
+  }
+
+  &:after {
+    border-width: $top-arrow-width;
+    top: -$top-arrow-height + 2;
+  }
+
+  &:before {
+    border-bottom-color: inherit;
+    border-width: $top-arrow-width;
+    top: -$top-arrow-height;
+  }
+}
+
+.danger.inline:after {
+  border-bottom-color: #f8d7da;
+}
+
+.secondary.inline:after {
+  border-bottom-color: #e2e3e5;
+}
+
+.warning.inline:after {
+  border-bottom-color: #fff3cd;
+}
+
 .description {
   margin-bottom: 0;
 }

--- a/src/components/LinterMessage/styles.module.scss
+++ b/src/components/LinterMessage/styles.module.scss
@@ -1,7 +1,12 @@
+@import '~bootstrap/scss/_functions.scss';
+@import '~bootstrap/scss/_variables.scss';
+
 $top-arrow-width: 10px;
 $top-arrow-height: 20px;
 
 .inline:first-child {
+  position: relative;
+
   &:after,
   &:before {
     border-color: transparent;
@@ -9,7 +14,7 @@ $top-arrow-height: 20px;
     content: '';
     display: block;
     height: 0;
-    left: 10px;
+    left: $top-arrow-height;
     position: absolute;
     width: 0;
   }
@@ -27,15 +32,15 @@ $top-arrow-height: 20px;
 }
 
 .danger.inline:after {
-  border-bottom-color: #f8d7da;
+  border-bottom-color: theme-color-level('danger', $alert-bg-level);
 }
 
 .secondary.inline:after {
-  border-bottom-color: #e2e3e5;
+  border-bottom-color: theme-color-level('secondary', $alert-bg-level);
 }
 
 .warning.inline:after {
-  border-bottom-color: #fff3cd;
+  border-bottom-color: theme-color-level('warning', $alert-bg-level);
 }
 
 .description {

--- a/stories/LinterMessage.stories.tsx
+++ b/stories/LinterMessage.stories.tsx
@@ -139,6 +139,35 @@ storiesOf('LinterMessage', module).addWithChapters('all variants', {
             />
           ),
         },
+        {
+          title: 'Two inline messages stacked',
+          sectionFn: () => (
+            <React.Fragment>
+              <LinterMessage
+                inline
+                message={createMessage({
+                  type: 'notice',
+                  message: 'Known JS library detected',
+                  description: [
+                    `JavaScript libraries are discouraged for
+                simple add-ons, but are generally accepted.`,
+                  ],
+                })}
+              />
+              <LinterMessage
+                inline
+                message={createMessage({
+                  type: 'error',
+                  message: 'Markup parsing error',
+                  description: [
+                    'There was an error parsing the markup document.',
+                    'malformed start tag, at line 1, column 26',
+                  ],
+                })}
+              />
+            </React.Fragment>
+          ),
+        },
       ],
     },
   ],

--- a/stories/LinterMessage.stories.tsx
+++ b/stories/LinterMessage.stories.tsx
@@ -92,6 +92,53 @@ storiesOf('LinterMessage', module).addWithChapters('all variants', {
             />
           ),
         },
+        {
+          title: 'Inlined error',
+          sectionFn: () => (
+            <LinterMessage
+              inline
+              message={createMessage({
+                type: 'error',
+                message: 'The value of &lt;em:id&gt; is invalid',
+                description: [
+                  'The values supplied for &lt;em:id&gt; in the install.rdf file is not a valid UUID string.',
+                ],
+              })}
+            />
+          ),
+        },
+        {
+          title: 'Inlined warning',
+          sectionFn: () => (
+            <LinterMessage
+              inline
+              message={createMessage({
+                type: 'warning',
+                message:
+                  'The manifest contains a dictionary but no id property.',
+                description: [
+                  'A dictionary was found in the manifest, but there was no id set.',
+                ],
+              })}
+            />
+          ),
+        },
+        {
+          title: 'Inlined notice',
+          sectionFn: () => (
+            <LinterMessage
+              inline
+              message={createMessage({
+                type: 'notice',
+                message: 'Known JS library detected',
+                description: [
+                  `JavaScript libraries are discouraged for
+                simple add-ons, but are generally accepted.`,
+                ],
+              })}
+            />
+          ),
+        },
       ],
     },
   ],


### PR DESCRIPTION
Fixes #436 

---

This is another proposal to fix #436.

Unfortunately, I don't know how to reuse the Bootstrap `background-color` without using its HEX code.


## Screenshots

![Screen Shot 2019-03-26 at 17 09 18](https://user-images.githubusercontent.com/217628/55013694-edf8f180-4fe9-11e9-94ba-8f81ab30b6b7.png)
![Screen Shot 2019-03-26 at 17 09 15](https://user-images.githubusercontent.com/217628/55013695-edf8f180-4fe9-11e9-9905-0cb9d8f62a60.png)
![Screen Shot 2019-03-26 at 17 08 25](https://user-images.githubusercontent.com/217628/55013696-edf8f180-4fe9-11e9-82a8-8074da36a1bb.png)
![Screen Shot 2019-03-26 at 17 07 58](https://user-images.githubusercontent.com/217628/55013697-ee918800-4fe9-11e9-8711-9af1aa671512.png)
![Screen Shot 2019-03-26 at 17 07 47](https://user-images.githubusercontent.com/217628/55013698-ee918800-4fe9-11e9-9629-959367ebe169.png)
![Screen Shot 2019-03-26 at 17 07 35](https://user-images.githubusercontent.com/217628/55013699-ee918800-4fe9-11e9-80ab-0b081029b127.png)
