### PR TITLE
Adds LinterProvider to FileTreeNode and fixes the compare view

### DIFF
--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -361,15 +361,8 @@ describe(__filename, () => {
     const render = ({
       onSelect = jest.fn(),
       version = getVersion(fakeVersion),
-      linterMessages = {},
     } = {}) => {
-      return shallow(
-        <FileTree
-          version={version}
-          linterMessages={linterMessages}
-          onSelect={onSelect}
-        />,
-      );
+      return shallow(<FileTree version={version} onSelect={onSelect} />);
     };
 
     it('renders a ListGroup component with a Treefold', () => {
@@ -412,21 +405,6 @@ describe(__filename, () => {
       expect(shallow(<div>{node}</div>).find(FileTreeNode)).toHaveProp(
         'version',
         version,
-      );
-    });
-
-    it('passes the linterMessages prop to FileTreeNode', () => {
-      const linterMessages = {};
-
-      const root = render({ linterMessages });
-
-      const node = (root.instance() as FileTree).renderNode(
-        getTreefoldRenderProps(),
-      );
-
-      expect(shallow(<div>{node}</div>).find(FileTreeNode)).toHaveProp(
-        'linterMessages',
-        linterMessages,
       );
     });
   });

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -6,7 +6,6 @@ import FileTreeNode, {
   PublicProps as FileTreeNodeProps,
 } from '../FileTreeNode';
 import { Version } from '../../reducers/versions';
-import { LinterMessageMap } from '../../reducers/linter';
 import { getLocalizedString } from '../../utils';
 
 type FileNode = {
@@ -21,6 +20,8 @@ export type DirectoryNode = {
 };
 
 export type TreeNode = FileNode | DirectoryNode;
+
+export type TreefoldRenderPropsForFileTree = TreefoldRenderProps<TreeNode>;
 
 const recursiveSortInPlace = (node: DirectoryNode): void => {
   node.children.sort((a, b) => {
@@ -129,8 +130,7 @@ export const buildFileTree = (
   return root;
 };
 
-type PublicProps = {
-  linterMessages: LinterMessageMap | void;
+export type PublicProps = {
   onSelect: FileTreeNodeProps['onSelect'];
   version: Version;
 };
@@ -138,17 +138,10 @@ type PublicProps = {
 type Props = PublicProps;
 
 export class FileTreeBase extends React.Component<Props> {
-  renderNode = (props: TreefoldRenderProps<TreeNode>) => {
-    const { linterMessages, onSelect, version } = this.props;
+  renderNode = (props: TreefoldRenderPropsForFileTree) => {
+    const { onSelect, version } = this.props;
 
-    return (
-      <FileTreeNode
-        {...props}
-        linterMessages={linterMessages}
-        onSelect={onSelect}
-        version={version}
-      />
-    );
+    return <FileTreeNode {...props} onSelect={onSelect} version={version} />;
   };
 
   render() {

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -125,11 +125,7 @@ export class BrowseBase extends React.Component<Props> {
         <Col md="3">
           <Row>
             <Col>
-              <FileTree
-                linterMessages={linterMessages}
-                onSelect={this.onSelectFile}
-                version={version}
-              />
+              <FileTree onSelect={this.onSelectFile} version={version} />
             </Col>
           </Row>
           {file && (

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -127,11 +127,7 @@ export class CompareBase extends React.Component<Props> {
       <React.Fragment>
         <Col md="3">
           {version ? (
-            <FileTree
-              linterMessages={undefined}
-              onSelect={this.onSelectFile}
-              version={version}
-            />
+            <FileTree onSelect={this.onSelectFile} version={version} />
           ) : (
             this.renderLoadingMessageOrError(gettext('Loading file tree...'))
           )}

--- a/stories/FileTree.stories.tsx
+++ b/stories/FileTree.stories.tsx
@@ -1,61 +1,68 @@
 /* eslint @typescript-eslint/camelcase: 0 */
 import React from 'react';
+import { Store } from 'redux';
 import { storiesOf } from '@storybook/react';
 
-import FileTree from '../src/components/FileTree';
+import configureStore from '../src/configureStore';
+import FileTree, {
+  PublicProps as FileTreeProps,
+} from '../src/components/FileTree';
 import { createInternalVersion } from '../src/reducers/versions';
 import { fakeVersion, fakeVersionEntry } from '../src/test-helpers';
+import { renderWithStoreAndRouter } from './utils';
 
-const version = createInternalVersion({
-  ...fakeVersion,
-  file: {
-    ...fakeVersion.file,
-    entries: {
-      'manifest.json': {
-        ...fakeVersionEntry,
-        filename: 'manifest.json',
-        path: 'manifest.json',
-      },
-      'background-scripts': {
-        ...fakeVersionEntry,
-        filename: 'background-scripts',
-        path: 'background-scripts',
-        mime_category: 'directory',
-      },
-      'background-scripts/index.js': {
-        ...fakeVersionEntry,
-        depth: 1,
-        filename: 'index.js',
-        path: 'background-scripts/index.js',
-      },
-      'background-scripts/libs': {
-        ...fakeVersionEntry,
-        depth: 1,
-        filename: 'libs',
-        mime_category: 'directory',
-        path: 'background-scripts/libs',
-      },
-      'background-scripts/libs/jquery.min.js': {
-        ...fakeVersionEntry,
-        depth: 2,
-        filename: 'jquery.min.js',
-        path: 'background-scripts/libs/jquery.min.js',
-      },
-      'background-scripts/extra': {
-        ...fakeVersionEntry,
-        depth: 1,
-        filename: 'extra',
-        mime_category: 'directory',
-        path: 'background-scripts/extra',
-      },
-      'styles.css': {
-        ...fakeVersionEntry,
-        filename: 'styles.css',
-        path: 'styles.css',
+const getVersion = () => {
+  return createInternalVersion({
+    ...fakeVersion,
+    file: {
+      ...fakeVersion.file,
+      entries: {
+        'manifest.json': {
+          ...fakeVersionEntry,
+          filename: 'manifest.json',
+          path: 'manifest.json',
+        },
+        'background-scripts': {
+          ...fakeVersionEntry,
+          filename: 'background-scripts',
+          path: 'background-scripts',
+          mime_category: 'directory',
+        },
+        'background-scripts/index.js': {
+          ...fakeVersionEntry,
+          depth: 1,
+          filename: 'index.js',
+          path: 'background-scripts/index.js',
+        },
+        'background-scripts/libs': {
+          ...fakeVersionEntry,
+          depth: 1,
+          filename: 'libs',
+          mime_category: 'directory',
+          path: 'background-scripts/libs',
+        },
+        'background-scripts/libs/jquery.min.js': {
+          ...fakeVersionEntry,
+          depth: 2,
+          filename: 'jquery.min.js',
+          path: 'background-scripts/libs/jquery.min.js',
+        },
+        'background-scripts/extra': {
+          ...fakeVersionEntry,
+          depth: 1,
+          filename: 'extra',
+          mime_category: 'directory',
+          path: 'background-scripts/extra',
+        },
+        'styles.css': {
+          ...fakeVersionEntry,
+          filename: 'styles.css',
+          path: 'styles.css',
+        },
       },
     },
-  },
-});
+  });
+};
 
 // We display an alert when a file has been selected.
 const onSelectFile = (path: string) => {
@@ -63,10 +70,16 @@ const onSelectFile = (path: string) => {
   alert(`Selected file: ${path}`);
 };
 
-storiesOf('FileTree', module).add('default', () => (
-  <FileTree
-    linterMessages={undefined}
-    onSelect={onSelectFile}
-    version={version}
-  />
-));
+const render = ({
+  store = configureStore(),
+  ...moreProps
+}: { store?: Store } & Partial<FileTreeProps> = {}) => {
+  const props: FileTreeProps = {
+    onSelect: onSelectFile,
+    version: getVersion(),
+    ...moreProps,
+  };
+  return renderWithStoreAndRouter(<FileTree {...props} />, store);
+};
+
+storiesOf('FileTree', module).add('default', () => render());

--- a/stories/FileTree.stories.tsx
+++ b/stories/FileTree.stories.tsx
@@ -11,58 +11,56 @@ import { createInternalVersion } from '../src/reducers/versions';
 import { fakeVersion, fakeVersionEntry } from '../src/test-helpers';
 import { renderWithStoreAndRouter } from './utils';
 
-const getVersion = () => {
-  return createInternalVersion({
-    ...fakeVersion,
-    file: {
-      ...fakeVersion.file,
-      entries: {
-        'manifest.json': {
-          ...fakeVersionEntry,
-          filename: 'manifest.json',
-          path: 'manifest.json',
-        },
-        'background-scripts': {
-          ...fakeVersionEntry,
-          filename: 'background-scripts',
-          path: 'background-scripts',
-          mime_category: 'directory',
-        },
-        'background-scripts/index.js': {
-          ...fakeVersionEntry,
-          depth: 1,
-          filename: 'index.js',
-          path: 'background-scripts/index.js',
-        },
-        'background-scripts/libs': {
-          ...fakeVersionEntry,
-          depth: 1,
-          filename: 'libs',
-          mime_category: 'directory',
-          path: 'background-scripts/libs',
-        },
-        'background-scripts/libs/jquery.min.js': {
-          ...fakeVersionEntry,
-          depth: 2,
-          filename: 'jquery.min.js',
-          path: 'background-scripts/libs/jquery.min.js',
-        },
-        'background-scripts/extra': {
-          ...fakeVersionEntry,
-          depth: 1,
-          filename: 'extra',
-          mime_category: 'directory',
-          path: 'background-scripts/extra',
-        },
-        'styles.css': {
-          ...fakeVersionEntry,
-          filename: 'styles.css',
-          path: 'styles.css',
-        },
+const version = createInternalVersion({
+  ...fakeVersion,
+  file: {
+    ...fakeVersion.file,
+    entries: {
+      'manifest.json': {
+        ...fakeVersionEntry,
+        filename: 'manifest.json',
+        path: 'manifest.json',
+      },
+      'background-scripts': {
+        ...fakeVersionEntry,
+        filename: 'background-scripts',
+        path: 'background-scripts',
+        mime_category: 'directory',
+      },
+      'background-scripts/index.js': {
+        ...fakeVersionEntry,
+        depth: 1,
+        filename: 'index.js',
+        path: 'background-scripts/index.js',
+      },
+      'background-scripts/libs': {
+        ...fakeVersionEntry,
+        depth: 1,
+        filename: 'libs',
+        mime_category: 'directory',
+        path: 'background-scripts/libs',
+      },
+      'background-scripts/libs/jquery.min.js': {
+        ...fakeVersionEntry,
+        depth: 2,
+        filename: 'jquery.min.js',
+        path: 'background-scripts/libs/jquery.min.js',
+      },
+      'background-scripts/extra': {
+        ...fakeVersionEntry,
+        depth: 1,
+        filename: 'extra',
+        mime_category: 'directory',
+        path: 'background-scripts/extra',
+      },
+      'styles.css': {
+        ...fakeVersionEntry,
+        filename: 'styles.css',
+        path: 'styles.css',
       },
     },
-  });
-};
+  },
+});
 
 // We display an alert when a file has been selected.
 const onSelectFile = (path: string) => {
@@ -76,7 +74,7 @@ const render = ({
 }: { store?: Store } & Partial<FileTreeProps> = {}) => {
   const props: FileTreeProps = {
     onSelect: onSelectFile,
-    version: getVersion(),
+    version,
     ...moreProps,
   };
   return renderWithStoreAndRouter(<FileTree {...props} />, store);

--- a/stories/FileTreeNode.stories.tsx
+++ b/stories/FileTreeNode.stories.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
+import { Store } from 'redux';
 import { storiesOf } from '@storybook/react';
 
+import configureStore from '../src/configureStore';
 import FileTreeNode, { PublicProps } from '../src/components/FileTreeNode';
 import { createInternalVersion } from '../src/reducers/versions';
 import { fakeVersion } from '../src/test-helpers';
+import { renderWithStoreAndRouter } from './utils';
+
+type GetPropsParams = {
+  nodeId?: PublicProps['node']['id'];
+  nodeName?: PublicProps['node']['name'];
+} & Partial<PublicProps>;
 
 const getProps = ({
   hasChildNodes = false,
@@ -13,9 +21,8 @@ const getProps = ({
   nodeName = 'node name',
   nodeId = 'node-id',
   renderChildNodes = () => ({}),
-  linterMessages = undefined as PublicProps['linterMessages'],
   version = createInternalVersion(fakeVersion),
-} = {}) => {
+}: GetPropsParams = {}) => {
   return {
     getToggleProps: () => ({
       onClick: () => {},
@@ -32,14 +39,16 @@ const getProps = ({
       name: nodeName,
     },
     renderChildNodes,
-    linterMessages,
     onSelect: () => {},
     version,
   };
 };
 
-const render = (props = {}) => {
-  return <FileTreeNode {...getProps(props)} />;
+const render = ({
+  store = configureStore(),
+  ...props
+}: { store?: Store } & GetPropsParams = {}) => {
+  return renderWithStoreAndRouter(<FileTreeNode {...getProps(props)} />, store);
 };
 
 storiesOf('FileTreeNode', module).addWithChapters('all variants', {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/451

This change was needed to make linter icons show up in the compare view