### PR TITLE
Add API host when not using the insecure proxy

### DIFF
--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -8,6 +8,7 @@ import {
 import {
   HttpMethod,
   callApi,
+  getApiHost,
   getCurrentUser,
   getDiff,
   getVersion,
@@ -38,7 +39,7 @@ describe(__filename, () => {
       await callApiWithDefaultApiState();
 
       expect(fetch).toHaveBeenCalledWith(
-        `/api/${defaultVersion}/?lang=${defaultLang}`,
+        `${getApiHost()}/api/${defaultVersion}/?lang=${defaultLang}`,
         {
           headers: {},
           method: 'GET',
@@ -186,6 +187,18 @@ describe(__filename, () => {
         expect.any(Object),
       );
     });
+
+    it('calls _getApiHost() to retrieve the API host', async () => {
+      const apiHost = 'http://example.org';
+      const _getApiHost = jest.fn().mockReturnValue(apiHost);
+
+      await callApiWithDefaultApiState({ _getApiHost });
+
+      expect(fetch).toHaveBeenCalledWith(
+        `${apiHost}/api/${defaultVersion}/?lang=${defaultLang}`,
+        expect.any(Object),
+      );
+    });
   });
 
   describe('isErrorResponse', () => {
@@ -324,6 +337,26 @@ describe(__filename, () => {
         expect.urlWithTheseParams({ file: path }),
         expect.any(Object),
       );
+    });
+  });
+
+  describe('getApiHost', () => {
+    it('returns the API host configured with REACT_APP_API_HOST', () => {
+      expect(getApiHost()).toEqual(process.env.REACT_APP_API_HOST);
+    });
+
+    it('returns an empty host when using an insecure proxy', () => {
+      expect(getApiHost({ useInsecureProxy: true })).toEqual('');
+    });
+
+    it('returns an empty host when apiHost is null', () => {
+      expect(getApiHost({ apiHost: null })).toEqual('');
+    });
+
+    it('returns the given apiHost when not using an insecure proxy', () => {
+      const apiHost = 'http://example.org';
+
+      expect(getApiHost({ apiHost, useInsecureProxy: false })).toEqual(apiHost);
     });
   });
 });

--- a/src/components/LoginButton/index.spec.tsx
+++ b/src/components/LoginButton/index.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Button } from 'react-bootstrap';
 
+import { getApiHost } from '../../api';
 import {
   createContextWithFakeRouter,
   createFakeLocation,
@@ -10,13 +11,18 @@ import {
 import LoginButton, { LoginButtonBase } from '.';
 
 describe(__filename, () => {
-  it('renders a login button', () => {
-    const apiVersion = 'api-version';
-    const fxaConfig = 'some-fxa-config';
-    const pathname = '/en-US/browse/491343/versions/1527716/';
-
-    const root = shallowUntilTarget(
-      <LoginButton fxaConfig={fxaConfig} apiVersion={apiVersion} />,
+  const render = ({
+    _getApiHost = getApiHost,
+    apiVersion = '123',
+    fxaConfig = 'fxa',
+    pathname = '/',
+  } = {}) => {
+    return shallowUntilTarget(
+      <LoginButton
+        _getApiHost={_getApiHost}
+        apiVersion={apiVersion}
+        fxaConfig={fxaConfig}
+      />,
       LoginButtonBase,
       {
         shallowOptions: createContextWithFakeRouter({
@@ -24,11 +30,32 @@ describe(__filename, () => {
         }),
       },
     );
+  };
+
+  it('renders a login button', () => {
+    const apiVersion = 'api-version';
+    const fxaConfig = 'some-fxa-config';
+    const pathname = '/en-US/browse/491343/versions/1527716/';
+
+    const root = render({ apiVersion, fxaConfig, pathname });
 
     expect(root.find(Button)).toHaveLength(1);
     expect(root.find(Button)).toHaveProp(
       'href',
-      `/api/${apiVersion}/accounts/login/start/?config=${fxaConfig}&to=${pathname}`,
+      `${getApiHost()}/api/${apiVersion}/accounts/login/start/?config=${fxaConfig}&to=${pathname}`,
+    );
+  });
+
+  it('calls _getApiHost() when rendering the button', () => {
+    const apiHost = 'http://example.org';
+    const _getApiHost = jest.fn().mockReturnValue(apiHost);
+
+    const root = render({ _getApiHost });
+
+    expect(_getApiHost).toHaveBeenCalled();
+    expect(root.find(Button)).toHaveProp(
+      'href',
+      expect.stringMatching(`^${apiHost}`),
     );
   });
 });

--- a/src/components/LoginButton/index.tsx
+++ b/src/components/LoginButton/index.tsx
@@ -2,12 +2,14 @@ import * as React from 'react';
 import { Button } from 'react-bootstrap';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 
+import { getApiHost } from '../../api';
 import { gettext } from '../../utils';
 import styles from './styles.module.scss';
 
 type PublicProps = {};
 
 type DefaultProps = {
+  _getApiHost: typeof getApiHost;
   apiVersion: string;
   fxaConfig: string;
 };
@@ -16,14 +18,15 @@ type Props = PublicProps & DefaultProps & RouteComponentProps;
 
 export class LoginButtonBase extends React.Component<Props> {
   static defaultProps: DefaultProps = {
+    _getApiHost: getApiHost,
     apiVersion: process.env.REACT_APP_DEFAULT_API_VERSION as string,
     fxaConfig: process.env.REACT_APP_FXA_CONFIG as string,
   };
 
   getFxaURL() {
-    const { apiVersion, fxaConfig, location } = this.props;
+    const { _getApiHost, apiVersion, fxaConfig, location } = this.props;
 
-    return `/api/${apiVersion}/accounts/login/start/?config=${fxaConfig}&to=${
+    return `${_getApiHost()}/api/${apiVersion}/accounts/login/start/?config=${fxaConfig}&to=${
       location.pathname
     }`;
   }


### PR DESCRIPTION
Fixes #460
Fixes #462 

---

How I tested it:

1. I tried to run the project like in prod:

```
rm -f .env.local && yarn build && yarn start
```

This should start the project at http://localhost:3000/ and the API call to fetch the user profile should have `addons.mozilla.org` as domain in the devtools > network panel (result should be a 401).

2. I ran `yarn dev` to make sure it behaves as before.


**Note:** I believe this won't fix the login issue entirely because we need some FxA changes (see: #463).