### PR TITLE
Apply LinterProvider to CodeView for code re-use

### DIFF
--- a/src/components/CodeView/index.spec.tsx
+++ b/src/components/CodeView/index.spec.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { Location } from 'history';
 import { mount } from 'enzyme';
-import { Provider } from 'react-redux';
 
 import configureStore from '../../configureStore';
 import refractor from '../../refractor';
@@ -85,12 +85,18 @@ describe(__filename, () => {
     location = createFakeLocation(),
     ...otherProps
   }: RenderParams = {}) => {
-    return mount(
-      <Provider store={configureStore()}>
-        <CodeView {...getProps(otherProps)} />
-      </Provider>,
-      createContextWithFakeRouter({ location }),
-    );
+    const options = createContextWithFakeRouter({ location });
+    return mount(<CodeView {...getProps(otherProps)} />, {
+      ...options,
+      childContextTypes: {
+        ...options.childContextTypes,
+        store: PropTypes.object.isRequired,
+      },
+      context: {
+        ...options.context,
+        store: configureStore(),
+      },
+    });
   };
 
   const renderWithMessages = ({

--- a/src/components/CodeView/index.spec.tsx
+++ b/src/components/CodeView/index.spec.tsx
@@ -30,7 +30,7 @@ describe(__filename, () => {
     location?: Location<{}>;
   };
 
-  const globalExternalMessage = (props = {}) => {
+  const createGlobalExternalMessage = (props = {}) => {
     return {
       ...fakeExternalLinterMessage,
       ...props,
@@ -291,7 +291,7 @@ describe(__filename, () => {
 
   it('renders a global LinterMessage', () => {
     const uid = 'some-global-message-id';
-    const externalMessage = globalExternalMessage({ uid });
+    const externalMessage = createGlobalExternalMessage({ uid });
 
     const { root } = renderWithMessages({
       messages: [externalMessage],
@@ -308,8 +308,8 @@ describe(__filename, () => {
 
     const { root } = renderWithMessages({
       messages: [
-        globalExternalMessage({ uid: firstUid }),
-        globalExternalMessage({ uid: secondUid }),
+        createGlobalExternalMessage({ uid: firstUid }),
+        createGlobalExternalMessage({ uid: secondUid }),
       ],
     });
 

--- a/src/components/CodeView/index.spec.tsx
+++ b/src/components/CodeView/index.spec.tsx
@@ -2,20 +2,24 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { Location } from 'history';
 import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
 
+import configureStore from '../../configureStore';
 import refractor from '../../refractor';
 import LinterMessage from '../LinterMessage';
-import {
-  LinterMessage as LinterMessageType,
-  getMessageMap,
-} from '../../reducers/linter';
+import LinterProvider, { LinterProviderInfo } from '../LinterProvider';
+import { ExternalLinterMessage, getMessageMap } from '../../reducers/linter';
+import { createInternalVersion } from '../../reducers/versions';
 import { mapWithDepth } from './utils';
 import { getLanguageFromMimeType } from '../../utils';
 import {
   createContextWithFakeRouter,
   createFakeExternalLinterResult,
   createFakeLocation,
+  fakeExternalLinterMessage,
+  fakeVersion,
   shallowUntilTarget,
+  simulateLinterProvider,
 } from '../../test-helpers';
 import styles from './styles.module.scss';
 
@@ -26,11 +30,22 @@ describe(__filename, () => {
     location?: Location<{}>;
   };
 
+  const globalExternalMessage = (props = {}) => {
+    return {
+      ...fakeExternalLinterMessage,
+      ...props,
+      // When a message isn't associated with a line, it's global.
+      column: null,
+      line: null,
+    };
+  };
+
   const getProps = (otherProps = {}) => {
     return {
       content: 'some content',
       linterMessagesByLine: undefined,
       mimeType: 'mime/type',
+      version: createInternalVersion(fakeVersion),
       ...otherProps,
     };
   };
@@ -48,36 +63,48 @@ describe(__filename, () => {
     );
   };
 
+  type RenderWithLinterProviderParams = Partial<LinterProviderInfo> &
+    RenderParams;
+
+  const renderWithLinterProvider = ({
+    messageMap = undefined,
+    messagesAreLoading = false,
+    selectedMessageMap = undefined,
+    ...renderParams
+  }: RenderWithLinterProviderParams = {}) => {
+    const root = render(renderParams);
+
+    return simulateLinterProvider(root, {
+      messageMap,
+      messagesAreLoading,
+      selectedMessageMap,
+    });
+  };
+
   const renderWithMount = ({
     location = createFakeLocation(),
     ...otherProps
   }: RenderParams = {}) => {
     return mount(
-      <CodeView {...getProps(otherProps)} />,
+      <Provider store={configureStore()}>
+        <CodeView {...getProps(otherProps)} />
+      </Provider>,
       createContextWithFakeRouter({ location }),
     );
   };
 
   const renderWithMessages = ({
-    file,
     messages,
     ...props
   }: {
-    file: string;
-    messages: Partial<LinterMessageType>[];
+    messages: Partial<ExternalLinterMessage>[];
     props?: RenderParams;
   }) => {
+    const file = 'scripts/content.js';
     const map = getMessageMap(
       createFakeExternalLinterResult({
         messages: messages.map((msg) => {
-          if (msg.file !== file) {
-            throw new Error(
-              `message uid:${msg.uid} has file "${
-                msg.file
-              }" but needs to have "${file}"`,
-            );
-          }
-          return msg;
+          return { ...msg, file };
         }),
       }),
     );
@@ -88,18 +115,21 @@ describe(__filename, () => {
       '}',
     ];
 
-    const root = render({
-      linterMessagesByLine: map[file].byLine,
+    const selectedMessageMap = map[file];
+
+    const root = renderWithLinterProvider({
+      messageMap: map,
+      selectedMessageMap,
       content: contentLines.join('\n'),
       ...props,
     });
 
-    return { root, map };
+    return { root, selectedMessageMap };
   };
 
   it('renders plain text code when mime type is not supported', () => {
     const mimeType = 'mime/type';
-    const root = render({ mimeType });
+    const root = renderWithLinterProvider({ mimeType });
 
     expect(root.find(`.${styles.CodeView}`)).toHaveLength(1);
     expect(root.find(`.${styles.lineNumber}`)).toHaveLength(1);
@@ -111,7 +141,7 @@ describe(__filename, () => {
   it('renders highlighted code when language is supported', () => {
     const content = '{ "foo": "bar" }';
     const mimeType = 'application/json';
-    const root = render({ mimeType, content });
+    const root = renderWithLinterProvider({ mimeType, content });
 
     expect(root.find(`.${styles.lineNumber}`)).toHaveLength(1);
     expect(root.find(`.${styles.code}`)).toHaveLength(1);
@@ -129,7 +159,7 @@ describe(__filename, () => {
   it('handles empty content', () => {
     const content = '';
     const mimeType = 'text/css';
-    const root = render({ mimeType, content });
+    const root = renderWithLinterProvider({ mimeType, content });
 
     expect(root.find('.language-css')).toHaveProp('children', content);
   });
@@ -139,7 +169,7 @@ describe(__filename, () => {
     const content = contentLines.join('\n');
 
     const mimeType = 'application/json';
-    const root = render({ mimeType, content });
+    const root = renderWithLinterProvider({ mimeType, content });
 
     expect(root.find(`.${styles.lineNumber}`)).toHaveLength(
       contentLines.length,
@@ -148,7 +178,7 @@ describe(__filename, () => {
   });
 
   it('renders an HTML ID for each line', () => {
-    const root = render({ content: 'line 1\nline 2' });
+    const root = renderWithLinterProvider({ content: 'line 1\nline 2' });
 
     expect(root.find(`.${styles.line}`)).toHaveLength(2);
     expect(root.find(`.${styles.line}`).at(0)).toHaveProp('id', 'L1');
@@ -159,7 +189,10 @@ describe(__filename, () => {
     const selectedLine = 2;
     const location = createFakeLocation({ hash: `#L${selectedLine}` });
 
-    const root = render({ content: 'line 1\nline 2', location });
+    const root = renderWithLinterProvider({
+      content: 'line 1\nline 2',
+      location,
+    });
 
     expect(root.find(`.${styles.selectedLine}`)).toHaveLength(1);
     expect(root.find(`.${styles.selectedLine}`)).toHaveProp(
@@ -169,7 +202,7 @@ describe(__filename, () => {
   });
 
   it('renders a link for each line number', () => {
-    const root = render({ content: 'single line' });
+    const root = renderWithLinterProvider({ content: 'single line' });
 
     expect(root.find(`.${styles.lineNumber}`)).toHaveLength(1);
     expect(root.find(`.${styles.lineNumber}`).find(Link)).toHaveLength(1);
@@ -200,57 +233,84 @@ describe(__filename, () => {
 
   it('renders a LinterMessage on a line', () => {
     const line = 2;
-    const file = 'scripts/content.js';
 
-    const { map, root } = renderWithMessages({
-      file,
-      messages: [{ file, line }],
+    const { root, selectedMessageMap } = renderWithMessages({
+      messages: [{ line }],
     });
 
     const message = root.find(`#line-${line}-messages`).find(LinterMessage);
 
     expect(message).toHaveLength(1);
-    expect(message).toHaveProp('message', map[file].byLine[line][0]);
+    expect(message).toHaveProp('message', selectedMessageMap.byLine[line][0]);
   });
 
   it('renders multiple LinterMessage components on one line', () => {
     const line = 2;
-    const file = 'scripts/content.js';
 
-    const { map, root } = renderWithMessages({
-      file,
-      messages: [{ file, line, uid: 'first' }, { file, line, uid: 'second' }],
+    const { root, selectedMessageMap } = renderWithMessages({
+      messages: [{ line, uid: 'first' }, { line, uid: 'second' }],
     });
 
     const message = root.find(`#line-${line}-messages`).find(LinterMessage);
 
     expect(message).toHaveLength(2);
 
-    const messagesAtLine = map[file].byLine[line];
+    const messagesAtLine = selectedMessageMap.byLine[line];
     expect(message.at(0)).toHaveProp('message', messagesAtLine[0]);
     expect(message.at(1)).toHaveProp('message', messagesAtLine[1]);
   });
 
   it('renders LinterMessage components on multiple lines', () => {
-    const file = 'scripts/content.js';
-
-    const { map, root } = renderWithMessages({
-      file,
-      messages: [
-        { file, line: 2, uid: 'first' },
-        { file, line: 3, uid: 'second' },
-      ],
+    const { root, selectedMessageMap } = renderWithMessages({
+      messages: [{ line: 2, uid: 'first' }, { line: 3, uid: 'second' }],
     });
 
     expect(root.find('#line-2-messages').find(LinterMessage)).toHaveProp(
       'message',
-      map[file].byLine[2][0],
+      selectedMessageMap.byLine[2][0],
     );
 
     expect(root.find('#line-3-messages').find(LinterMessage)).toHaveProp(
       'message',
-      map[file].byLine[3][0],
+      selectedMessageMap.byLine[3][0],
     );
+  });
+
+  it('configures LinterProvider', () => {
+    const version = createInternalVersion(fakeVersion);
+    const root = render({ version });
+
+    expect(root.find(LinterProvider)).toHaveProp('version', version);
+  });
+
+  it('renders a global LinterMessage', () => {
+    const uid = 'some-global-message-id';
+    const externalMessage = globalExternalMessage({ uid });
+
+    const { root } = renderWithMessages({
+      messages: [externalMessage],
+    });
+
+    const message = root.find(LinterMessage);
+    expect(message).toHaveLength(1);
+    expect(message).toHaveProp('message', expect.objectContaining({ uid }));
+  });
+
+  it('renders all global LinterMessage components', () => {
+    const firstUid = 'first-uid';
+    const secondUid = 'second-uid';
+
+    const { root } = renderWithMessages({
+      messages: [
+        globalExternalMessage({ uid: firstUid }),
+        globalExternalMessage({ uid: secondUid }),
+      ],
+    });
+
+    const message = root.find(LinterMessage);
+    expect(message).toHaveLength(2);
+    expect(message.at(0).prop('message')).toMatchObject({ uid: firstUid });
+    expect(message.at(1).prop('message')).toMatchObject({ uid: secondUid });
   });
 
   describe('scrollToSelectedLine', () => {

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -2,33 +2,19 @@ import * as React from 'react';
 import { Store } from 'redux';
 
 import {
-  createFakeExternalLinterResult,
   createFakeHistory,
   createFakeThunk,
-  fakeExternalLinterMessage,
-  fakeExternalLinterResult,
   fakeVersion,
-  fakeVersionFile,
-  fakeVersionEntry,
   shallowUntilTarget,
   spyOn,
 } from '../../test-helpers';
 import configureStore from '../../configureStore';
 import {
-  ExternalLinterMessage,
-  ExternalLinterResult,
-  actions as linterActions,
-  createInternalMessage,
-  getMessageMap,
-} from '../../reducers/linter';
-import {
-  ExternalVersionWithContent,
   actions as versionActions,
   createInternalVersion,
   getVersionFile,
 } from '../../reducers/versions';
 import FileTree from '../../components/FileTree';
-import LinterMessage from '../../components/LinterMessage';
 import Loading from '../../components/Loading';
 import CodeView from '../../components/CodeView';
 import FileMetadata from '../../components/FileMetadata';
@@ -55,18 +41,7 @@ describe(__filename, () => {
     };
   };
 
-  const globalExternalMessage = (props = {}) => {
-    return {
-      ...fakeExternalLinterMessage,
-      ...props,
-      // When a message isn't associated with a line, it's global.
-      column: null,
-      line: null,
-    };
-  };
-
   type RenderParams = {
-    _fetchLinterMessages?: PublicProps['_fetchLinterMessages'];
     _fetchVersion?: PublicProps['_fetchVersion'];
     _fetchVersionFile?: PublicProps['_fetchVersionFile'];
     _log?: PublicProps['_log'];
@@ -76,7 +51,6 @@ describe(__filename, () => {
   };
 
   const render = ({
-    _fetchLinterMessages,
     _fetchVersion,
     _fetchVersionFile,
     _log,
@@ -86,7 +60,6 @@ describe(__filename, () => {
   }: RenderParams = {}) => {
     const props = {
       ...createFakeRouteComponentProps({ params: { addonId, versionId } }),
-      _fetchLinterMessages,
       _fetchVersion,
       _fetchVersionFile,
       _log,
@@ -110,91 +83,6 @@ describe(__filename, () => {
         version,
       }),
     );
-  };
-
-  const renderAndUpdateWithVersion = ({
-    store = configureStore(),
-    version,
-  }: {
-    store?: Store;
-    version: ExternalVersionWithContent;
-  }) => {
-    const fakeThunk = createFakeThunk();
-    const _fetchLinterMessages = fakeThunk.createThunk;
-
-    _loadVersionAndFile({ store, version });
-    const dispatch = spyOn(store, 'dispatch');
-
-    const root = render({
-      _fetchLinterMessages,
-      store,
-      versionId: String(version.id),
-    });
-
-    dispatch.mockClear();
-
-    // Simulate an update.
-    root.setProps({});
-
-    return { dispatch, _fetchLinterMessages, version, fakeThunk };
-  };
-
-  const renderWithMessages = ({
-    externalMessages = [],
-    path,
-    result,
-    versionId,
-  }: {
-    externalMessages?: ExternalLinterMessage[];
-    path: string;
-    result?: ExternalLinterResult;
-    versionId?: string;
-  }) => {
-    const store = configureStore();
-
-    // Prepare a result with all messages for the selected file.
-    const externalResult =
-      result ||
-      createFakeExternalLinterResult({
-        messages: externalMessages.map((msg) => {
-          if (msg.file !== path) {
-            throw new Error(
-              `message uid:${msg.uid} has file "${
-                msg.file
-              }" but needs to have "${path}"`,
-            );
-          }
-          return msg;
-        }),
-      });
-
-    const version = {
-      ...fakeVersion,
-      file: {
-        ...fakeVersionFile,
-        entries: { [path]: { ...fakeVersionEntry, path } },
-        // eslint-disable-next-line @typescript-eslint/camelcase
-        selected_file: path,
-      },
-    };
-
-    _loadVersionAndFile({ store, version });
-
-    // Simulate selecting the file to render.
-    store.dispatch(
-      versionActions.updateSelectedPath({
-        selectedPath: path,
-        versionId: version.id,
-      }),
-    );
-    store.dispatch(
-      linterActions.loadLinterResult({
-        versionId: version.id,
-        result: externalResult,
-      }),
-    );
-
-    return render({ versionId: versionId || String(version.id), store });
   };
 
   it('renders a page with a loading message', () => {
@@ -272,86 +160,6 @@ describe(__filename, () => {
     expect(root.find(Loading)).toHaveProp('message', 'Loading content...');
   });
 
-  it('dispatches fetchVersion() on mount', () => {
-    const addonId = 123456;
-    const version = fakeVersion;
-
-    const store = configureStore();
-    const dispatch = spyOn(store, 'dispatch');
-    const fakeThunk = createFakeThunk();
-    const _fetchVersion = fakeThunk.createThunk;
-
-    render({
-      _fetchVersion,
-      store,
-      addonId: String(addonId),
-      versionId: String(version.id),
-    });
-
-    expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(_fetchVersion).toHaveBeenCalledWith({
-      addonId,
-      versionId: version.id,
-    });
-  });
-
-  it('dispatches fetchLinterMessages() when receiving a version', () => {
-    const version = { ...fakeVersion, id: fakeVersion.id + 1 };
-    const {
-      dispatch,
-      _fetchLinterMessages,
-      fakeThunk,
-    } = renderAndUpdateWithVersion({ version });
-
-    expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(_fetchLinterMessages).toHaveBeenCalledWith({
-      versionId: version.id,
-      url: createInternalVersion(version).validationURL,
-    });
-  });
-
-  it('does not dispatch fetchLinterMessages() without a version', () => {
-    const fakeThunk = createFakeThunk();
-    const _fetchLinterMessages = fakeThunk.createThunk;
-
-    const store = configureStore();
-    const dispatch = spyOn(store, 'dispatch');
-
-    const root = render({ _fetchLinterMessages, store });
-
-    dispatch.mockClear();
-
-    // Simulate an update.
-    root.setProps({});
-
-    expect(dispatch).not.toHaveBeenCalled();
-  });
-
-  it('does not dispatch fetchLinterMessages() if linter messages have loaded', () => {
-    const version = { ...fakeVersion, id: fakeVersion.id + 1 };
-    const store = configureStore();
-    store.dispatch(
-      linterActions.loadLinterResult({
-        versionId: version.id,
-        result: fakeExternalLinterResult,
-      }),
-    );
-    const { dispatch } = renderAndUpdateWithVersion({ store, version });
-
-    expect(dispatch).not.toHaveBeenCalled();
-  });
-
-  it('does not dispatch fetchLinterMessages() when linter messages are loading', () => {
-    const version = { ...fakeVersion, id: fakeVersion.id + 1 };
-    const store = configureStore();
-    store.dispatch(
-      linterActions.beginFetchLinterResult({ versionId: version.id }),
-    );
-    const { dispatch } = renderAndUpdateWithVersion({ version, store });
-
-    expect(dispatch).not.toHaveBeenCalled();
-  });
-
   it('dispatches fetchVersionFile() when a file is selected', () => {
     const addonId = 123456;
     const version = fakeVersion;
@@ -383,118 +191,5 @@ describe(__filename, () => {
       versionId: version.id,
       path,
     });
-  });
-
-  it('renders a global LinterMessage', () => {
-    const path = 'lib/react.js';
-    const externalMessage = globalExternalMessage({ file: path });
-
-    const root = renderWithMessages({
-      path,
-      externalMessages: [externalMessage],
-    });
-
-    const message = root.find(LinterMessage);
-    expect(message).toHaveLength(1);
-    expect(message).toHaveProp(
-      'message',
-      createInternalMessage(externalMessage),
-    );
-  });
-
-  it('renders all global LinterMessage components', () => {
-    const firstUid = 'first-uid';
-    const secondUid = 'second-uid';
-
-    const path = 'lib/react.js';
-    const root = renderWithMessages({
-      path,
-      externalMessages: [
-        globalExternalMessage({ uid: firstUid, file: path }),
-        globalExternalMessage({ uid: secondUid, file: path }),
-      ],
-    });
-
-    const message = root.find(LinterMessage);
-    expect(message).toHaveLength(2);
-    expect(message.at(0).prop('message')).toMatchObject({ uid: firstUid });
-    expect(message.at(1).prop('message')).toMatchObject({ uid: secondUid });
-  });
-
-  it('ignores global messages for the wrong version', () => {
-    const path = 'lib/react.js';
-
-    const root = renderWithMessages({
-      path,
-      externalMessages: [globalExternalMessage({ file: path })],
-      // Render an unrelated version.
-      versionId: '432132',
-    });
-
-    const message = root.find(LinterMessage);
-    expect(message).toHaveLength(0);
-  });
-
-  it('ignores global messages for the wrong file', () => {
-    const result = createFakeExternalLinterResult({
-      messages: [
-        // Define a message for an unrelated file.
-        globalExternalMessage({ file: 'scripts/background.js' }),
-      ],
-    });
-
-    const root = renderWithMessages({
-      // Render this as the selected file path.
-      path: 'lib/react.js',
-      result,
-    });
-
-    const message = root.find(LinterMessage);
-    expect(message).toHaveLength(0);
-  });
-
-  it('passes LinterMessagesByLine to CodeView', () => {
-    const path = 'lib/react.js';
-    const externalMessage = {
-      ...fakeExternalLinterMessage,
-      file: path,
-      line: 1,
-    };
-
-    const result = createFakeExternalLinterResult({
-      messages: [externalMessage],
-    });
-
-    const root = renderWithMessages({ path, result });
-
-    const code = root.find(CodeView);
-    expect(code).toHaveLength(1);
-    expect(code).toHaveProp(
-      'linterMessagesByLine',
-      getMessageMap(result)[path].byLine,
-    );
-  });
-
-  it('does not pass LinterMessagesByLine to CodeView if files do not match', () => {
-    const result = createFakeExternalLinterResult({
-      messages: [
-        {
-          ...fakeExternalLinterMessage,
-          // Define a message for an unrelated file.
-          file: 'scripts/background.js',
-          line: 1,
-        },
-      ],
-    });
-
-    const root = renderWithMessages({
-      // Render this as the selected file path.
-      path: 'lib/react.js',
-      result,
-    });
-
-    const code = root.find(CodeView);
-    expect(code).toHaveLength(1);
-    expect(code).toHaveProp('linterMessagesByLine', undefined);
   });
 });

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -356,6 +356,9 @@ export const createContextWithFakeRouter = ({
         },
       },
     },
+    // Enzyme's mount() seems to validate the prop-types by throwing
+    // invariant errors.
+    // See https://github.com/mozilla/addons-code-manager/issues/404
     childContextTypes: {
       router: PropTypes.object.isRequired,
     },

--- a/stories/DiffView.stories.tsx
+++ b/stories/DiffView.stories.tsx
@@ -16,15 +16,7 @@ import {
   fakeVersionEntry,
   fakeVersionFile,
 } from '../src/test-helpers';
-import { renderWithStoreAndRouter } from './utils';
-
-let uid = 0;
-
-const newUID = () => {
-  // This helps make message keys for the storybook React page.
-  uid++;
-  return `msg-${uid}`;
-};
+import { newLinterMessageUID, renderWithStoreAndRouter } from './utils';
 
 const render = (
   moreProps: Partial<DiffViewProps> = {},
@@ -47,7 +39,7 @@ const renderWithMessages = (
   const path = 'lib/some-file.js';
   const result = createFakeExternalLinterResult({
     messages: messages.map((msg) => {
-      return { uid: newUID(), ...msg, file: path };
+      return { uid: newLinterMessageUID(), ...msg, file: path };
     }),
   });
 

--- a/stories/utils.tsx
+++ b/stories/utils.tsx
@@ -14,3 +14,16 @@ export const renderWithStoreAndRouter = (
     </Provider>
   );
 };
+
+let _uid = 0;
+
+/*
+ * Returns a unique UID for a linter message.
+ *
+ * This is only needed in story book where linter messages do not already
+ * have unique UIDs.
+ */
+export const newLinterMessageUID = () => {
+  _uid++;
+  return `msg-${_uid}`;
+};


### PR DESCRIPTION
This is the final patch to fix https://github.com/mozilla/addons-code-manager/issues/438

It moves `CodeView` to a `LinterProvider` implementation and removes unnecessary linter logic from `pages/Browse`. After this, all components are sharing the same linter logic without any duplicated code.