### PR TITLE
Use new fxa config

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ REACT_APP_AUTHENTICATION_COOKIE=frontend_auth_token
 REACT_APP_DEFAULT_API_LANG=en-US
 REACT_APP_DEFAULT_API_VERSION=v4dev
 
-REACT_APP_FXA_CONFIG=amo
+REACT_APP_FXA_CONFIG=code-manager
 
 # This is disabled so that CRA doesn't inject inline script
 # which violates the CSP.


### PR DESCRIPTION
Fixes #477

---

This won't change anything right now, but it is needed to make
authentication work with FxA and the API in -dev (and later, stage and
prod).