### PR TITLE
Dispatch addError() instead of logging an error message

### DIFF
--- a/src/reducers/linter.tsx
+++ b/src/reducers/linter.tsx
@@ -3,6 +3,7 @@ import { Reducer } from 'redux';
 import { ActionType, createAction, getType } from 'typesafe-actions';
 
 import { ThunkActionCreator } from '../configureStore';
+import { actions as errorsActions } from './errors';
 
 type LinterMessageBase = {
   column: number | null;
@@ -147,11 +148,9 @@ export const actions = {
 };
 
 export const fetchLinterMessages = ({
-  _log = log,
   url,
   versionId,
 }: {
-  _log?: typeof log;
   url: string;
   versionId: number;
 }): ThunkActionCreator => {
@@ -168,7 +167,7 @@ export const fetchLinterMessages = ({
       const result = await response.json();
       dispatch(actions.loadLinterResult({ versionId, result }));
     } catch (error) {
-      _log.error(`TODO: handle this error: ${error}`);
+      dispatch(errorsActions.addError({ error }));
       dispatch(actions.abortFetchLinterResult({ versionId }));
     }
   };

--- a/src/reducers/users.spec.tsx
+++ b/src/reducers/users.spec.tsx
@@ -9,7 +9,8 @@ import reducer, {
   requestLogOut,
   selectCurrentUser,
 } from './users';
-import { createFakeLogger, fakeUser, thunkTester } from '../test-helpers';
+import { fakeUser, thunkTester } from '../test-helpers';
+import { actions as errorsActions } from './errors';
 
 describe(__filename, () => {
   describe('reducer', () => {
@@ -187,23 +188,17 @@ describe(__filename, () => {
       expect(dispatch).toHaveBeenCalledWith(actions.loadCurrentUser({ user }));
     });
 
-    it('logs an error when API response is not successful', async () => {
-      const _log = createFakeLogger();
+    it('dispatches addError() when API response is not successful', async () => {
+      const error = new Error('Bad Request');
+      const _getCurrentUser = jest
+        .fn()
+        .mockReturnValue(Promise.resolve({ error }));
 
-      const _getCurrentUser = jest.fn().mockReturnValue(
-        Promise.resolve({
-          error: new Error('Bad Request'),
-        }),
-      );
-
-      const { dispatch, thunk } = _fetchCurrentUser({
-        _log,
-        _getCurrentUser,
-      });
+      const { dispatch, thunk } = _fetchCurrentUser({ _getCurrentUser });
 
       await thunk();
 
-      expect(_log.error).toHaveBeenCalled();
+      expect(dispatch).toHaveBeenCalledWith(errorsActions.addError({ error }));
       expect(dispatch).not.toHaveBeenCalledWith(
         expect.objectContaining({
           type: getType(actions.loadCurrentUser),

--- a/src/reducers/users.tsx
+++ b/src/reducers/users.tsx
@@ -1,9 +1,9 @@
 import { Reducer } from 'redux';
 import { ActionType, createAction, getType } from 'typesafe-actions';
-import log from 'loglevel';
 
 import { ThunkActionCreator } from '../configureStore';
 import { getCurrentUser, isErrorResponse, logOutFromServer } from '../api';
+import { actions as errorsActions } from './errors';
 
 type UserId = number;
 
@@ -89,7 +89,6 @@ export const currentUserIsLoading = (users: UsersState) => {
 
 export const fetchCurrentUser = ({
   _getCurrentUser = getCurrentUser,
-  _log = log,
 } = {}): ThunkActionCreator => {
   return async (dispatch, getState) => {
     const { api: apiState } = getState();
@@ -98,7 +97,7 @@ export const fetchCurrentUser = ({
     const response = await _getCurrentUser(apiState);
 
     if (isErrorResponse(response)) {
-      _log.error(`TODO: handle this error response: ${response.error}`);
+      dispatch(errorsActions.addError({ error: response.error }));
       dispatch(actions.abortFetchCurrentUser());
     } else {
       dispatch(actions.loadCurrentUser({ user: response }));

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -525,7 +525,6 @@ describe(__filename, () => {
 
   describe('fetchVersionFile', () => {
     const _fetchVersionFile = ({
-      _log = createFakeLogger(),
       addonId = 123,
       path = 'some/path.js',
       version = fakeVersion,
@@ -535,7 +534,6 @@ describe(__filename, () => {
         createThunk: () =>
           fetchVersionFile({
             _getVersion,
-            _log,
             addonId,
             path,
             versionId: version.id,
@@ -599,20 +597,15 @@ describe(__filename, () => {
       );
     });
 
-    it('logs an error when API response is not successful', async () => {
-      const _log = createFakeLogger();
+    it('dispatches addError() when API response is not successful', async () => {
+      const error = new Error('Bad Request');
+      const _getVersion = jest.fn().mockReturnValue(Promise.resolve({ error }));
 
-      const _getVersion = jest.fn().mockReturnValue(
-        Promise.resolve({
-          error: new Error('Bad Request'),
-        }),
-      );
-
-      const { dispatch, thunk } = _fetchVersionFile({ _log, _getVersion });
+      const { dispatch, thunk } = _fetchVersionFile({ _getVersion });
 
       await thunk();
 
-      expect(_log.error).toHaveBeenCalled();
+      expect(dispatch).toHaveBeenCalledWith(errorsActions.addError({ error }));
       expect(dispatch).not.toHaveBeenCalledWith(
         expect.objectContaining({
           type: getType(actions.loadVersionFile),
@@ -626,14 +619,12 @@ describe(__filename, () => {
       _getVersionsList = jest
         .fn()
         .mockReturnValue(Promise.resolve(fakeVersionsList)),
-      _log = createFakeLogger(),
       addonId = 123,
     } = {}) => {
       return thunkTester({
         createThunk: () =>
           fetchVersionsList({
             _getVersionsList,
-            _log,
             addonId,
           }),
       });
@@ -678,21 +669,16 @@ describe(__filename, () => {
     });
 
     it('logs an error when API response is not successful', async () => {
-      const _log = createFakeLogger();
-      const _getVersionsList = jest.fn().mockReturnValue(
-        Promise.resolve({
-          error: new Error('Bad Request'),
-        }),
-      );
+      const error = new Error('Bad Request');
+      const _getVersionsList = jest
+        .fn()
+        .mockReturnValue(Promise.resolve({ error }));
 
-      const { dispatch, thunk } = _fetchVersionsList({
-        _getVersionsList,
-        _log,
-      });
+      const { dispatch, thunk } = _fetchVersionsList({ _getVersionsList });
 
       await thunk();
 
-      expect(_log.error).toHaveBeenCalled();
+      expect(dispatch).toHaveBeenCalledWith(errorsActions.addError({ error }));
       expect(dispatch).not.toHaveBeenCalledWith(
         expect.objectContaining({
           type: getType(actions.loadVersionsList),

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -352,7 +352,6 @@ export const getVersionFile = (
 };
 
 type FetchVersionParams = {
-  _log?: typeof log;
   _getVersion?: typeof getVersion;
   addonId: number;
   versionId: number;
@@ -388,7 +387,6 @@ export const fetchVersion = ({
 
 type FetchVersionFileParams = {
   _getVersion?: typeof getVersion;
-  _log?: typeof log;
   addonId: number;
   path: string;
   versionId: number;
@@ -396,7 +394,6 @@ type FetchVersionFileParams = {
 
 export const fetchVersionFile = ({
   _getVersion = getVersion,
-  _log = log,
   addonId,
   path,
   versionId,
@@ -414,7 +411,7 @@ export const fetchVersionFile = ({
     });
 
     if (isErrorResponse(response)) {
-      _log.error(`TODO: handle this error response: ${response.error}`);
+      dispatch(errorsActions.addError({ error: response.error }));
     } else {
       dispatch(actions.loadVersionFile({ path, version: response }));
     }
@@ -435,13 +432,11 @@ export const createVersionsMap = (
 
 type FetchVersionsListParams = {
   _getVersionsList?: typeof getVersionsList;
-  _log?: typeof log;
   addonId: number;
 };
 
 export const fetchVersionsList = ({
   _getVersionsList = getVersionsList,
-  _log = log,
   addonId,
 }: FetchVersionsListParams): ThunkActionCreator => {
   return async (dispatch, getState) => {
@@ -450,7 +445,7 @@ export const fetchVersionsList = ({
     const response = await _getVersionsList({ addonId, apiState });
 
     if (isErrorResponse(response)) {
-      _log.error(`TODO: handle this error response: ${response.error}`);
+      dispatch(errorsActions.addError({ error: response.error }));
     } else {
       dispatch(actions.loadVersionsList({ addonId, versions: response }));
     }
@@ -517,7 +512,6 @@ export const createInternalDiffs = ({
 
 type FetchDiffParams = {
   _getDiff?: typeof getDiff;
-  _log?: typeof log;
   addonId: number;
   baseVersionId: number;
   headVersionId: number;
@@ -526,7 +520,6 @@ type FetchDiffParams = {
 
 export const fetchDiff = ({
   _getDiff = getDiff,
-  _log = log,
   addonId,
   baseVersionId,
   headVersionId,
@@ -546,7 +539,7 @@ export const fetchDiff = ({
     });
 
     if (isErrorResponse(response)) {
-      _log.error(`TODO: handle this error response: ${response.error}`);
+      dispatch(errorsActions.addError({ error: response.error }));
       dispatch(actions.abortFetchDiff());
     } else {
       dispatch(actions.loadVersionInfo({ version: response }));


### PR DESCRIPTION
Fixes #472 

---

Removed a bunch of TODOs by dispatching `addError()` instead.

Note: I did not change the behavior of the `linter` reducer here: https://github.com/mozilla/addons-code-manager/blob/c77356d60a358b1775dacb627f9f6630974c4773/src/reducers/linter.tsx#L198-L207