### PR TITLE
Create a function to construct an API URL and use it

### DIFF
--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -359,6 +359,7 @@ describe(__filename, () => {
       expect(makeApiURL({ _getApiHost, path })).toEqual(
         `${apiHost}/api/${defaultVersion}${path}`,
       );
+      expect(_getApiHost).toHaveBeenCalled();
     });
 
     it('can omit the version', () => {
@@ -371,7 +372,6 @@ describe(__filename, () => {
 
     it('can omit the prefix', () => {
       const path = '/foo/';
-      // This is needed because `stringMatching` won't throw if `prefix` is there.
       const apiHost = 'https://example.org';
       const _getApiHost = jest.fn().mockReturnValue(apiHost);
 
@@ -382,7 +382,6 @@ describe(__filename, () => {
 
     it('can omit both the prefix and version', () => {
       const path = '/foo/';
-      // This is needed because `stringMatching` won't throw if `prefix` is there.
       const apiHost = 'https://example.org';
       const _getApiHost = jest.fn().mockReturnValue(apiHost);
 
@@ -415,14 +414,6 @@ describe(__filename, () => {
       expect(makeApiURL({ path })).toEqual(
         expect.stringMatching(`/api/${defaultVersion}/${path}`),
       );
-    });
-
-    it('calls _getApiHost', () => {
-      const _getApiHost = jest.fn();
-
-      makeApiURL({ _getApiHost, path: '/' });
-
-      expect(_getApiHost).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/LoginButton/index.spec.tsx
+++ b/src/components/LoginButton/index.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button } from 'react-bootstrap';
 
-import { getApiHost } from '../../api';
+import { makeApiURL } from '../../api';
 import {
   createContextWithFakeRouter,
   createFakeLocation,
@@ -11,18 +11,9 @@ import {
 import LoginButton, { LoginButtonBase } from '.';
 
 describe(__filename, () => {
-  const render = ({
-    _getApiHost = getApiHost,
-    apiVersion = '123',
-    fxaConfig = 'fxa',
-    pathname = '/',
-  } = {}) => {
+  const render = ({ fxaConfig = 'fxa', pathname = '/' } = {}) => {
     return shallowUntilTarget(
-      <LoginButton
-        _getApiHost={_getApiHost}
-        apiVersion={apiVersion}
-        fxaConfig={fxaConfig}
-      />,
+      <LoginButton fxaConfig={fxaConfig} />,
       LoginButtonBase,
       {
         shallowOptions: createContextWithFakeRouter({
@@ -33,29 +24,17 @@ describe(__filename, () => {
   };
 
   it('renders a login button', () => {
-    const apiVersion = 'api-version';
     const fxaConfig = 'some-fxa-config';
     const pathname = '/en-US/browse/491343/versions/1527716/';
 
-    const root = render({ apiVersion, fxaConfig, pathname });
+    const root = render({ fxaConfig, pathname });
 
     expect(root.find(Button)).toHaveLength(1);
     expect(root.find(Button)).toHaveProp(
       'href',
-      `${getApiHost()}/api/${apiVersion}/accounts/login/start/?config=${fxaConfig}&to=${pathname}`,
-    );
-  });
-
-  it('calls _getApiHost() when rendering the button', () => {
-    const apiHost = 'http://example.org';
-    const _getApiHost = jest.fn().mockReturnValue(apiHost);
-
-    const root = render({ _getApiHost });
-
-    expect(_getApiHost).toHaveBeenCalled();
-    expect(root.find(Button)).toHaveProp(
-      'href',
-      expect.stringMatching(`^${apiHost}`),
+      makeApiURL({
+        path: `/accounts/login/start/?config=${fxaConfig}&to=${pathname}`,
+      }),
     );
   });
 });

--- a/src/components/LoginButton/index.tsx
+++ b/src/components/LoginButton/index.tsx
@@ -2,15 +2,13 @@ import * as React from 'react';
 import { Button } from 'react-bootstrap';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 
-import { getApiHost } from '../../api';
+import { makeApiURL } from '../../api';
 import { gettext } from '../../utils';
 import styles from './styles.module.scss';
 
 type PublicProps = {};
 
 type DefaultProps = {
-  _getApiHost: typeof getApiHost;
-  apiVersion: string;
   fxaConfig: string;
 };
 
@@ -18,17 +16,17 @@ type Props = PublicProps & DefaultProps & RouteComponentProps;
 
 export class LoginButtonBase extends React.Component<Props> {
   static defaultProps: DefaultProps = {
-    _getApiHost: getApiHost,
-    apiVersion: process.env.REACT_APP_DEFAULT_API_VERSION as string,
     fxaConfig: process.env.REACT_APP_FXA_CONFIG as string,
   };
 
   getFxaURL() {
-    const { _getApiHost, apiVersion, fxaConfig, location } = this.props;
+    const { fxaConfig, location } = this.props;
 
-    return `${_getApiHost()}/api/${apiVersion}/accounts/login/start/?config=${fxaConfig}&to=${
-      location.pathname
-    }`;
+    return makeApiURL({
+      path: `/accounts/login/start/?config=${fxaConfig}&to=${
+        location.pathname
+      }`,
+    });
   }
 
   render() {

--- a/src/reducers/linter.spec.tsx
+++ b/src/reducers/linter.spec.tsx
@@ -19,6 +19,7 @@ import linterReducer, {
   selectMessageMap,
 } from './linter';
 import { actions as errorsActions } from './errors';
+import { makeApiURL } from '../api';
 
 describe(__filename, () => {
   const createExternalLinterResult = (
@@ -429,7 +430,9 @@ describe(__filename, () => {
       const { thunk } = _fetchLinterMessages({ url });
       await thunk();
 
-      expect(fetchMock).toHaveBeenCalledWith(url);
+      expect(fetchMock).toHaveBeenCalledWith(
+        makeApiURL({ path: url, version: null, prefix: null }),
+      );
     });
 
     it('dispatches beginFetchLinterResult', async () => {

--- a/src/reducers/linter.tsx
+++ b/src/reducers/linter.tsx
@@ -4,6 +4,7 @@ import { ActionType, createAction, getType } from 'typesafe-actions';
 
 import { ThunkActionCreator } from '../configureStore';
 import { actions as errorsActions } from './errors';
+import { makeApiURL } from '../api';
 
 type LinterMessageBase = {
   column: number | null;
@@ -158,7 +159,9 @@ export const fetchLinterMessages = ({
     dispatch(actions.beginFetchLinterResult({ versionId }));
 
     // This is a special URL and returns a non-standard JSON response.
-    const response = await fetch(url);
+    const response = await fetch(
+      makeApiURL({ path: url, version: null, prefix: null }),
+    );
 
     try {
       if (!response.ok) {


### PR DESCRIPTION
Fixes #466
Fixes #480 

---

This patch ntroduces a `makeApiURL` function to construct an API URL with common values. Happy to change its name.