### PR TITLE
Configure a CDN

### DIFF
--- a/.env
+++ b/.env
@@ -15,3 +15,6 @@ REACT_APP_FXA_CONFIG=code-manager
 # which violates the CSP.
 INLINE_RUNTIME_CHUNK=false
 
+# CRA forces us to use a variable named `PUBLIC_URL` to set the CDN URL...
+# See: https://facebook.github.io/create-react-app/docs/advanced-configuration
+PUBLIC_URL=https://addons-code-manager.cdn.mozilla.net

--- a/.env.dev
+++ b/.env.dev
@@ -1,1 +1,3 @@
 REACT_APP_API_HOST=https://addons-dev.allizom.org
+# CDN URL
+PUBLIC_URL=https://addons-code-manager-dev-cdn.allizom.org

--- a/.env.stage
+++ b/.env.stage
@@ -1,1 +1,3 @@
 REACT_APP_API_HOST=https://addons.allizom.org
+# CDN URL
+PUBLIC_URL=https://addons-code-manager-stage-cdn.allizom.org

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -15,6 +15,7 @@ export const DEFAULT_PORT = 3000;
 export type ServerEnvVars = {
   NODE_ENV: string;
   PORT: number;
+  PUBLIC_URL: string;
   REACT_APP_API_HOST: string;
   REACT_APP_AUTHENTICATION_COOKIE: string;
   REACT_APP_AUTH_TOKEN_PLACEHOLDER: string;
@@ -63,9 +64,9 @@ export const createServer = ({
     reportUri: '/__cspreport__',
   };
 
+  const cdnURL = env.PUBLIC_URL || "'none'";
+
   // This config sets the non-static CSP for deployed instances.
-  // TODO: A separate CDN should be configured for statics. When that happens
-  // the 'self' should be removed and replaced with the CDN host + path for statics.
   const prodCSP = {
     defaultSrc: ["'none'"],
     childSrc: ["'none'"],
@@ -81,12 +82,12 @@ export const createServer = ({
     formAction: ["'none'"],
     frameAncestors: ["'none'"],
     frameSrc: ["'none'"],
-    imgSrc: ["'self'"],
+    imgSrc: [cdnURL],
     manifestSrc: ["'none'"],
     mediaSrc: ["'none'"],
     objectSrc: ["'none'"],
-    scriptSrc: ["'self'"],
-    styleSrc: ["'self'"],
+    scriptSrc: [cdnURL],
+    styleSrc: [cdnURL],
     workerSrc: ["'none'"],
     reportUri: '/__cspreport__',
   };


### PR DESCRIPTION
Fixes #421 

---

This _should_ work. When running `yarn start` locally, I see absolute URLs in the HTML and these URLs look good.

Static files are already available on the -dev CDN: http://addons-code-manager-dev-cdn.allizom.org/, so deploying this patch should not be a problem, unless there is a CSP issue. We might loose the `favicon.ico` though 😢 