### PR TITLE
Pass credentials when fetching the linter results

### DIFF
--- a/src/reducers/linter.spec.tsx
+++ b/src/reducers/linter.spec.tsx
@@ -432,6 +432,7 @@ describe(__filename, () => {
 
       expect(fetchMock).toHaveBeenCalledWith(
         makeApiURL({ path: url, version: null, prefix: null }),
+        { credentials: 'include' },
       );
     });
 

--- a/src/reducers/linter.tsx
+++ b/src/reducers/linter.tsx
@@ -161,6 +161,7 @@ export const fetchLinterMessages = ({
     // This is a special URL and returns a non-standard JSON response.
     const response = await fetch(
       makeApiURL({ path: url, version: null, prefix: null }),
+      { credentials: 'include' },
     );
 
     try {


### PR DESCRIPTION
Fixes #490

---

This is safe to land since https://github.com/mozilla/addons-server/issues/11048 has been merged.

It is possible to try this patch in -dev by using Chrome and its "Local Overrides" feature:

![Screen Shot 2019-03-29 at 12 23 00](https://user-images.githubusercontent.com/217628/55229474-68f61e00-521d-11e9-8a85-cc89135a7fe9.png)
