### PR TITLE
Load a version into the store for the FileTree story

### DIFF
--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -8,10 +8,12 @@ import configureStore from '../../configureStore';
 import {
   Version,
   actions as versionActions,
+  createInternalVersion,
   createInternalVersionEntry,
   getVersionInfo,
 } from '../../reducers/versions';
 import {
+  createFakeLogger,
   fakeVersion,
   fakeVersionEntry,
   shallowUntilTarget,
@@ -366,12 +368,13 @@ describe(__filename, () => {
     };
 
     const render = ({
+      _log = createFakeLogger(),
       onSelect = jest.fn(),
       store = configureStore(),
       version = getVersion({ store }),
     } = {}) => {
       return shallowUntilTarget(
-        <FileTree versionId={version.id} onSelect={onSelect} />,
+        <FileTree _log={_log} versionId={version.id} onSelect={onSelect} />,
         FileTreeBase,
         {
           shallowOptions: { context: { store } },
@@ -495,6 +498,17 @@ describe(__filename, () => {
 
       const isNodeExpanded = treeFold.prop('isNodeExpanded');
       expect(isNodeExpanded(node)).toBeFalsy();
+    });
+
+    it('logs a warning message when no version is loaded', () => {
+      const _log = createFakeLogger();
+
+      render({
+        _log,
+        version: createInternalVersion({ ...fakeVersion, id: 0 }),
+      });
+
+      expect(_log.warn).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -8,7 +8,6 @@ import configureStore from '../../configureStore';
 import {
   Version,
   actions as versionActions,
-  createInternalVersion,
   createInternalVersionEntry,
   getVersionInfo,
 } from '../../reducers/versions';
@@ -372,10 +371,10 @@ describe(__filename, () => {
       _log = createFakeLogger(),
       onSelect = jest.fn(),
       store = configureStore(),
-      version = getVersion({ store }),
+      versionId = 1234,
     } = {}) => {
       return shallowUntilTarget(
-        <FileTree _log={_log} versionId={version.id} onSelect={onSelect} />,
+        <FileTree _log={_log} versionId={versionId} onSelect={onSelect} />,
         FileTreeBase,
         {
           shallowOptions: { context: { store } },
@@ -387,7 +386,7 @@ describe(__filename, () => {
       const store = configureStore();
       const version = getVersion({ store });
 
-      const root = render({ store, version });
+      const root = render({ store, versionId: version.id });
 
       expect(root.find(ListGroup)).toHaveLength(1);
       expect(root.find(Treefold)).toHaveLength(1);
@@ -401,7 +400,7 @@ describe(__filename, () => {
       const version = getVersion({ store });
       const onSelect = jest.fn();
 
-      const root = render({ onSelect, store, version });
+      const root = render({ onSelect, store, versionId: version.id });
 
       const node = (root.instance() as FileTreeBase).renderNode(
         getTreefoldRenderProps(),
@@ -417,7 +416,7 @@ describe(__filename, () => {
       const store = configureStore();
       const version = getVersion({ store });
 
-      const root = render({ store, version });
+      const root = render({ store, versionId: version.id });
 
       const node = (root.instance() as FileTreeBase).renderNode(
         getTreefoldRenderProps(),
@@ -440,7 +439,7 @@ describe(__filename, () => {
 
       const dispatch = spyOn(store, 'dispatch');
 
-      const root = render({ store, version });
+      const root = render({ store, versionId: version.id });
 
       const treeFold = root.find(Treefold);
       expect(treeFold).toHaveProp('onToggleExpand');
@@ -474,7 +473,7 @@ describe(__filename, () => {
 
       version = getVersionInfo(store.getState().versions, version.id);
 
-      const root = render({ store, version });
+      const root = render({ store, versionId: version.id });
 
       const treeFold = root.find(Treefold);
       expect(treeFold).toHaveProp('isNodeExpanded');
@@ -492,7 +491,7 @@ describe(__filename, () => {
       };
       const version = getVersion({ store });
 
-      const root = render({ store, version });
+      const root = render({ store, versionId: version.id });
 
       const treeFold = root.find(Treefold);
       expect(treeFold).toHaveProp('isNodeExpanded');
@@ -504,20 +503,25 @@ describe(__filename, () => {
     it('logs a warning message when no version is loaded', () => {
       const _log = createFakeLogger();
 
-      render({
-        _log,
-        version: createInternalVersion({ ...fakeVersion, id: 0 }),
-      });
+      render({ _log });
 
       expect(_log.warn).toHaveBeenCalled();
     });
 
     it('renders a Loading component when no version is loaded', () => {
-      const root = render({
-        version: createInternalVersion({ ...fakeVersion, id: 0 }),
-      });
+      const root = render();
 
       expect(root.find(Loading)).toHaveLength(1);
+    });
+
+    it('returns a Loading component from renderNode when no version is loaded', () => {
+      const root = render();
+
+      const node = (root.instance() as FileTreeBase).renderNode(
+        getTreefoldRenderProps(),
+      );
+
+      expect(shallow(<div>{node}</div>).find(Loading)).toHaveLength(1);
     });
 
     it('throws an error when isNodeExpanded is called without a version', () => {
@@ -526,9 +530,7 @@ describe(__filename, () => {
         name: 'some name',
         children: [],
       };
-      const root = render({
-        version: createInternalVersion({ ...fakeVersion, id: 0 }),
-      });
+      const root = render();
 
       const { isNodeExpanded } = root.instance() as FileTreeBase;
 
@@ -543,9 +545,7 @@ describe(__filename, () => {
         name: 'some name',
         children: [],
       };
-      const root = render({
-        version: createInternalVersion({ ...fakeVersion, id: 0 }),
-      });
+      const root = render();
 
       const { onToggleExpand } = root.instance() as FileTreeBase;
 

--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -371,7 +371,7 @@ describe(__filename, () => {
       version = getVersion({ store }),
     } = {}) => {
       return shallowUntilTarget(
-        <FileTree version={version} onSelect={onSelect} />,
+        <FileTree versionId={version.id} onSelect={onSelect} />,
         FileTreeBase,
         {
           shallowOptions: { context: { store } },
@@ -397,7 +397,7 @@ describe(__filename, () => {
       const version = getVersion({ store });
       const onSelect = jest.fn();
 
-      const root = render({ version, onSelect });
+      const root = render({ onSelect, store, version });
 
       const node = (root.instance() as FileTreeBase).renderNode(
         getTreefoldRenderProps(),
@@ -413,7 +413,7 @@ describe(__filename, () => {
       const store = configureStore();
       const version = getVersion({ store });
 
-      const root = render({ version });
+      const root = render({ store, version });
 
       const node = (root.instance() as FileTreeBase).renderNode(
         getTreefoldRenderProps(),

--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -22,6 +22,7 @@ import {
 import { getLocalizedString } from '../../utils';
 import { getTreefoldRenderProps } from '../FileTreeNode/index.spec';
 import FileTreeNode from '../FileTreeNode';
+import Loading from '../Loading';
 
 import FileTree, { DirectoryNode, FileTreeBase, buildFileTree } from '.';
 
@@ -509,6 +510,48 @@ describe(__filename, () => {
       });
 
       expect(_log.warn).toHaveBeenCalled();
+    });
+
+    it('renders a Loading component when no version is loaded', () => {
+      const root = render({
+        version: createInternalVersion({ ...fakeVersion, id: 0 }),
+      });
+
+      expect(root.find(Loading)).toHaveLength(1);
+    });
+
+    it('throws an error when isNodeExpanded is called without a version', () => {
+      const node = {
+        id: 'some/path',
+        name: 'some name',
+        children: [],
+      };
+      const root = render({
+        version: createInternalVersion({ ...fakeVersion, id: 0 }),
+      });
+
+      const { isNodeExpanded } = root.instance() as FileTreeBase;
+
+      expect(() => {
+        isNodeExpanded(node);
+      }).toThrow('Cannot check if node is expanded without a version');
+    });
+
+    it('throws an error when onToggleExpand is called without a version', () => {
+      const node = {
+        id: 'some/path',
+        name: 'some name',
+        children: [],
+      };
+      const root = render({
+        version: createInternalVersion({ ...fakeVersion, id: 0 }),
+      });
+
+      const { onToggleExpand } = root.instance() as FileTreeBase;
+
+      expect(() => {
+        onToggleExpand(node);
+      }).toThrow('Cannot toggle expanded path without a version');
     });
   });
 });

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -7,13 +7,14 @@ import Treefold, { TreefoldRenderProps } from 'react-treefold';
 import FileTreeNode, {
   PublicProps as FileTreeNodeProps,
 } from '../FileTreeNode';
+import Loading from '../Loading';
 import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
 import {
   Version,
   actions as versionsActions,
   getVersionInfo,
 } from '../../reducers/versions';
-import { getLocalizedString } from '../../utils';
+import { getLocalizedString, gettext } from '../../utils';
 
 type FileNode = {
   id: string;
@@ -163,39 +164,39 @@ export class FileTreeBase extends React.Component<Props> {
     if (version) {
       return <FileTreeNode {...props} onSelect={onSelect} version={version} />;
     }
-    // This should never happen. See the comment in mapStateToProps.
-    return null;
+    return <Loading message={gettext('Loading version...')} />;
   };
 
   onToggleExpand = (node: TreeNode) => {
     const { dispatch, version } = this.props;
 
-    if (version) {
-      dispatch(
-        versionsActions.toggleExpandedPath({
-          path: node.id,
-          versionId: version.id,
-        }),
-      );
+    if (!version) {
+      throw new Error('Cannot toggle expanded path without a version');
     }
+
+    dispatch(
+      versionsActions.toggleExpandedPath({
+        path: node.id,
+        versionId: version.id,
+      }),
+    );
   };
 
   isNodeExpanded = (node: TreeNode) => {
     const { version } = this.props;
 
-    if (version) {
-      return version.expandedPaths.includes(node.id);
+    if (!version) {
+      throw new Error('Cannot check if node is expanded without a version');
     }
-    // This should never happen. See the comment in mapStateToProps.
-    return false;
+
+    return version.expandedPaths.includes(node.id);
   };
 
   render() {
     const { version } = this.props;
 
     if (!version) {
-      // This should never happen. See the comment in mapStateToProps.
-      return null;
+      return <Loading message={gettext('Loading version...')} />;
     }
 
     const tree = buildFileTree(

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -6,8 +6,12 @@ import Treefold, { TreefoldRenderProps } from 'react-treefold';
 import FileTreeNode, {
   PublicProps as FileTreeNodeProps,
 } from '../FileTreeNode';
-import { ConnectedReduxProps } from '../../configureStore';
-import { Version, actions as versionsActions } from '../../reducers/versions';
+import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
+import {
+  Version,
+  actions as versionsActions,
+  getVersionInfo,
+} from '../../reducers/versions';
 import { getLocalizedString } from '../../utils';
 
 type FileNode = {
@@ -134,10 +138,14 @@ export const buildFileTree = (
 
 export type PublicProps = {
   onSelect: FileTreeNodeProps['onSelect'];
+  versionId: number;
+};
+
+type PropsFromState = {
   version: Version;
 };
 
-type Props = PublicProps & ConnectedReduxProps;
+type Props = PublicProps & PropsFromState & ConnectedReduxProps;
 
 export class FileTreeBase extends React.Component<Props> {
   renderNode = (props: TreefoldRenderPropsForFileTree) => {
@@ -184,4 +192,17 @@ export class FileTreeBase extends React.Component<Props> {
   }
 }
 
-export default connect()(FileTreeBase) as React.ComponentType<PublicProps>;
+const mapStateToProps = (
+  state: ApplicationState,
+  ownProps: PublicProps,
+): PropsFromState => {
+  const { versionId } = ownProps;
+
+  return {
+    version: getVersionInfo(state.versions, versionId),
+  };
+};
+
+export default connect(mapStateToProps)(FileTreeBase) as React.ComponentType<
+  PublicProps
+>;

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -1,3 +1,4 @@
+import log from 'loglevel';
 import * as React from 'react';
 import { ListGroup } from 'react-bootstrap';
 import { connect } from 'react-redux';
@@ -197,9 +198,18 @@ const mapStateToProps = (
   ownProps: PublicProps,
 ): PropsFromState => {
   const { versionId } = ownProps;
+  const version = getVersionInfo(state.versions, versionId);
+
+  if (!version) {
+    // This should never happen as we are fetching the version in all of the
+    // parents on this component and only rendering the FileTree if we have a
+    // version, but let's log a warning in case we encounter a case where this
+    // does happen.
+    log.warn(`No version was loaded for version: `, versionId);
+  }
 
   return {
-    version: getVersionInfo(state.versions, versionId),
+    version,
   };
 };
 

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -11,7 +11,6 @@ import {
 import configureStore from '../../configureStore';
 import {
   actions as versionActions,
-  createInternalVersion,
   getVersionFile,
 } from '../../reducers/versions';
 import FileTree from '../../components/FileTree';
@@ -103,10 +102,7 @@ describe(__filename, () => {
     const root = render({ store, versionId: String(version.id) });
 
     expect(root.find(FileTree)).toHaveLength(1);
-    expect(root.find(FileTree)).toHaveProp(
-      'version',
-      createInternalVersion(version),
-    );
+    expect(root.find(FileTree)).toHaveProp('versionId', version.id);
   });
 
   it('renders a FileMetadata component when a version file has loaded', () => {

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -91,7 +91,7 @@ export class BrowseBase extends React.Component<Props> {
         <Col md="3">
           <Row>
             <Col>
-              <FileTree onSelect={this.onSelectFile} version={version} />
+              <FileTree onSelect={this.onSelectFile} versionId={version.id} />
             </Col>
           </Row>
           {file && (

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -149,10 +149,7 @@ describe(__filename, () => {
     });
 
     expect(root.find(FileTree)).toHaveLength(1);
-    expect(root.find(FileTree)).toHaveProp(
-      'version',
-      createInternalVersion(version),
-    );
+    expect(root.find(FileTree)).toHaveProp('versionId', version.id);
   });
 
   it('renders a DiffView', () => {

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -127,7 +127,7 @@ export class CompareBase extends React.Component<Props> {
       <React.Fragment>
         <Col md="3">
           {version ? (
-            <FileTree onSelect={this.onSelectFile} version={version} />
+            <FileTree onSelect={this.onSelectFile} versionId={version.id} />
           ) : (
             this.renderLoadingMessageOrError(gettext('Loading file tree...'))
           )}

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -501,6 +501,7 @@ export const createFakeLogger = () => {
     debug: jest.fn(),
     error: jest.fn(),
     info: jest.fn(),
+    warn: jest.fn(),
   };
 };
 

--- a/stories/FileTree.stories.tsx
+++ b/stories/FileTree.stories.tsx
@@ -76,14 +76,9 @@ const render = ({ ...moreProps }: Partial<FileTreeProps> = {}) => {
   const store = configureStore();
   store.dispatch(versionActions.loadVersionInfo({ version }));
 
-  const internalVersion = getVersionInfo(
-    store.getState().versions,
-    version.id,
-  ) as Version;
-
   const props: FileTreeProps = {
     onSelect: onSelectFile,
-    versionId: internalVersion.id,
+    versionId: version.id,
     ...moreProps,
   };
   return renderWithStoreAndRouter(<FileTree {...props} />, store);

--- a/stories/FileTree.stories.tsx
+++ b/stories/FileTree.stories.tsx
@@ -1,6 +1,5 @@
 /* eslint @typescript-eslint/camelcase: 0 */
 import React from 'react';
-import { Store } from 'redux';
 import { storiesOf } from '@storybook/react';
 
 import configureStore from '../src/configureStore';
@@ -84,7 +83,7 @@ const render = ({ ...moreProps }: Partial<FileTreeProps> = {}) => {
 
   const props: FileTreeProps = {
     onSelect: onSelectFile,
-    version: internalVersion,
+    versionId: internalVersion.id,
     ...moreProps,
   };
   return renderWithStoreAndRouter(<FileTree {...props} />, store);

--- a/stories/FileTree.stories.tsx
+++ b/stories/FileTree.stories.tsx
@@ -7,11 +7,16 @@ import configureStore from '../src/configureStore';
 import FileTree, {
   PublicProps as FileTreeProps,
 } from '../src/components/FileTree';
-import { createInternalVersion } from '../src/reducers/versions';
+import {
+  Version,
+  VersionEntryType,
+  getVersionInfo,
+  actions as versionActions,
+} from '../src/reducers/versions';
 import { fakeVersion, fakeVersionEntry } from '../src/test-helpers';
 import { renderWithStoreAndRouter } from './utils';
 
-const version = createInternalVersion({
+const version = {
   ...fakeVersion,
   file: {
     ...fakeVersion.file,
@@ -25,7 +30,7 @@ const version = createInternalVersion({
         ...fakeVersionEntry,
         filename: 'background-scripts',
         path: 'background-scripts',
-        mime_category: 'directory',
+        mime_category: 'directory' as VersionEntryType,
       },
       'background-scripts/index.js': {
         ...fakeVersionEntry,
@@ -37,7 +42,7 @@ const version = createInternalVersion({
         ...fakeVersionEntry,
         depth: 1,
         filename: 'libs',
-        mime_category: 'directory',
+        mime_category: 'directory' as VersionEntryType,
         path: 'background-scripts/libs',
       },
       'background-scripts/libs/jquery.min.js': {
@@ -50,7 +55,7 @@ const version = createInternalVersion({
         ...fakeVersionEntry,
         depth: 1,
         filename: 'extra',
-        mime_category: 'directory',
+        mime_category: 'directory' as VersionEntryType,
         path: 'background-scripts/extra',
       },
       'styles.css': {
@@ -60,7 +65,7 @@ const version = createInternalVersion({
       },
     },
   },
-});
+};
 
 // We display an alert when a file has been selected.
 const onSelectFile = (path: string) => {
@@ -68,13 +73,18 @@ const onSelectFile = (path: string) => {
   alert(`Selected file: ${path}`);
 };
 
-const render = ({
-  store = configureStore(),
-  ...moreProps
-}: { store?: Store } & Partial<FileTreeProps> = {}) => {
+const render = ({ ...moreProps }: Partial<FileTreeProps> = {}) => {
+  const store = configureStore();
+  store.dispatch(versionActions.loadVersionInfo({ version }));
+
+  const internalVersion = getVersionInfo(
+    store.getState().versions,
+    version.id,
+  ) as Version;
+
   const props: FileTreeProps = {
     onSelect: onSelectFile,
-    version,
+    version: internalVersion,
     ...moreProps,
   };
   return renderWithStoreAndRouter(<FileTree {...props} />, store);


### PR DESCRIPTION
Fixes #502 

This doesn't actually fix #502, but it's a start. There was a problem before that we were not loading a version into the store, so when `toggleExpandedPath` was dispatched it generated an error. With this patch I can see that `toggleExpandedPath` is succeeding, and that `expandedPaths` in the store is being updated when we click on a folder, but the component isn't responding to that change. So it looks like the `FileTree` component in the story isn't actually connected to the store, even though we're using `renderWithStoreAndRouter`.

Do either of you have any ideas about why that might be?

As an aside, while doing some of this work on `FileTree` I keep running into situations in which it seems to me that it would make more sense to have `FileTree` get its `version` via `mapStateToProps` rather than being passed a `version` via `props` from its parent. I wonder if that would also fix this case as well, and if that's really what we should be doing here?
