### PR TITLE
Pass absolute url to api login (fxa)

### DIFF
--- a/src/components/LoginButton/index.spec.tsx
+++ b/src/components/LoginButton/index.spec.tsx
@@ -1,39 +1,34 @@
 import * as React from 'react';
 import { Button } from 'react-bootstrap';
+import { shallow } from 'enzyme';
 
 import { makeApiURL } from '../../api';
-import {
-  createContextWithFakeRouter,
-  createFakeLocation,
-  shallowUntilTarget,
-} from '../../test-helpers';
 
-import LoginButton, { LoginButtonBase } from '.';
+import LoginButton from '.';
 
 describe(__filename, () => {
-  const render = ({ fxaConfig = 'fxa', pathname = '/' } = {}) => {
-    return shallowUntilTarget(
-      <LoginButton fxaConfig={fxaConfig} />,
-      LoginButtonBase,
-      {
-        shallowOptions: createContextWithFakeRouter({
-          location: createFakeLocation({ pathname }),
-        }),
-      },
-    );
+  const render = ({ fxaConfig = 'fxa', _window = window } = {}) => {
+    return shallow(<LoginButton fxaConfig={fxaConfig} _window={_window} />);
   };
 
   it('renders a login button', () => {
     const fxaConfig = 'some-fxa-config';
-    const pathname = '/en-US/browse/491343/versions/1527716/';
+    const href = 'https://example.org/en-US/browse/4913/versions/1527/';
+    const _window = {
+      ...window,
+      location: {
+        ...window.location,
+        href,
+      },
+    };
 
-    const root = render({ fxaConfig, pathname });
+    const root = render({ fxaConfig, _window });
 
     expect(root.find(Button)).toHaveLength(1);
     expect(root.find(Button)).toHaveProp(
       'href',
       makeApiURL({
-        path: `/accounts/login/start/?config=${fxaConfig}&to=${pathname}`,
+        path: `/accounts/login/start/?config=${fxaConfig}&to=${href}`,
       }),
     );
   });

--- a/src/components/LoginButton/index.tsx
+++ b/src/components/LoginButton/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Button } from 'react-bootstrap';
-import { withRouter, RouteComponentProps } from 'react-router-dom';
 
 import { makeApiURL } from '../../api';
 import { gettext } from '../../utils';
@@ -9,22 +8,24 @@ import styles from './styles.module.scss';
 type PublicProps = {};
 
 type DefaultProps = {
+  _window: typeof window;
   fxaConfig: string;
 };
 
-type Props = PublicProps & DefaultProps & RouteComponentProps;
+type Props = PublicProps & DefaultProps;
 
 export class LoginButtonBase extends React.Component<Props> {
   static defaultProps: DefaultProps = {
+    _window: window,
     fxaConfig: process.env.REACT_APP_FXA_CONFIG as string,
   };
 
   getFxaURL() {
-    const { fxaConfig, location } = this.props;
+    const { _window, fxaConfig } = this.props;
 
     return makeApiURL({
       path: `/accounts/login/start/?config=${fxaConfig}&to=${
-        location.pathname
+        _window.location.href
       }`,
     });
   }
@@ -38,6 +39,6 @@ export class LoginButtonBase extends React.Component<Props> {
   }
 }
 
-export default withRouter(LoginButtonBase) as React.ComponentType<
+export default LoginButtonBase as React.ComponentType<
   PublicProps & Partial<DefaultProps>
 >;

--- a/src/components/LoginButton/index.tsx
+++ b/src/components/LoginButton/index.tsx
@@ -39,6 +39,4 @@ export class LoginButtonBase extends React.Component<Props> {
   }
 }
 
-export default LoginButtonBase as React.ComponentType<
-  PublicProps & Partial<DefaultProps>
->;
+export default LoginButtonBase;


### PR DESCRIPTION
Fixes #486

---

This is needed because the API (which sends the redirect after FxA login page) is not on the same domain, hence a relative URL cannot work. ~~This is not working yet because of an API issue (cf. https://github.com/mozilla/addons-server/issues/11018)~~.

When we use the `local` FxA config, we still want relative URLs because we are using the -dev API for local dev and the API will not allow `localhost:3000` as a valid domain (valid domains are: `code.addons-dev.allizom.org` or `addons-dev.allizom.org`). If we're using the API locally too, then it would recognize `localhost:3000` or `olympia.test` as valid domains, but that would work with relative URLs too so it is much simpler to always pass a relative URL when FxA config is `local`. This also means: the behavior before and after this patch remains the same locally (but it fixes the login issue on https://code.addons-dev.allizom.org).