### PR TITLE
Pass absolute url to api login (fxa)

### DIFF
--- a/src/components/LoginButton/index.spec.tsx
+++ b/src/components/LoginButton/index.spec.tsx
@@ -32,4 +32,29 @@ describe(__filename, () => {
       }),
     );
   });
+
+  it('passes a relative URL to addons-server when FxA config is `local`', () => {
+    const fxaConfig = 'local';
+    const origin = 'https://example.org';
+    const path = '/en-US/browse/4913/versions/1527/';
+    const href = `${origin}${path}`;
+    const _window = {
+      ...window,
+      location: {
+        ...window.location,
+        href,
+        origin,
+      },
+    };
+
+    const root = render({ fxaConfig, _window });
+
+    expect(root.find(Button)).toHaveLength(1);
+    expect(root.find(Button)).toHaveProp(
+      'href',
+      makeApiURL({
+        path: `/accounts/login/start/?config=${fxaConfig}&to=${path}`,
+      }),
+    );
+  });
 });

--- a/src/components/LoginButton/index.tsx
+++ b/src/components/LoginButton/index.tsx
@@ -22,11 +22,15 @@ export class LoginButtonBase extends React.Component<Props> {
 
   getFxaURL() {
     const { _window, fxaConfig } = this.props;
+    let { href } = _window.location;
+
+    // We use a relative URL for `local` FxA config.
+    if (fxaConfig === 'local') {
+      href = href.replace(_window.location.origin, '');
+    }
 
     return makeApiURL({
-      path: `/accounts/login/start/?config=${fxaConfig}&to=${
-        _window.location.href
-      }`,
+      path: `/accounts/login/start/?config=${fxaConfig}&to=${href}`,
     });
   }
 


### PR DESCRIPTION
I forgot these changes in #505 due to a bad rebase from a different laptop :/

This patch makes sure we use relative URLs for local dev because we're using the -dev API but the redirect URL is `localhost:3000` and it will be rejected by the -dev API.