### PR TITLE
Use existing CSP report URLs

### DIFF
--- a/src/server/index.spec.tsx
+++ b/src/server/index.spec.tsx
@@ -417,6 +417,13 @@ describe(__filename, () => {
           const policy = cspParser(response.header['content-security-policy']);
           expect(policy['connect-src']).toEqual(["'self'"]);
         });
+
+        it('uses a relative for the CSP report URI', async () => {
+          const response = await server.get('/');
+
+          const policy = cspParser(response.header['content-security-policy']);
+          expect(policy['report-uri']).toEqual(['/__cspreport__']);
+        });
       });
     });
 

--- a/src/server/index.spec.tsx
+++ b/src/server/index.spec.tsx
@@ -157,7 +157,9 @@ describe(__filename, () => {
           `${fakeEnv.PUBLIC_URL}${STATIC_PATH}`,
         ]);
         expect(policy['worker-src']).toEqual(["'none'"]);
-        expect(policy['report-uri']).toEqual(['/__cspreport__']);
+        expect(policy['report-uri']).toEqual([
+          `${fakeEnv.REACT_APP_API_HOST}/__cspreport__`,
+        ]);
 
         expect(response.header['referrer-policy']).toEqual('no-referrer');
         expect(response.header['strict-transport-security']).toEqual(
@@ -179,7 +181,9 @@ describe(__filename, () => {
         expect(staticPolicy['base-uri']).toEqual(["'none'"]);
         expect(staticPolicy['form-action']).toEqual(["'none'"]);
         expect(staticPolicy['object-src']).toEqual(["'none'"]);
-        expect(staticPolicy['report-uri']).toEqual(['/__cspreport__']);
+        expect(staticPolicy['report-uri']).toEqual([
+          `${fakeEnv.REACT_APP_API_HOST}/__cspreport__`,
+        ]);
 
         // Everything else, that shouldn't be set for statics.
         expect(staticPolicy['frame-ancestors']).toEqual(undefined);
@@ -191,8 +195,13 @@ describe(__filename, () => {
         expect(staticPolicy['script-src']).toEqual(undefined);
         expect(staticPolicy['style-src']).toEqual(undefined);
         expect(staticPolicy['worker-src']).toEqual(undefined);
+      });
 
-        // Check we have a default no-op CSP report endpoint.
+      it('exposes a default no-op CSP report endpoint', async () => {
+        const server = request(
+          createServer({ env: prodEnv as ServerEnvVars, rootPath }),
+        );
+
         const cspReportResponse = await server.post('/__cspreport__');
         expect(cspReportResponse.status).toEqual(200);
       });


### PR DESCRIPTION
Fixes #423

---

Use real CSP report URLs instead of the no-op one. In local dev, it should still be the no-op endpoint (`/__cspreport__`) but one can build and serve the app (make sure `.env.local` does not contain `REACT_APP_USE_INSECURE_PROXY=true`, then run `yarn build && yarn serve`) to see absolute CSP report URLs.