### PR TITLE
Add credentials: 'include' to logout call

### DIFF
--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -189,6 +189,19 @@ describe(__filename, () => {
         expect.any(Object),
       );
     });
+
+    it('accepts credentials', async () => {
+      const credentials = 'include';
+
+      await callApiWithDefaultApiState({ endpoint: '/url', credentials });
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          credentials,
+        }),
+      );
+    });
   });
 
   describe('isErrorResponse', () => {
@@ -267,6 +280,7 @@ describe(__filename, () => {
       expect(fetch).toHaveBeenCalledWith(
         expect.stringMatching(`/api/${defaultVersion}/accounts/session/`),
         {
+          credentials: 'include',
           headers: {},
           method: HttpMethod.DELETE,
         },

--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -203,6 +203,20 @@ describe(__filename, () => {
         }),
       );
     });
+
+    it('can omit credentials', async () => {
+      await callApiWithDefaultApiState({
+        endpoint: '/url',
+        includeCredentials: false,
+      });
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          credentials: undefined,
+        }),
+      );
+    });
   });
 
   describe('isErrorResponse', () => {

--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -190,15 +190,16 @@ describe(__filename, () => {
       );
     });
 
-    it('accepts credentials', async () => {
-      const credentials = 'include';
-
-      await callApiWithDefaultApiState({ endpoint: '/url', credentials });
+    it('can include credentials', async () => {
+      await callApiWithDefaultApiState({
+        endpoint: '/url',
+        includeCredentials: true,
+      });
 
       expect(fetch).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          credentials,
+          credentials: 'include',
         }),
       );
     });

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -67,6 +67,7 @@ export enum HttpMethod {
 
 type CallApiParams = {
   apiState: ApiState;
+  credentials?: 'omit' | 'same-origin' | 'include';
   endpoint: string;
   lang?: string;
   method?: HttpMethod;
@@ -99,6 +100,7 @@ type Headers = {
 // https://github.com/Microsoft/TypeScript/issues/4922
 export const callApi = async <SuccessResponseType extends {}>({
   apiState,
+  credentials,
   endpoint,
   lang = process.env.REACT_APP_DEFAULT_API_LANG,
   method = HttpMethod.GET,
@@ -133,8 +135,9 @@ export const callApi = async <SuccessResponseType extends {}>({
 
   try {
     const response = await fetch(makeApiURL({ path, version }), {
-      method,
+      credentials,
       headers,
+      method,
     });
 
     if (!response.ok) {
@@ -191,6 +194,7 @@ export const getVersionsList = async ({
 export const logOutFromServer = async (apiState: ApiState) => {
   return callApi<{}>({
     apiState,
+    credentials: 'include',
     endpoint: 'accounts/session',
     method: HttpMethod.DELETE,
   });

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -67,8 +67,8 @@ export enum HttpMethod {
 
 type CallApiParams = {
   apiState: ApiState;
-  credentials?: 'omit' | 'same-origin' | 'include';
   endpoint: string;
+  includeCredentials?: boolean;
   lang?: string;
   method?: HttpMethod;
   query?: { [key: string]: string };
@@ -100,8 +100,8 @@ type Headers = {
 // https://github.com/Microsoft/TypeScript/issues/4922
 export const callApi = async <SuccessResponseType extends {}>({
   apiState,
-  credentials,
   endpoint,
+  includeCredentials = false,
   lang = process.env.REACT_APP_DEFAULT_API_LANG,
   method = HttpMethod.GET,
   query = {},
@@ -135,7 +135,7 @@ export const callApi = async <SuccessResponseType extends {}>({
 
   try {
     const response = await fetch(makeApiURL({ path, version }), {
-      credentials,
+      credentials: includeCredentials ? 'include' : undefined,
       headers,
       method,
     });
@@ -194,7 +194,7 @@ export const getVersionsList = async ({
 export const logOutFromServer = async (apiState: ApiState) => {
   return callApi<{}>({
     apiState,
-    credentials: 'include',
+    includeCredentials: true,
     endpoint: 'accounts/session',
     method: HttpMethod.DELETE,
   });

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -194,6 +194,9 @@ export const getVersionsList = async ({
 export const logOutFromServer = async (apiState: ApiState) => {
   return callApi<{}>({
     apiState,
+    // We need to send the credentials (cookies) because the API will return
+    // new `Set-Cookie` headers to clear the cookies in the client. Without
+    // this, logging out would not be possible.
     includeCredentials: true,
     endpoint: 'accounts/session',
     method: HttpMethod.DELETE,


### PR DESCRIPTION
Fixes #515 

---

I don't know if a new parameter to `callApi` is what we want because only one endpoint will accept credentials and it will fail in all other cases, but it is simpler than re-implementing `callApi` in `logOutFromServer`.

This patch requires https://github.com/mozilla/addons-server/issues/11112 and I want to live-test this change in Chrome before landing this patch, but a quick review is always welcomed :)