### PR TITLE
Handle absolute URLs coming from the API

### DIFF
--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -380,15 +380,13 @@ describe(__filename, () => {
   });
 
   describe('makeApiURL', () => {
-    it('constructs an API URL for a given path', () => {
+    it('constructs an API url for a given path', () => {
       const apiHost = 'https://example.org';
       const path = '/foo/';
-      const _getApiHost = jest.fn().mockReturnValue(apiHost);
 
-      expect(makeApiURL({ _getApiHost, path })).toEqual(
+      expect(makeApiURL({ apiHost, path })).toEqual(
         `${apiHost}/api/${defaultVersion}${path}`,
       );
-      expect(_getApiHost).toHaveBeenCalled();
     });
 
     it('can omit the version', () => {
@@ -402,9 +400,8 @@ describe(__filename, () => {
     it('can omit the prefix', () => {
       const path = '/foo/';
       const apiHost = 'https://example.org';
-      const _getApiHost = jest.fn().mockReturnValue(apiHost);
 
-      expect(makeApiURL({ _getApiHost, path, prefix: null })).toEqual(
+      expect(makeApiURL({ apiHost, path, prefix: null })).toEqual(
         `${apiHost}/${defaultVersion}${path}`,
       );
     });
@@ -412,10 +409,9 @@ describe(__filename, () => {
     it('can omit both the prefix and version', () => {
       const path = '/foo/';
       const apiHost = 'https://example.org';
-      const _getApiHost = jest.fn().mockReturnValue(apiHost);
 
       expect(
-        makeApiURL({ _getApiHost, path, prefix: null, version: null }),
+        makeApiURL({ apiHost, path, prefix: null, version: null }),
       ).toEqual(`${apiHost}${path}`);
     });
 
@@ -443,6 +439,54 @@ describe(__filename, () => {
       expect(makeApiURL({ path })).toEqual(
         expect.stringMatching(`/api/${defaultVersion}/${path}`),
       );
+    });
+
+    it('constructs an API url for a given url', () => {
+      const url = 'https://example.org/foo/';
+
+      expect(makeApiURL({ url })).toEqual(url);
+    });
+
+    it('removes the apiHost of an url when apiHost is defined and useInsecureProxy is true', () => {
+      const apiHost = 'https://example.org';
+      const path = '/foo/';
+      const url = `${apiHost}${path}`;
+
+      expect(makeApiURL({ apiHost, url, useInsecureProxy: true })).toEqual(
+        path,
+      );
+    });
+
+    it('does not change the given url when apiHost is defined but useInsecureProxy is false', () => {
+      const apiHost = 'https://example.org';
+      const path = '/foo/';
+      const url = `${apiHost}${path}`;
+
+      expect(makeApiURL({ apiHost, url, useInsecureProxy: false })).toEqual(
+        url,
+      );
+    });
+
+    it('does not change the given url when useInsecureProxy is true but apiHost is not defined', () => {
+      const apiHost = 'https://example.org';
+      const path = '/foo/';
+      const url = `${apiHost}${path}`;
+
+      expect(
+        makeApiURL({ apiHost: null, url, useInsecureProxy: true }),
+      ).toEqual(url);
+    });
+
+    it('throws when both url and path are passed', () => {
+      expect(() => {
+        makeApiURL({ path: 'some-path', url: 'some-url' });
+      }).toThrow(/Cannot receive both `path` and `url` parameters/);
+    });
+
+    it('throws when neither url nor path are passed', () => {
+      expect(() => {
+        makeApiURL({});
+      }).toThrow(/Either `path` or `url` must be defined/);
     });
   });
 });

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -26,33 +26,53 @@ export const getApiHost = ({
 };
 
 type MakApiUrlParams = {
-  _getApiHost?: typeof getApiHost;
-  version?: string | null;
-  path: string;
+  apiHost?: string | null;
+  path?: string;
   prefix?: string | null;
+  url?: string;
+  useInsecureProxy?: boolean;
+  version?: string | null;
 };
 
 export const makeApiURL = ({
-  _getApiHost = getApiHost,
+  apiHost = process.env.REACT_APP_API_HOST,
   path,
   prefix = 'api',
+  url,
+  useInsecureProxy = process.env.REACT_APP_USE_INSECURE_PROXY === 'true',
   version = process.env.REACT_APP_DEFAULT_API_VERSION,
 }: MakApiUrlParams) => {
-  const parts = [_getApiHost()];
-
-  if (prefix) {
-    parts.push(`/${prefix}`);
+  if (path && url) {
+    throw new Error('Cannot receive both `path` and `url` parameters.');
   }
 
-  if (version) {
-    parts.push(`/${version}`);
-  }
+  const parts = [];
 
-  let adjustedPath = path;
-  if (!path.startsWith('/')) {
-    adjustedPath = `/${adjustedPath}`;
+  if (path) {
+    parts.push(getApiHost({ apiHost, useInsecureProxy }));
+
+    if (prefix) {
+      parts.push(`/${prefix}`);
+    }
+
+    if (version) {
+      parts.push(`/${version}`);
+    }
+
+    let adjustedPath = path;
+    if (!path.startsWith('/')) {
+      adjustedPath = `/${adjustedPath}`;
+    }
+    parts.push(adjustedPath);
+  } else if (url) {
+    let adjustedUrl = url;
+    if (apiHost && useInsecureProxy) {
+      adjustedUrl = adjustedUrl.replace(apiHost, '');
+    }
+    parts.push(adjustedUrl);
+  } else {
+    throw new Error('Either `path` or `url` must be defined.');
   }
-  parts.push(adjustedPath);
 
   return parts.join('');
 };

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -60,7 +60,7 @@ export const makeApiURL = ({
     }
 
     let adjustedPath = path;
-    if (!path.startsWith('/')) {
+    if (!adjustedPath.startsWith('/')) {
       adjustedPath = `/${adjustedPath}`;
     }
     parts.push(adjustedPath);

--- a/src/components/FileMetadata/index.spec.tsx
+++ b/src/components/FileMetadata/index.spec.tsx
@@ -10,6 +10,7 @@ import {
 import { fakeVersion } from '../../test-helpers';
 import styles from './styles.module.scss';
 import { formatFilesize } from '../../utils';
+import { makeApiURL } from '../../api';
 
 import FileMetadata from '.';
 
@@ -45,7 +46,11 @@ describe(__filename, () => {
     const downloadLink = root.find(`.${styles.downloadURL}`).find('a');
     expect(downloadLink).toHaveLength(1);
     expect(downloadLink).toHaveText(file.filename);
-    expect(downloadLink).toHaveProp('href', file.downloadURL);
+    expect(downloadLink).toHaveProp(
+      'href',
+      // `downloadURL` can only be `null` when `file` is a directory.
+      makeApiURL({ url: file.downloadURL as string }),
+    );
   });
 
   it('renders a formatted filesize', () => {

--- a/src/components/FileMetadata/index.tsx
+++ b/src/components/FileMetadata/index.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { VersionFile } from '../../reducers/versions';
 import styles from './styles.module.scss';
 import { formatFilesize, gettext } from '../../utils';
+import { makeApiURL } from '../../api';
 
 type PublicProps = {
   file: VersionFile;
@@ -28,7 +29,9 @@ const FileMetadataBase = ({ file }: PublicProps) => {
           <React.Fragment>
             <dt>{gettext('Download link')}</dt>
             <dd className={styles.downloadURL}>
-              <a href={file.downloadURL}>{file.filename}</a>
+              <a href={makeApiURL({ url: file.downloadURL })}>
+                {file.filename}
+              </a>
             </dd>
           </React.Fragment>
         )}

--- a/src/reducers/linter.spec.tsx
+++ b/src/reducers/linter.spec.tsx
@@ -430,10 +430,9 @@ describe(__filename, () => {
       const { thunk } = _fetchLinterMessages({ url });
       await thunk();
 
-      expect(fetchMock).toHaveBeenCalledWith(
-        makeApiURL({ path: url, version: null, prefix: null }),
-        { credentials: 'include' },
-      );
+      expect(fetchMock).toHaveBeenCalledWith(makeApiURL({ url }), {
+        credentials: 'include',
+      });
     });
 
     it('dispatches beginFetchLinterResult', async () => {

--- a/src/reducers/linter.tsx
+++ b/src/reducers/linter.tsx
@@ -159,10 +159,9 @@ export const fetchLinterMessages = ({
     dispatch(actions.beginFetchLinterResult({ versionId }));
 
     // This is a special URL and returns a non-standard JSON response.
-    const response = await fetch(
-      makeApiURL({ path: url, version: null, prefix: null }),
-      { credentials: 'include' },
-    );
+    const response = await fetch(makeApiURL({ url }), {
+      credentials: 'include',
+    });
 
     try {
       if (!response.ok) {

--- a/src/server/index.spec.tsx
+++ b/src/server/index.spec.tsx
@@ -411,12 +411,22 @@ describe(__filename, () => {
           expect(response.header).not.toHaveProperty('set-cookie');
         });
 
-        // The Browse API returns a `validation_url_json` field with the URL to
-        // the addons-linter validation report (in JSON).
-        // See: https://addons-server.readthedocs.io/en/latest/topics/api/reviewers.html#browse
+        // The Browse/Compare APIs return a `validation_url_json` field with
+        // the URL to the addons-linter validation report (in JSON).
+        // See: https://addons-server.readthedocs.io/en/latest/topics/api/reviewers.html
         it('forwards the addons-linter validation URLs to the REACT_APP_API_HOST server', async () => {
           const response = await server.get(
             '/en-US/developers/addon/amo-info-with-extra-dirs/file/262459/validation.json',
+          );
+
+          expect(response.text).toEqual(apiResponseBody);
+        });
+
+        // The Browse/Compare APIs return a `download_url` field with the URL
+        // to download the content of the selected file.
+        it('forwards the download URLs to the REACT_APP_API_HOST server', async () => {
+          const response = await server.get(
+            '/en-US/reviewers/download-git-file/1532144/manifest.json/',
           );
 
           expect(response.text).toEqual(apiResponseBody);

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -159,26 +159,33 @@ export const createServer = ({
     }
 
     app.use(
-      proxy(['/api/**', '/**/validation.json'], {
-        target: env.REACT_APP_API_HOST,
-        autoRewrite: true,
-        changeOrigin: true,
-        cookieDomainRewrite: '',
-        protocolRewrite: 'http',
-        secure: false,
-        onProxyRes: (proxyResponse: http.IncomingMessage) => {
-          // We make cookies unsecure because local development uses http and
-          // not https. Without this change, the server code would not be able
-          // to read the cookie that stores the authentication token.
-          if (proxyResponse.headers['set-cookie']) {
-            const cookies = proxyResponse.headers['set-cookie'].map(
-              (cookie: string) => cookie.replace(/;\s*?(Secure)/i, ''),
-            );
-            // eslint-disable-next-line no-param-reassign
-            proxyResponse.headers['set-cookie'] = cookies;
-          }
+      proxy(
+        [
+          '/api/**',
+          '/**/validation.json',
+          '/**/reviewers/download-git-file/**/',
+        ],
+        {
+          target: env.REACT_APP_API_HOST,
+          autoRewrite: true,
+          changeOrigin: true,
+          cookieDomainRewrite: '',
+          protocolRewrite: 'http',
+          secure: false,
+          onProxyRes: (proxyResponse: http.IncomingMessage) => {
+            // We make cookies unsecure because local development uses http and
+            // not https. Without this change, the server code would not be able
+            // to read the cookie that stores the authentication token.
+            if (proxyResponse.headers['set-cookie']) {
+              const cookies = proxyResponse.headers['set-cookie'].map(
+                (cookie: string) => cookie.replace(/;\s*?(Secure)/i, ''),
+              );
+              // eslint-disable-next-line no-param-reassign
+              proxyResponse.headers['set-cookie'] = cookies;
+            }
+          },
         },
-      }),
+      ),
     );
   }
 


### PR DESCRIPTION
Fixes mozilla/addons-server#531

---

Without this patch in local dev, it is not possible to download a file (authentication issue). Linter messages won't be retrieved anymore either because of https://github.com/mozilla/addons/issues/6512. In -dev, linter messages cannot be retrieved anymore either.

This patch fixes all these issues.