### PR TITLE
Filter old/new versions depending on the selected values

### DIFF
--- a/src/components/VersionChooser/index.spec.tsx
+++ b/src/components/VersionChooser/index.spec.tsx
@@ -286,16 +286,4 @@ describe(__filename, () => {
       `/${lang}/compare/${addonId}/versions/${baseVersionId}...${selectedVersion}/`,
     );
   });
-
-  describe('higherVersionsThan', () => {
-    it('returns a predicate that is always true when versionId is empty', () => {
-      expect(higherVersionsThan('')).toEqual(Boolean);
-    });
-  });
-
-  describe('lowerVersionsThan', () => {
-    it('returns a predicate that is always true when versionId is empty', () => {
-      expect(lowerVersionsThan('')).toEqual(Boolean);
-    });
-  });
 });

--- a/src/components/VersionChooser/index.spec.tsx
+++ b/src/components/VersionChooser/index.spec.tsx
@@ -286,4 +286,16 @@ describe(__filename, () => {
       `/${lang}/compare/${addonId}/versions/${baseVersionId}...${selectedVersion}/`,
     );
   });
+
+  describe('higherVersionsThan', () => {
+    it('returns a predicate that is always true when versionId is empty', () => {
+      expect(higherVersionsThan('')).toEqual(Boolean);
+    });
+  });
+
+  describe('lowerVersionsThan', () => {
+    it('returns a predicate that is always true when versionId is empty', () => {
+      expect(lowerVersionsThan('')).toEqual(Boolean);
+    });
+  });
 });

--- a/src/components/VersionChooser/index.tsx
+++ b/src/components/VersionChooser/index.tsx
@@ -15,12 +15,22 @@ import {
 import { gettext } from '../../utils';
 import styles from './styles.module.scss';
 
+export const higherVersionsThan = (versionId: string) => {
+  return (version: VersionsListItem) => version.id > parseInt(versionId, 10);
+};
+
+export const lowerVersionsThan = (versionId: string) => {
+  return (version: VersionsListItem) => version.id < parseInt(versionId, 10);
+};
+
 export type PublicProps = {
   addonId: number;
 };
 
 export type DefaultProps = {
   _fetchVersionsList: typeof fetchVersionsList;
+  _higherVersionsThan: typeof higherVersionsThan;
+  _lowerVersionsThan: typeof lowerVersionsThan;
 };
 
 type PropsFromState = {
@@ -41,17 +51,11 @@ type Props = PublicProps &
   PropsFromState &
   RouterProps;
 
-export const higherVersionsThan = (versionId: string) => {
-  return (version: VersionsListItem) => version.id > parseInt(versionId, 10);
-};
-
-export const lowerVersionsThan = (versionId: string) => {
-  return (version: VersionsListItem) => version.id < parseInt(versionId, 10);
-};
-
 export class VersionChooserBase extends React.Component<Props> {
   static defaultProps: DefaultProps = {
     _fetchVersionsList: fetchVersionsList,
+    _higherVersionsThan: higherVersionsThan,
+    _lowerVersionsThan: lowerVersionsThan,
   };
 
   componentDidMount() {
@@ -88,7 +92,12 @@ export class VersionChooserBase extends React.Component<Props> {
   };
 
   render() {
-    const { match, versionsMap } = this.props;
+    const {
+      _higherVersionsThan,
+      _lowerVersionsThan,
+      match,
+      versionsMap,
+    } = this.props;
     const { baseVersionId, headVersionId } = match.params;
 
     return (
@@ -104,27 +113,21 @@ export class VersionChooserBase extends React.Component<Props> {
             <Form.Row>
               <VersionSelect
                 className={styles.baseVersionSelect}
+                isSelectable={_lowerVersionsThan(headVersionId)}
                 label={gettext('Choose an old version')}
-                listedVersions={versionsMap.listed.filter(
-                  lowerVersionsThan(headVersionId),
-                )}
+                listedVersions={versionsMap.listed}
                 onChange={this.onOldVersionChange}
-                unlistedVersions={versionsMap.unlisted.filter(
-                  lowerVersionsThan(headVersionId),
-                )}
+                unlistedVersions={versionsMap.unlisted}
                 value={baseVersionId}
               />
 
               <VersionSelect
                 className={styles.headVersionSelect}
+                isSelectable={_higherVersionsThan(baseVersionId)}
                 label={gettext('Choose a new version')}
-                listedVersions={versionsMap.listed.filter(
-                  higherVersionsThan(baseVersionId),
-                )}
+                listedVersions={versionsMap.listed}
                 onChange={this.onNewVersionChange}
-                unlistedVersions={versionsMap.unlisted.filter(
-                  higherVersionsThan(baseVersionId),
-                )}
+                unlistedVersions={versionsMap.unlisted}
                 value={headVersionId}
                 withLeftArrow
               />

--- a/src/components/VersionChooser/index.tsx
+++ b/src/components/VersionChooser/index.tsx
@@ -155,9 +155,18 @@ const mapStateToProps = (
   };
 };
 
-export const ConnectedVersionChooser = connect(mapStateToProps)(
-  VersionChooserBase,
-);
+const ConnectedVersionChooser = connect(mapStateToProps)(VersionChooserBase);
+
+export const VersionChooserWithoutRouter = ConnectedVersionChooser as React.ComponentType<
+  PublicProps &
+    Partial<
+      DefaultProps & {
+        match: {
+          params: PropsFromRouter;
+        };
+      }
+    >
+>;
 
 export default withRouter<PublicProps & Partial<DefaultProps> & RouterProps>(
   ConnectedVersionChooser,

--- a/src/components/VersionChooser/index.tsx
+++ b/src/components/VersionChooser/index.tsx
@@ -42,18 +42,10 @@ type Props = PublicProps &
   RouterProps;
 
 export const higherVersionsThan = (versionId: string) => {
-  if (!versionId) {
-    return Boolean;
-  }
-
   return (version: VersionsListItem) => version.id > parseInt(versionId, 10);
 };
 
 export const lowerVersionsThan = (versionId: string) => {
-  if (!versionId) {
-    return Boolean;
-  }
-
   return (version: VersionsListItem) => version.id < parseInt(versionId, 10);
 };
 
@@ -160,6 +152,10 @@ const mapStateToProps = (
   };
 };
 
+export const ConnectedVersionChooser = connect(mapStateToProps)(
+  VersionChooserBase,
+);
+
 export default withRouter<PublicProps & Partial<DefaultProps> & RouterProps>(
-  connect(mapStateToProps)(VersionChooserBase),
+  ConnectedVersionChooser,
 );

--- a/src/components/VersionChooser/index.tsx
+++ b/src/components/VersionChooser/index.tsx
@@ -7,7 +7,11 @@ import Loading from '../Loading';
 import { ApplicationState } from '../../reducers';
 import { ConnectedReduxProps } from '../../configureStore';
 import VersionSelect from '../VersionSelect';
-import { VersionsMap, fetchVersionsList } from '../../reducers/versions';
+import {
+  VersionsListItem,
+  VersionsMap,
+  fetchVersionsList,
+} from '../../reducers/versions';
 import { gettext } from '../../utils';
 import styles from './styles.module.scss';
 
@@ -36,6 +40,22 @@ type Props = PublicProps &
   DefaultProps &
   PropsFromState &
   RouterProps;
+
+export const higherVersionsThan = (versionId: string) => {
+  if (!versionId) {
+    return Boolean;
+  }
+
+  return (version: VersionsListItem) => version.id > parseInt(versionId, 10);
+};
+
+export const lowerVersionsThan = (versionId: string) => {
+  if (!versionId) {
+    return Boolean;
+  }
+
+  return (version: VersionsListItem) => version.id < parseInt(versionId, 10);
+};
 
 export class VersionChooserBase extends React.Component<Props> {
   static defaultProps: DefaultProps = {
@@ -93,18 +113,26 @@ export class VersionChooserBase extends React.Component<Props> {
               <VersionSelect
                 className={styles.baseVersionSelect}
                 label={gettext('Choose an old version')}
-                listedVersions={versionsMap.listed}
+                listedVersions={versionsMap.listed.filter(
+                  lowerVersionsThan(headVersionId),
+                )}
                 onChange={this.onOldVersionChange}
-                unlistedVersions={versionsMap.unlisted}
+                unlistedVersions={versionsMap.unlisted.filter(
+                  lowerVersionsThan(headVersionId),
+                )}
                 value={baseVersionId}
               />
 
               <VersionSelect
                 className={styles.headVersionSelect}
                 label={gettext('Choose a new version')}
-                listedVersions={versionsMap.listed}
+                listedVersions={versionsMap.listed.filter(
+                  higherVersionsThan(baseVersionId),
+                )}
                 onChange={this.onNewVersionChange}
-                unlistedVersions={versionsMap.unlisted}
+                unlistedVersions={versionsMap.unlisted.filter(
+                  higherVersionsThan(baseVersionId),
+                )}
                 value={headVersionId}
                 withLeftArrow
               />

--- a/src/components/VersionChooser/index.tsx
+++ b/src/components/VersionChooser/index.tsx
@@ -161,6 +161,10 @@ export const VersionChooserWithoutRouter = ConnectedVersionChooser as React.Comp
   PublicProps &
     Partial<
       DefaultProps & {
+        // We have to add this type to tell Storybook that it's okay to inject
+        // the router props directly. That's because we want to by-pass the
+        // `withRouter()` HOC, which requires a `Router` and a `Route` and we
+        // don't want that in Storybook.
         match: {
           params: PropsFromRouter;
         };

--- a/src/components/VersionSelect/index.spec.tsx
+++ b/src/components/VersionSelect/index.spec.tsx
@@ -16,18 +16,26 @@ import styles from './styles.module.scss';
 import VersionSelect, { PublicProps } from '.';
 
 describe(__filename, () => {
+  type RenderParams = Partial<
+    PublicProps & {
+      versions: ExternalVersionsList;
+    }
+  >;
+
   const render = ({
-    className = undefined as PublicProps['className'],
+    className = undefined,
+    isSelectable = jest.fn().mockReturnValue(true),
     label = 'select a version',
     onChange = jest.fn(),
-    value = undefined as PublicProps['value'],
+    value = undefined,
     versions = fakeVersionsList,
     withLeftArrow = false,
-  } = {}) => {
+  }: RenderParams = {}) => {
     const versionsMap = createVersionsMap(versions);
 
     const allProps = {
       className,
+      isSelectable,
       label,
       listedVersions: versionsMap.listed,
       onChange,
@@ -82,6 +90,7 @@ describe(__filename, () => {
     expect(root.find(`.${styles.listedGroup}`)).toHaveProp('label', 'Listed');
     expect(root.find('option').at(0)).toHaveProp('value', listedVersions[0].id);
     expect(root.find('option').at(0)).toIncludeText(listedVersions[0].version);
+    expect(root.find('option').at(0)).toHaveProp('disabled', false);
 
     expect(root.find(`.${styles.unlistedGroup}`)).toHaveProp(
       'label',
@@ -94,6 +103,7 @@ describe(__filename, () => {
     expect(root.find('option').at(1)).toIncludeText(
       unlistedVersions[0].version,
     );
+    expect(root.find('option').at(1)).toHaveProp('disabled', false);
   });
 
   it('passes the value prop to the Form.Control component', () => {
@@ -128,5 +138,30 @@ describe(__filename, () => {
     const root = render({ className });
 
     expect(root.find(`.${className}`)).toHaveLength(1);
+  });
+
+  it('marks versions as disabled when they are not selectable', () => {
+    const versions: ExternalVersionsList = [
+      {
+        ...fakeVersionsListItem,
+        id: 123,
+        channel: 'listed',
+        version: 'v1',
+      },
+      {
+        ...fakeVersionsListItem,
+        id: 456,
+        channel: 'unlisted',
+        version: 'v2',
+      },
+    ];
+
+    const root = render({
+      isSelectable: () => false,
+      versions,
+    });
+
+    expect(root.find('option').at(0)).toHaveProp('disabled', true);
+    expect(root.find('option').at(1)).toHaveProp('disabled', true);
   });
 });

--- a/src/components/VersionSelect/index.spec.tsx
+++ b/src/components/VersionSelect/index.spec.tsx
@@ -140,6 +140,29 @@ describe(__filename, () => {
     expect(root.find(`.${className}`)).toHaveLength(1);
   });
 
+  it('passes each version to `isSelectable`', () => {
+    const versions: ExternalVersionsList = [
+      {
+        ...fakeVersionsListItem,
+        id: 123,
+        channel: 'listed',
+        version: 'v1',
+      },
+      {
+        ...fakeVersionsListItem,
+        id: 456,
+        channel: 'unlisted',
+        version: 'v2',
+      },
+    ];
+    const isSelectable = jest.fn();
+
+    render({ isSelectable, versions });
+
+    expect(isSelectable).toHaveBeenCalledWith(versions[0]);
+    expect(isSelectable).toHaveBeenCalledWith(versions[1]);
+  });
+
   it('marks versions as disabled when they are not selectable', () => {
     const versions: ExternalVersionsList = [
       {
@@ -156,12 +179,35 @@ describe(__filename, () => {
       },
     ];
 
+    const root = render({ isSelectable: () => false, versions });
+
+    expect(root.find('option').at(0)).toHaveProp('disabled', true);
+    expect(root.find('option').at(1)).toHaveProp('disabled', true);
+  });
+
+  it('marks one versions as disabled when not selectable', () => {
+    const versions: ExternalVersionsList = [
+      {
+        ...fakeVersionsListItem,
+        id: 123,
+        channel: 'listed',
+        version: 'v1',
+      },
+      {
+        ...fakeVersionsListItem,
+        id: 456,
+        channel: 'unlisted',
+        version: 'v2',
+      },
+    ];
+
     const root = render({
-      isSelectable: () => false,
+      // Only the second version is selectable.
+      isSelectable: (version) => version.id === versions[1].id,
       versions,
     });
 
     expect(root.find('option').at(0)).toHaveProp('disabled', true);
-    expect(root.find('option').at(1)).toHaveProp('disabled', true);
+    expect(root.find('option').at(1)).toHaveProp('disabled', false);
   });
 });

--- a/src/components/VersionSelect/index.tsx
+++ b/src/components/VersionSelect/index.tsx
@@ -4,12 +4,13 @@ import { Col, Form } from 'react-bootstrap';
 import { FormControlProps } from 'react-bootstrap/lib/FormControl';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import { VersionsList } from '../../reducers/versions';
+import { VersionsList, VersionsListItem } from '../../reducers/versions';
 import { gettext } from '../../utils';
 import styles from './styles.module.scss';
 
 export type PublicProps = {
   className?: string;
+  isSelectable: (version: VersionsListItem) => boolean;
   label: string;
   listedVersions: VersionsList;
   onChange: (version: string) => void;
@@ -27,6 +28,20 @@ class VersionSelectBase extends React.Component<PublicProps> {
     const value = event.currentTarget.value as string;
 
     this.props.onChange(value);
+  };
+
+  renderOption = (version: VersionsListItem) => {
+    const { isSelectable } = this.props;
+
+    return (
+      <option
+        disabled={!isSelectable(version)}
+        key={version.id}
+        value={version.id}
+      >
+        {version.version}
+      </option>
+    );
   };
 
   render() {
@@ -55,11 +70,7 @@ class VersionSelectBase extends React.Component<PublicProps> {
                 className={styles.listedGroup}
                 label={gettext('Listed')}
               >
-                {listedVersions.map((version) => (
-                  <option key={version.id} value={version.id}>
-                    {version.version}
-                  </option>
-                ))}
+                {listedVersions.map(this.renderOption)}
               </optgroup>
             )}
             {unlistedVersions.length && (
@@ -67,11 +78,7 @@ class VersionSelectBase extends React.Component<PublicProps> {
                 className={styles.unlistedGroup}
                 label={gettext('Unlisted')}
               >
-                {unlistedVersions.map((version) => (
-                  <option key={version.id} value={version.id}>
-                    {version.version}
-                  </option>
-                ))}
+                {unlistedVersions.map(this.renderOption)}
               </optgroup>
             )}
           </Form.Control>

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -181,7 +181,7 @@ export type Version = {
   version: string;
 };
 
-type VersionsListItem = {
+export type VersionsListItem = {
   channel: 'unlisted' | 'listed';
   id: number;
   version: string;

--- a/stories/VersionChooser.stories.tsx
+++ b/stories/VersionChooser.stories.tsx
@@ -2,13 +2,20 @@ import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import configureStore from '../src/configureStore';
-import VersionChooser from '../src/components/VersionChooser';
+import { ConnectedVersionChooser } from '../src/components/VersionChooser';
 import { actions } from '../src/reducers/versions';
 import { fakeVersionsList } from '../src/test-helpers';
 import { renderWithStoreAndRouter } from './utils';
 
-const render = ({ addonId = 124, store = configureStore() } = {}) => {
-  return renderWithStoreAndRouter(<VersionChooser addonId={addonId} />, store);
+const render = ({
+  addonId = 124,
+  params = {},
+  store = configureStore(),
+} = {}) => {
+  return renderWithStoreAndRouter(
+    <ConnectedVersionChooser addonId={addonId} match={{ params }} />,
+    store,
+  );
 };
 
 storiesOf('VersionChooser', module).addWithChapters('all variants', {
@@ -24,7 +31,14 @@ storiesOf('VersionChooser', module).addWithChapters('all variants', {
               actions.loadVersionsList({ addonId, versions: fakeVersionsList }),
             );
 
-            return render({ addonId, store });
+            return render({
+              addonId,
+              store,
+              params: {
+                baseVersionId: 1541786,
+                headVersionId: 1541798,
+              },
+            });
           },
         },
         {

--- a/stories/VersionChooser.stories.tsx
+++ b/stories/VersionChooser.stories.tsx
@@ -3,8 +3,8 @@ import { storiesOf } from '@storybook/react';
 
 import configureStore from '../src/configureStore';
 import { ConnectedVersionChooser } from '../src/components/VersionChooser';
-import { actions } from '../src/reducers/versions';
-import { fakeVersionsList } from '../src/test-helpers';
+import { ExternalVersionsList, actions } from '../src/reducers/versions';
+import { fakeVersionsListItem } from '../src/test-helpers';
 import { renderWithStoreAndRouter } from './utils';
 
 const render = ({
@@ -18,32 +18,79 @@ const render = ({
   );
 };
 
+const listedVersions: ExternalVersionsList = [
+  {
+    ...fakeVersionsListItem,
+    id: 100,
+    channel: 'listed',
+    version: '1.0.0',
+  },
+  {
+    ...fakeVersionsListItem,
+    id: 110,
+    channel: 'listed',
+    version: '1.1.0',
+  },
+  {
+    ...fakeVersionsListItem,
+    id: 120,
+    channel: 'listed',
+    version: '1.2.0',
+  },
+];
+
 storiesOf('VersionChooser', module).addWithChapters('all variants', {
   chapters: [
     {
       sections: [
         {
-          title: 'with lists of versions loaded',
+          title: 'loading state',
+          sectionFn: () => render(),
+        },
+        {
+          title: 'with listed and unlisted versions',
           sectionFn: () => {
             const addonId = 124;
+            const versions: ExternalVersionsList = [
+              ...listedVersions,
+              {
+                ...fakeVersionsListItem,
+                id: 130,
+                channel: 'unlisted',
+                version: '1.3.0',
+              },
+            ];
+
             const store = configureStore();
-            store.dispatch(
-              actions.loadVersionsList({ addonId, versions: fakeVersionsList }),
-            );
+            store.dispatch(actions.loadVersionsList({ addonId, versions }));
 
             return render({
               addonId,
               store,
               params: {
-                baseVersionId: 1541786,
-                headVersionId: 1541798,
+                baseVersionId: String(versions[0].id),
+                headVersionId: String(versions[2].id),
               },
             });
           },
         },
         {
-          title: 'loading state',
-          sectionFn: () => render(),
+          title: 'with some new versions disabled',
+          sectionFn: () => {
+            const addonId = 124;
+            const versions = listedVersions;
+            const store = configureStore();
+            store.dispatch(actions.loadVersionsList({ addonId, versions }));
+
+            return render({
+              addonId,
+              store,
+              params: {
+                baseVersionId: String(versions[1].id),
+                headVersionId: String(versions[2].id),
+              },
+            });
+          },
         },
       ],
     },

--- a/stories/VersionChooser.stories.tsx
+++ b/stories/VersionChooser.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import configureStore from '../src/configureStore';
-import { ConnectedVersionChooser } from '../src/components/VersionChooser';
+import { VersionChooserWithoutRouter } from '../src/components/VersionChooser';
 import { ExternalVersionsList, actions } from '../src/reducers/versions';
 import { fakeVersionsListItem } from '../src/test-helpers';
 import { renderWithStoreAndRouter } from './utils';
@@ -13,7 +13,17 @@ const render = ({
   store = configureStore(),
 } = {}) => {
   return renderWithStoreAndRouter(
-    <ConnectedVersionChooser addonId={addonId} match={{ params }} />,
+    <VersionChooserWithoutRouter
+      addonId={addonId}
+      match={{
+        params: {
+          baseVersionId: '1',
+          headVersionId: '1',
+          lang: 'fr',
+          ...params,
+        },
+      }}
+    />,
     store,
   );
 };


### PR DESCRIPTION
Fixes #415

---

Comparisons are strict because I am not sure we want to compare the same old/new version but it is easy to change if needed.