### PR TITLE
Move buildFileTree into a fileTree reducer

### DIFF
--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -32,10 +32,10 @@ describe(__filename, () => {
     const getVersion = ({
       store = configureStore(),
       version = fakeVersion,
-    }) => {
+    }): Version => {
       store.dispatch(versionActions.loadVersionInfo({ version }));
 
-      return getVersionInfo(store.getState().versions, version.id);
+      return getVersionInfo(store.getState().versions, version.id) as Version;
     };
 
     type RenderParams = {

--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -81,9 +81,8 @@ describe(__filename, () => {
 
       const root = render({ _loadData, store, versionId: version.id });
 
-      _loadData.mockClear();
       // Simulate an update.
-      root.setProps({});
+      root.setProps({ versionId: version.id + 1 });
 
       expect(_loadData).toHaveBeenCalledWith();
     });

--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -65,17 +65,21 @@ describe(__filename, () => {
     };
 
     it('calls loadData on construction', () => {
+      const store = configureStore();
+      const version = getVersion({ store });
       const _loadData = jest.fn();
 
-      render({ _loadData });
+      render({ _loadData, store, versionId: version.id });
 
       expect(_loadData).toHaveBeenCalled();
     });
 
     it('calls loadData on update', () => {
+      const store = configureStore();
+      const version = getVersion({ store });
       const _loadData = jest.fn();
 
-      const root = render({ _loadData });
+      const root = render({ _loadData, store, versionId: version.id });
 
       _loadData.mockClear();
       // Simulate an update.

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -11,158 +11,68 @@ import FileTreeNode, {
 import Loading from '../Loading';
 import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
 import {
+  DirectoryNode,
+  TreeNode,
+  actions as fileTreeActions,
+  getTree,
+} from '../../reducers/fileTree';
+import {
   Version,
   actions as versionsActions,
   getVersionInfo,
 } from '../../reducers/versions';
-import { getLocalizedString, gettext } from '../../utils';
+import { gettext } from '../../utils';
 
-type FileNode = {
-  id: string;
-  name: string;
-};
-
-export type DirectoryNode = {
-  id: string;
-  name: string;
-  children: TreeNode[];
-};
-
-export type TreeNode = FileNode | DirectoryNode;
+type LoadData = () => void;
 
 export type TreefoldRenderPropsForFileTree = TreefoldRenderProps<TreeNode>;
 
-const recursiveSortInPlace = (node: DirectoryNode): void => {
-  node.children.sort((a, b) => {
-    if ('children' in a && 'children' in b) {
-      return a.name.localeCompare(b.name);
-    }
-
-    if ('children' in a === false && 'children' in b === false) {
-      return a.name.localeCompare(b.name);
-    }
-
-    if ('children' in b === false) {
-      return -1;
-    }
-
-    return 1;
-  });
-
-  node.children.forEach((child) => {
-    if ('children' in child) {
-      recursiveSortInPlace(child);
-    }
-  });
-};
-
-const getVersionName = (version: Version) => {
-  return getLocalizedString(version.addon.name);
-};
-
-export const getRootPath = (version: Version) => {
-  return `root-${getVersionName(version)}`;
-};
-
-export const buildFileTree = (version: Version): DirectoryNode => {
-  const { entries } = version;
-  const root: DirectoryNode = {
-    id: getRootPath(version),
-    name: getVersionName(version),
-    children: [],
-  };
-
-  // We need to know how depth the tree is because we'll build the Treebeard
-  // tree depth by depth.
-  const maxDepth = entries.reduce((max, entry) => {
-    if (entry.depth > max) {
-      return entry.depth;
-    }
-
-    return max;
-  }, 0);
-
-  let currentDepth = 0;
-  while (currentDepth <= maxDepth) {
-    // We find the entries for the current depth.
-    const currentEntries = entries.filter(
-      // eslint-disable-next-line no-loop-func
-      (entry) => entry.depth === currentDepth,
-    );
-
-    // This is where we create new "nodes" for each entry.
-    // eslint-disable-next-line no-loop-func
-    currentEntries.forEach((entry) => {
-      let currentNode = root;
-
-      if (currentDepth > 0) {
-        // We need to find the current node (directory) to add the current
-        // entry in its children. We do this by splitting the `path` attribute
-        // and visit each node until we reach the desired node.
-        //
-        // This only applies when the current depth is not 0 (a.k.a. the root
-        // directory) because we already know `root`.
-        const parts = entry.path.split('/');
-        // Remove the filename
-        parts.pop();
-
-        for (let i = 0; i < parts.length; i++) {
-          const foundNode = currentNode.children.find(
-            (child: TreeNode) => child.name === parts[i],
-          ) as DirectoryNode;
-
-          if (foundNode) {
-            currentNode = foundNode;
-          }
-
-          // TODO: this should not happen but what if we don't find a node?
-        }
-      }
-
-      // Create a new node.
-      let node: TreeNode = {
-        id: entry.path,
-        name: entry.filename,
-      };
-
-      // When the entry is a directory, we create a `DirectoryNode`.
-      if (entry.type === 'directory') {
-        node = {
-          ...node,
-          children: [],
-        };
-      }
-
-      currentNode.children.push(node);
-    });
-
-    // To the next depth.
-    currentDepth++;
-  }
-
-  recursiveSortInPlace(root);
-
-  return root;
-};
-
 export type PublicProps = {
+  _loadData?: LoadData;
   onSelect: FileTreeNodeProps['onSelect'];
   versionId: number;
 };
 
 export type DefaultProps = {
+  _buildTree: typeof fileTreeActions.buildTree;
   _log: typeof log;
 };
 
 type PropsFromState = {
+  tree: DirectoryNode | void;
   version: Version | void;
 };
 
 type Props = PublicProps & DefaultProps & PropsFromState & ConnectedReduxProps;
 
 export class FileTreeBase extends React.Component<Props> {
+  loadData: LoadData;
+
   static defaultProps: DefaultProps = {
+    _buildTree: fileTreeActions.buildTree,
     _log: log,
+  };
+
+  constructor(props: Props) {
+    super(props);
+    // Allow dependency injection to test all the ways loadData() gets executed.
+    this.loadData = props._loadData || this._loadData;
+  }
+
+  componentDidMount() {
+    this.loadData();
+  }
+
+  componentDidUpdate() {
+    this.loadData();
+  }
+
+  _loadData = () => {
+    const { _buildTree, dispatch, tree, version } = this.props;
+
+    if (version && !tree) {
+      dispatch(_buildTree({ version }));
+    }
   };
 
   renderNode = (props: TreefoldRenderPropsForFileTree) => {
@@ -224,13 +134,11 @@ export class FileTreeBase extends React.Component<Props> {
   };
 
   render() {
-    const { version } = this.props;
+    const { tree, version } = this.props;
 
-    if (!version) {
+    if (!version || !tree) {
       return <Loading message={gettext('Loading version...')} />;
     }
-
-    const tree = buildFileTree(version);
 
     return (
       <ListGroup>
@@ -283,6 +191,7 @@ const mapStateToProps = (
   }
 
   return {
+    tree: getTree(state.fileTree, version),
     version,
   };
 };

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -189,7 +189,7 @@ const mapStateToProps = (
   }
 
   return {
-    tree: getTree(state.fileTree, version),
+    tree: version ? getTree(state.fileTree, version.id) : undefined,
     version,
   };
 };

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -34,7 +34,6 @@ export type PublicProps = {
 };
 
 export type DefaultProps = {
-  _buildTree: typeof fileTreeActions.buildTree;
   _log: typeof log;
 };
 
@@ -49,7 +48,6 @@ export class FileTreeBase extends React.Component<Props> {
   loadData: LoadData;
 
   static defaultProps: DefaultProps = {
-    _buildTree: fileTreeActions.buildTree,
     _log: log,
   };
 
@@ -68,10 +66,10 @@ export class FileTreeBase extends React.Component<Props> {
   }
 
   _loadData = () => {
-    const { _buildTree, dispatch, tree, version } = this.props;
+    const { dispatch, tree, version } = this.props;
 
     if (version && !tree) {
-      dispatch(_buildTree({ version }));
+      dispatch(fileTreeActions.buildTree({ version }));
     }
   };
 

--- a/src/configureStore.spec.tsx
+++ b/src/configureStore.spec.tsx
@@ -7,6 +7,7 @@ describe(__filename, () => {
     expect(Object.keys(store.getState())).toEqual([
       'api',
       'errors',
+      'fileTree',
       'linter',
       'users',
       'versions',

--- a/src/configureStore.tsx
+++ b/src/configureStore.tsx
@@ -17,6 +17,7 @@ import thunk, {
 
 import api, { ApiState } from './reducers/api';
 import errors, { ErrorsState } from './reducers/errors';
+import fileTree, { FileTreeState } from './reducers/fileTree';
 import linter, { LinterState } from './reducers/linter';
 import users, { UsersState } from './reducers/users';
 import versions, { VersionsState } from './reducers/versions';
@@ -24,6 +25,7 @@ import versions, { VersionsState } from './reducers/versions';
 export type ApplicationState = {
   api: ApiState;
   errors: ErrorsState;
+  fileTree: FileTreeState;
   linter: LinterState;
   users: UsersState;
   versions: VersionsState;
@@ -50,6 +52,7 @@ const createRootReducer = () => {
   return combineReducers<ApplicationState>({
     api,
     errors,
+    fileTree,
     linter,
     users,
     versions,

--- a/src/reducers/fileTree.spec.tsx
+++ b/src/reducers/fileTree.spec.tsx
@@ -1,0 +1,398 @@
+/* eslint @typescript-eslint/camelcase: 0 */
+import reducer, {
+  DirectoryNode,
+  actions,
+  buildFileTree,
+  getRootPath,
+  initialState,
+  getTree,
+} from './fileTree';
+import { createInternalVersion, createInternalVersionEntry } from './versions';
+import {
+  createVersionWithEntries,
+  fakeVersion,
+  fakeVersionEntry,
+} from '../test-helpers';
+import { getLocalizedString } from '../utils';
+
+describe(__filename, () => {
+  describe('reducer', () => {
+    it('builds and loads a tree', () => {
+      const version = createInternalVersion(fakeVersion);
+      const state = reducer(undefined, actions.buildTree({ version }));
+
+      expect(state).toEqual({
+        ...initialState,
+        forVersionId: version.id,
+        tree: buildFileTree(version),
+      });
+    });
+  });
+
+  describe('getTree', () => {
+    it('returns a tree', () => {
+      const version = createInternalVersion(fakeVersion);
+      const state = reducer(undefined, actions.buildTree({ version }));
+
+      expect(getTree(state, version)).toEqual(buildFileTree(version));
+    });
+
+    it('returns undefined if there is no tree loaded', () => {
+      const version = createInternalVersion(fakeVersion);
+      const state = initialState;
+
+      expect(getTree(state, version)).toEqual(undefined);
+    });
+
+    it('returns undefined if a version is requested that has not been loaded', () => {
+      const version1 = createInternalVersion({ ...fakeVersion, id: 1 });
+      const version2 = createInternalVersion({ ...fakeVersion, id: 2 });
+      const state = reducer(
+        undefined,
+        actions.buildTree({ version: version2 }),
+      );
+
+      expect(getTree(state, version1)).toEqual(undefined);
+    });
+
+    it('returns undefined if no version is passed', () => {
+      const state = initialState;
+
+      expect(getTree(state, undefined)).toEqual(undefined);
+    });
+  });
+
+  describe('getRootPath', () => {
+    const version = createInternalVersion(fakeVersion);
+    const addonName = getLocalizedString(version.addon.name);
+
+    expect(getRootPath(version)).toEqual(`root-${addonName}`);
+  });
+
+  describe('buildFileTree', () => {
+    it('creates a root node', () => {
+      const version = createVersionWithEntries([]);
+      const addonName = getLocalizedString(version.addon.name);
+
+      const tree = buildFileTree(version);
+
+      expect(tree).toEqual({
+        id: `root-${addonName}`,
+        name: addonName,
+        children: [],
+      });
+    });
+
+    it('converts a non-directory entry to a file node', () => {
+      const filename = 'some-filename';
+      const entries = [
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          mime_category: 'text',
+          filename,
+        }),
+      ];
+      const version = createVersionWithEntries(entries);
+
+      const tree = buildFileTree(version);
+
+      expect(tree.children).toEqual([
+        {
+          id: entries[0].path,
+          name: filename,
+        },
+      ]);
+    });
+
+    it('converts a directory entry to a directory node', () => {
+      const filename = 'some-directory';
+      const entries = [
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          mime_category: 'directory',
+          filename,
+        }),
+      ];
+      const version = createVersionWithEntries(entries);
+
+      const tree = buildFileTree(version);
+
+      expect(tree.children).toEqual([
+        {
+          id: entries[0].path,
+          name: filename,
+          children: [],
+        },
+      ]);
+    });
+
+    it('finds the appropriate node to add a new entry to it', () => {
+      const directory = 'parent';
+      const file = 'child';
+
+      const entries = [
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          filename: directory,
+          mime_category: 'directory',
+        }),
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          depth: 1,
+          filename: file,
+          mime_category: 'text',
+          path: `${directory}/${file}`,
+        }),
+      ];
+      const version = createVersionWithEntries(entries);
+
+      const tree = buildFileTree(version);
+
+      expect(tree.children).toEqual([
+        {
+          id: entries[0].path,
+          name: directory,
+          children: [
+            {
+              id: entries[1].path,
+              name: file,
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('traverses multiple levels to find the right directory', () => {
+      const directoryName = 'same-file';
+      const fileName = 'same-nfile';
+
+      const entries = [
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          filename: directoryName,
+          mime_category: 'directory',
+        }),
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          depth: 1,
+          filename: directoryName,
+          mime_category: 'directory',
+          path: `${directoryName}/${directoryName}`,
+        }),
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          depth: 2,
+          filename: fileName,
+          mime_category: 'text',
+          path: `${directoryName}/${directoryName}/${fileName}`,
+        }),
+      ];
+      const version = createVersionWithEntries(entries);
+
+      const data = buildFileTree(version);
+
+      expect(data.children).toEqual([
+        {
+          id: entries[0].path,
+          name: directoryName,
+          children: [
+            {
+              id: entries[1].path,
+              name: directoryName,
+              children: [
+                {
+                  id: entries[2].path,
+                  name: fileName,
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('sorts the nodes so that directories come first', () => {
+      const entries = [
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          filename: 'B',
+          mime_category: 'directory',
+        }),
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          filename: 'A',
+          mime_category: 'text',
+        }),
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          filename: 'C',
+          mime_category: 'directory',
+        }),
+      ];
+      const version = createVersionWithEntries(entries);
+
+      const tree = buildFileTree(version);
+
+      expect(tree.children).toEqual([
+        {
+          id: entries[0].path,
+          name: 'B',
+          children: [],
+        },
+        {
+          id: entries[2].path,
+          name: 'C',
+          children: [],
+        },
+        {
+          id: entries[1].path,
+          name: 'A',
+        },
+      ]);
+    });
+
+    it('sorts files alphabetically', () => {
+      const entries = [
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          filename: 'C',
+        }),
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          filename: 'B',
+        }),
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          filename: 'A',
+        }),
+      ];
+      const version = createVersionWithEntries(entries);
+
+      const tree = buildFileTree(version);
+
+      expect(tree.children).toEqual([
+        {
+          id: entries[2].path,
+          name: 'A',
+        },
+        {
+          id: entries[1].path,
+          name: 'B',
+        },
+        {
+          id: entries[0].path,
+          name: 'C',
+        },
+      ]);
+    });
+
+    it('sorts directories alphabetically', () => {
+      const entries = [
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          filename: 'B',
+          mime_category: 'directory',
+        }),
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          filename: 'A',
+          mime_category: 'directory',
+        }),
+      ];
+      const version = createVersionWithEntries(entries);
+
+      const tree = buildFileTree(version);
+
+      expect(tree.children).toEqual([
+        {
+          id: entries[1].path,
+          name: 'A',
+          children: [],
+        },
+        {
+          id: entries[0].path,
+          name: 'B',
+          children: [],
+        },
+      ]);
+    });
+
+    it('sorts the nodes recursively', () => {
+      const entries = [
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          filename: 'parent',
+          mime_category: 'directory',
+          path: 'parent',
+        }),
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          depth: 1,
+          filename: 'B',
+          path: 'parent/B',
+        }),
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          depth: 1,
+          filename: 'A',
+          path: 'parent/A',
+        }),
+      ];
+      const version = createVersionWithEntries(entries);
+
+      const tree = buildFileTree(version);
+      const firstNode = tree.children[0] as DirectoryNode;
+
+      expect(firstNode.children).toEqual([
+        {
+          id: entries[2].path,
+          name: 'A',
+        },
+        {
+          id: entries[1].path,
+          name: 'B',
+        },
+      ]);
+    });
+
+    it('puts directories first in a child node', () => {
+      const entries = [
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          filename: 'parent',
+          mime_category: 'directory',
+          path: 'parent',
+        }),
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          depth: 1,
+          filename: 'B',
+          mime_category: 'directory',
+          path: 'parent/B',
+        }),
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          depth: 1,
+          filename: 'A',
+          path: 'parent/A',
+        }),
+      ];
+      const version = createVersionWithEntries(entries);
+
+      const tree = buildFileTree(version);
+      const firstNode = tree.children[0] as DirectoryNode;
+
+      expect(firstNode.children).toEqual([
+        {
+          id: entries[1].path,
+          name: 'B',
+          children: [],
+        },
+        {
+          id: entries[2].path,
+          name: 'A',
+        },
+      ]);
+    });
+  });
+});

--- a/src/reducers/fileTree.spec.tsx
+++ b/src/reducers/fileTree.spec.tsx
@@ -34,14 +34,14 @@ describe(__filename, () => {
       const version = createInternalVersion(fakeVersion);
       const state = reducer(undefined, actions.buildTree({ version }));
 
-      expect(getTree(state, version)).toEqual(buildFileTree(version));
+      expect(getTree(state, version.id)).toEqual(buildFileTree(version));
     });
 
     it('returns undefined if there is no tree loaded', () => {
       const version = createInternalVersion(fakeVersion);
       const state = initialState;
 
-      expect(getTree(state, version)).toEqual(undefined);
+      expect(getTree(state, version.id)).toEqual(undefined);
     });
 
     it('returns undefined if a version is requested that has not been loaded', () => {
@@ -52,13 +52,7 @@ describe(__filename, () => {
         actions.buildTree({ version: version2 }),
       );
 
-      expect(getTree(state, version1)).toEqual(undefined);
-    });
-
-    it('returns undefined if no version is passed', () => {
-      const state = initialState;
-
-      expect(getTree(state, undefined)).toEqual(undefined);
+      expect(getTree(state, version1.id)).toEqual(undefined);
     });
   });
 
@@ -160,6 +154,32 @@ describe(__filename, () => {
           ],
         },
       ]);
+    });
+
+    it('throws an error when it cannot find the appropriate node to add a new entry to', () => {
+      const directory = 'parent';
+      const file = 'child';
+      const badDirectoryName = 'incorrect-directory-name';
+
+      const entries = [
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          filename: directory,
+          mime_category: 'directory',
+        }),
+        createInternalVersionEntry({
+          ...fakeVersionEntry,
+          depth: 1,
+          filename: file,
+          mime_category: 'text',
+          path: `${badDirectoryName}/${file}`,
+        }),
+      ];
+      const version = createVersionWithEntries(entries);
+
+      expect(() => {
+        buildFileTree(version);
+      }).toThrow(`Could not find parent of entry: ${badDirectoryName}/${file}`);
     });
 
     it('traverses multiple levels to find the right directory', () => {

--- a/src/reducers/fileTree.tsx
+++ b/src/reducers/fileTree.tsx
@@ -1,0 +1,179 @@
+import { Reducer } from 'redux';
+import { ActionType, createAction, getType } from 'typesafe-actions';
+
+import { Version } from './versions';
+import { getLocalizedString } from '../utils';
+
+type FileNode = {
+  id: string;
+  name: string;
+};
+
+export type DirectoryNode = {
+  id: string;
+  name: string;
+  children: TreeNode[];
+};
+
+export type TreeNode = FileNode | DirectoryNode;
+
+const recursiveSortInPlace = (node: DirectoryNode): void => {
+  node.children.sort((a, b) => {
+    if ('children' in a && 'children' in b) {
+      return a.name.localeCompare(b.name);
+    }
+
+    if ('children' in a === false && 'children' in b === false) {
+      return a.name.localeCompare(b.name);
+    }
+
+    if ('children' in b === false) {
+      return -1;
+    }
+
+    return 1;
+  });
+
+  node.children.forEach((child) => {
+    if ('children' in child) {
+      recursiveSortInPlace(child);
+    }
+  });
+};
+
+const getVersionName = (version: Version) => {
+  return getLocalizedString(version.addon.name);
+};
+
+export const getRootPath = (version: Version) => {
+  return `root-${getVersionName(version)}`;
+};
+
+export const buildFileTree = (version: Version): DirectoryNode => {
+  const { entries } = version;
+  const root: DirectoryNode = {
+    id: getRootPath(version),
+    name: getVersionName(version),
+    children: [],
+  };
+
+  // We need to know how depth the tree is because we'll build the Treebeard
+  // tree depth by depth.
+  const maxDepth = entries.reduce((max, entry) => {
+    if (entry.depth > max) {
+      return entry.depth;
+    }
+
+    return max;
+  }, 0);
+
+  let currentDepth = 0;
+  while (currentDepth <= maxDepth) {
+    // We find the entries for the current depth.
+    const currentEntries = entries.filter(
+      // eslint-disable-next-line no-loop-func
+      (entry) => entry.depth === currentDepth,
+    );
+
+    // This is where we create new "nodes" for each entry.
+    // eslint-disable-next-line no-loop-func
+    currentEntries.forEach((entry) => {
+      let currentNode = root;
+
+      if (currentDepth > 0) {
+        // We need to find the current node (directory) to add the current
+        // entry in its children. We do this by splitting the `path` attribute
+        // and visit each node until we reach the desired node.
+        //
+        // This only applies when the current depth is not 0 (a.k.a. the root
+        // directory) because we already know `root`.
+        const parts = entry.path.split('/');
+        // Remove the filename
+        parts.pop();
+
+        for (let i = 0; i < parts.length; i++) {
+          const foundNode = currentNode.children.find(
+            (child: TreeNode) => child.name === parts[i],
+          ) as DirectoryNode;
+
+          if (foundNode) {
+            currentNode = foundNode;
+          }
+
+          // TODO: this should not happen but what if we don't find a node?
+        }
+      }
+
+      // Create a new node.
+      let node: TreeNode = {
+        id: entry.path,
+        name: entry.filename,
+      };
+
+      // When the entry is a directory, we create a `DirectoryNode`.
+      if (entry.type === 'directory') {
+        node = {
+          ...node,
+          children: [],
+        };
+      }
+
+      currentNode.children.push(node);
+    });
+
+    // To the next depth.
+    currentDepth++;
+  }
+
+  recursiveSortInPlace(root);
+
+  return root;
+};
+
+export type FileTreeState = {
+  forVersionId: void | number;
+  tree: DirectoryNode | void;
+};
+
+export const initialState: FileTreeState = {
+  forVersionId: undefined,
+  tree: undefined,
+};
+
+export const actions = {
+  buildTree: createAction('BUILD_TREE', (resolve) => {
+    return (payload: { version: Version }) => resolve(payload);
+  }),
+};
+
+export const getTree = (
+  treeState: FileTreeState,
+  version: Version | void,
+): void | DirectoryNode => {
+  if (!version || treeState.forVersionId !== version.id) {
+    return undefined;
+  }
+  return treeState.tree;
+};
+
+const reducer: Reducer<FileTreeState, ActionType<typeof actions>> = (
+  state = initialState,
+  action,
+): FileTreeState => {
+  switch (action.type) {
+    case getType(actions.buildTree): {
+      const { version } = action.payload;
+      const tree = buildFileTree(version);
+
+      return {
+        ...state,
+        forVersionId: version.id,
+        tree,
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/src/reducers/fileTree.tsx
+++ b/src/reducers/fileTree.tsx
@@ -98,9 +98,10 @@ export const buildFileTree = (version: Version): DirectoryNode => {
 
           if (foundNode) {
             currentNode = foundNode;
+          } else {
+            // This should not happen, but throw an exception if it does.
+            throw new Error(`Could not find parent of entry: ${entry.path}`);
           }
-
-          // TODO: this should not happen but what if we don't find a node?
         }
       }
 
@@ -148,9 +149,9 @@ export const actions = {
 
 export const getTree = (
   treeState: FileTreeState,
-  version: Version | void,
+  versionId: number,
 ): void | DirectoryNode => {
-  if (!version || treeState.forVersionId !== version.id) {
+  if (treeState.forVersionId !== versionId) {
     return undefined;
   }
   return treeState.tree;

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -22,7 +22,7 @@ import reducer, {
   initialState,
   isFileLoading,
 } from './versions';
-import { getRootPath } from '../components/FileTree';
+import { getRootPath } from './fileTree';
 import {
   createFakeEntry,
   fakeExternalDiff,

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -7,7 +7,7 @@ import { ThunkActionCreator } from '../configureStore';
 import { getDiff, getVersion, getVersionsList, isErrorResponse } from '../api';
 import { LocalizedStringMap } from '../utils';
 import { actions as errorsActions } from './errors';
-import { getRootPath } from '../components/FileTree';
+import { getRootPath } from './fileTree';
 
 type VersionCompatibility = {
   [appName: string]: {


### PR DESCRIPTION
Fixes #533 

This patch moves all of the functionality that creates the `tree` structure out of the `FileTree` component and into a new `fileTree` reducer. This includes:

- The types for `FileNode`, `DirectoryNode` and `TreeNode`.
- The functions `getVersionName`, `getRootPath`, `recursiveSortInPlace` and `buildFileTree`, all of which are used for generating the `tree` and were all moved exactly as is.
- The `FileTree` component now gets its `tree` prop via `mapStateToProps` from the `fileTree` reducer.
- The `FileTree` component now has a `loadData` function which is called from both `componentDidMount` and `componentDidUpdate` which checks whether has a value in the `tree` prop and if not dispatches `fileTreeActions.buildTree`.
- The new `fileTree` reducer exposes one action: `buildTree` which accepts a version and stores a `tree` structure in its state, and one selector: `getTree` which returns either the `tree` structure, or `undefined` if it hasn't been built yet for the requested `version`.

