### PR TITLE
Store a list of ordered file paths in the fileTree reducer 

### DIFF
--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -133,7 +133,9 @@ describe(__filename, () => {
 
       expect(root.find(ListGroup)).toHaveLength(1);
       expect(root.find(Treefold)).toHaveLength(1);
-      expect(root.find(Treefold)).toHaveProp('nodes', [buildFileTree(version)]);
+      expect(root.find(Treefold)).toHaveProp('nodes', [
+        buildFileTree(version).nodes,
+      ]);
     });
 
     it('passes the onSelect prop to FileTreeNode', () => {

--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -87,6 +87,16 @@ describe(__filename, () => {
       expect(_loadData).toHaveBeenCalledWith();
     });
 
+    it('does not dispatch anything when version is undefined', () => {
+      const store = configureStore();
+
+      const dispatch = spyOn(store, 'dispatch');
+
+      render({ store });
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
     it('dispatches buildTree when tree is undefined', () => {
       const store = configureStore();
       const version = getVersion({ store });
@@ -111,7 +121,61 @@ describe(__filename, () => {
 
       render({ store, versionId: version.id });
 
-      expect(dispatch).not.toHaveBeenCalled();
+      expect(dispatch).not.toHaveBeenCalledWith(
+        fileTreeActions.buildTree({
+          version,
+        }),
+      );
+    });
+
+    it('dispatches buildTreePathList when treePathList is undefined', () => {
+      const store = configureStore();
+      const version = getVersion({ store });
+      _buildTree(store, version);
+
+      const dispatch = spyOn(store, 'dispatch');
+
+      render({ store, versionId: version.id });
+
+      expect(dispatch).toHaveBeenCalledWith(
+        fileTreeActions.buildTreePathList({
+          versionId: version.id,
+        }),
+      );
+    });
+
+    it('does not dispatch buildTreePathList when tree is not defined', () => {
+      const store = configureStore();
+      const version = getVersion({ store });
+
+      const dispatch = spyOn(store, 'dispatch');
+
+      render({ store, versionId: version.id });
+
+      expect(dispatch).not.toHaveBeenCalledWith(
+        fileTreeActions.buildTreePathList({
+          versionId: version.id,
+        }),
+      );
+    });
+
+    it('does not dispatch buildTreePathList when treePathList is defined', () => {
+      const store = configureStore();
+      const version = getVersion({ store });
+      _buildTree(store, version);
+      store.dispatch(
+        fileTreeActions.buildTreePathList({ versionId: version.id }),
+      );
+
+      const dispatch = spyOn(store, 'dispatch');
+
+      render({ store, versionId: version.id });
+
+      expect(dispatch).not.toHaveBeenCalledWith(
+        fileTreeActions.buildTreePathList({
+          versionId: version.id,
+        }),
+      );
     });
 
     it('renders a ListGroup component with a Treefold', () => {

--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -87,7 +87,7 @@ describe(__filename, () => {
       expect(_loadData).toHaveBeenCalledWith();
     });
 
-    it('does not dispatch anything when version is undefined', () => {
+    it('does not dispatch buildTree when version is undefined', () => {
       const store = configureStore();
 
       const dispatch = spyOn(store, 'dispatch');
@@ -121,61 +121,7 @@ describe(__filename, () => {
 
       render({ store, versionId: version.id });
 
-      expect(dispatch).not.toHaveBeenCalledWith(
-        fileTreeActions.buildTree({
-          version,
-        }),
-      );
-    });
-
-    it('dispatches buildTreePathList when treePathList is undefined', () => {
-      const store = configureStore();
-      const version = getVersion({ store });
-      _buildTree(store, version);
-
-      const dispatch = spyOn(store, 'dispatch');
-
-      render({ store, versionId: version.id });
-
-      expect(dispatch).toHaveBeenCalledWith(
-        fileTreeActions.buildTreePathList({
-          versionId: version.id,
-        }),
-      );
-    });
-
-    it('does not dispatch buildTreePathList when tree is not defined', () => {
-      const store = configureStore();
-      const version = getVersion({ store });
-
-      const dispatch = spyOn(store, 'dispatch');
-
-      render({ store, versionId: version.id });
-
-      expect(dispatch).not.toHaveBeenCalledWith(
-        fileTreeActions.buildTreePathList({
-          versionId: version.id,
-        }),
-      );
-    });
-
-    it('does not dispatch buildTreePathList when treePathList is defined', () => {
-      const store = configureStore();
-      const version = getVersion({ store });
-      _buildTree(store, version);
-      store.dispatch(
-        fileTreeActions.buildTreePathList({ versionId: version.id }),
-      );
-
-      const dispatch = spyOn(store, 'dispatch');
-
-      render({ store, versionId: version.id });
-
-      expect(dispatch).not.toHaveBeenCalledWith(
-        fileTreeActions.buildTreePathList({
-          versionId: version.id,
-        }),
-      );
+      expect(dispatch).not.toHaveBeenCalled();
     });
 
     it('renders a ListGroup component with a Treefold', () => {

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -15,6 +15,7 @@ import {
   TreeNode,
   actions as fileTreeActions,
   getTree,
+  getTreePathList,
 } from '../../reducers/fileTree';
 import {
   Version,
@@ -39,6 +40,7 @@ export type DefaultProps = {
 
 type PropsFromState = {
   tree: DirectoryNode | void;
+  treePathList: string[] | void;
   version: Version | void;
 };
 
@@ -66,10 +68,15 @@ export class FileTreeBase extends React.Component<Props> {
   }
 
   _loadData = () => {
-    const { dispatch, tree, version } = this.props;
+    const { dispatch, tree, treePathList, version } = this.props;
 
-    if (version && !tree) {
-      dispatch(fileTreeActions.buildTree({ version }));
+    if (version) {
+      if (!tree) {
+        dispatch(fileTreeActions.buildTree({ version }));
+      } else if (!treePathList) {
+        console.log(tree);
+        dispatch(fileTreeActions.buildTreePathList({ versionId: version.id }));
+      }
     }
   };
 
@@ -190,6 +197,9 @@ const mapStateToProps = (
 
   return {
     tree: version ? getTree(state.fileTree, version.id) : undefined,
+    treePathList: version
+      ? getTreePathList(state.fileTree, version.id)
+      : undefined,
     version,
   };
 };

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -15,7 +15,6 @@ import {
   TreeNode,
   actions as fileTreeActions,
   getTree,
-  getTreePathList,
 } from '../../reducers/fileTree';
 import {
   Version,
@@ -39,8 +38,7 @@ export type DefaultProps = {
 };
 
 type PropsFromState = {
-  tree: DirectoryNode | void;
-  treePathList: string[] | void;
+  treeNodes: DirectoryNode | void;
   version: Version | void;
 };
 
@@ -68,15 +66,10 @@ export class FileTreeBase extends React.Component<Props> {
   }
 
   _loadData = () => {
-    const { dispatch, tree, treePathList, version } = this.props;
+    const { dispatch, treeNodes, version } = this.props;
 
-    if (version) {
-      if (!tree) {
-        dispatch(fileTreeActions.buildTree({ version }));
-      } else if (!treePathList) {
-        console.log(tree);
-        dispatch(fileTreeActions.buildTreePathList({ versionId: version.id }));
-      }
+    if (version && !treeNodes) {
+      dispatch(fileTreeActions.buildTree({ version }));
     }
   };
 
@@ -139,9 +132,9 @@ export class FileTreeBase extends React.Component<Props> {
   };
 
   render() {
-    const { tree, version } = this.props;
+    const { treeNodes, version } = this.props;
 
-    if (!version || !tree) {
+    if (!version || !treeNodes) {
       return <Loading message={gettext('Loading version...')} />;
     }
 
@@ -170,7 +163,7 @@ export class FileTreeBase extends React.Component<Props> {
           </Button>
         </div>
         <Treefold
-          nodes={[tree]}
+          nodes={[treeNodes]}
           render={this.renderNode}
           isNodeExpanded={this.isNodeExpanded}
           onToggleExpand={this.onToggleExpand}
@@ -195,11 +188,11 @@ const mapStateToProps = (
     _log.warn(`No version was loaded for version: `, versionId);
   }
 
+  const tree = version ? getTree(state.fileTree, version.id) : undefined;
+  const treeNodes = tree ? tree.nodes : undefined;
+
   return {
-    tree: version ? getTree(state.fileTree, version.id) : undefined,
-    treePathList: version
-      ? getTreePathList(state.fileTree, version.id)
-      : undefined,
+    treeNodes,
     version,
   };
 };

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -11,7 +11,7 @@ import FileTreeNode, {
 import Loading from '../Loading';
 import { ApplicationState, ConnectedReduxProps } from '../../configureStore';
 import {
-  DirectoryNode,
+  FileTree,
   TreeNode,
   actions as fileTreeActions,
   getTree,
@@ -38,7 +38,7 @@ export type DefaultProps = {
 };
 
 type PropsFromState = {
-  treeNodes: DirectoryNode | void;
+  treeNodes: FileTree['nodes'] | void;
   version: Version | void;
 };
 

--- a/src/reducers/fileTree.spec.tsx
+++ b/src/reducers/fileTree.spec.tsx
@@ -3,6 +3,7 @@ import reducer, {
   DirectoryNode,
   actions,
   buildFileTree,
+  buildFileTreeNodes,
   buildTreePathList,
   getRootPath,
   initialState,
@@ -21,15 +22,11 @@ describe(__filename, () => {
     it('builds and loads a tree', () => {
       const version = createInternalVersion(fakeVersion);
       const state = reducer(undefined, actions.buildTree({ version }));
-      const nodes = buildFileTree(version);
 
       expect(state).toEqual({
         ...initialState,
         forVersionId: version.id,
-        tree: {
-          nodes,
-          pathList: buildTreePathList(nodes),
-        },
+        tree: buildFileTree(version),
       });
     });
   });
@@ -38,12 +35,8 @@ describe(__filename, () => {
     it('returns a tree', () => {
       const version = createInternalVersion(fakeVersion);
       const state = reducer(undefined, actions.buildTree({ version }));
-      const nodes = buildFileTree(version);
 
-      expect(getTree(state, version.id)).toEqual({
-        nodes,
-        pathList: buildTreePathList(nodes),
-      });
+      expect(getTree(state, version.id)).toEqual(buildFileTree(version));
     });
 
     it('returns undefined if there is no tree loaded', () => {
@@ -77,7 +70,7 @@ describe(__filename, () => {
       const version = createVersionWithEntries([]);
       const addonName = getLocalizedString(version.addon.name);
 
-      const tree = buildFileTree(version);
+      const tree = buildFileTreeNodes(version);
 
       expect(tree).toEqual({
         id: `root-${addonName}`,
@@ -97,7 +90,7 @@ describe(__filename, () => {
       ];
       const version = createVersionWithEntries(entries);
 
-      const tree = buildFileTree(version);
+      const tree = buildFileTreeNodes(version);
 
       expect(tree.children).toEqual([
         {
@@ -118,7 +111,7 @@ describe(__filename, () => {
       ];
       const version = createVersionWithEntries(entries);
 
-      const tree = buildFileTree(version);
+      const tree = buildFileTreeNodes(version);
 
       expect(tree.children).toEqual([
         {
@@ -149,7 +142,7 @@ describe(__filename, () => {
       ];
       const version = createVersionWithEntries(entries);
 
-      const tree = buildFileTree(version);
+      const tree = buildFileTreeNodes(version);
 
       expect(tree.children).toEqual([
         {
@@ -187,7 +180,7 @@ describe(__filename, () => {
       const version = createVersionWithEntries(entries);
 
       expect(() => {
-        buildFileTree(version);
+        buildFileTreeNodes(version);
       }).toThrow(`Could not find parent of entry: ${badDirectoryName}/${file}`);
     });
 
@@ -218,7 +211,7 @@ describe(__filename, () => {
       ];
       const version = createVersionWithEntries(entries);
 
-      const data = buildFileTree(version);
+      const data = buildFileTreeNodes(version);
 
       expect(data.children).toEqual([
         {
@@ -260,7 +253,7 @@ describe(__filename, () => {
       ];
       const version = createVersionWithEntries(entries);
 
-      const tree = buildFileTree(version);
+      const tree = buildFileTreeNodes(version);
 
       expect(tree.children).toEqual([
         {
@@ -297,7 +290,7 @@ describe(__filename, () => {
       ];
       const version = createVersionWithEntries(entries);
 
-      const tree = buildFileTree(version);
+      const tree = buildFileTreeNodes(version);
 
       expect(tree.children).toEqual([
         {
@@ -330,7 +323,7 @@ describe(__filename, () => {
       ];
       const version = createVersionWithEntries(entries);
 
-      const tree = buildFileTree(version);
+      const tree = buildFileTreeNodes(version);
 
       expect(tree.children).toEqual([
         {
@@ -369,7 +362,7 @@ describe(__filename, () => {
       ];
       const version = createVersionWithEntries(entries);
 
-      const tree = buildFileTree(version);
+      const tree = buildFileTreeNodes(version);
       const firstNode = tree.children[0] as DirectoryNode;
 
       expect(firstNode.children).toEqual([
@@ -408,7 +401,7 @@ describe(__filename, () => {
       ];
       const version = createVersionWithEntries(entries);
 
-      const tree = buildFileTree(version);
+      const tree = buildFileTreeNodes(version);
       const firstNode = tree.children[0] as DirectoryNode;
 
       expect(firstNode.children).toEqual([

--- a/src/reducers/fileTree.spec.tsx
+++ b/src/reducers/fileTree.spec.tsx
@@ -7,7 +7,6 @@ import reducer, {
   getRootPath,
   initialState,
   getTree,
-  getTreePathList,
 } from './fileTree';
 import { createInternalVersion, createInternalVersionEntry } from './versions';
 import {
@@ -22,28 +21,15 @@ describe(__filename, () => {
     it('builds and loads a tree', () => {
       const version = createInternalVersion(fakeVersion);
       const state = reducer(undefined, actions.buildTree({ version }));
+      const nodes = buildFileTree(version);
 
       expect(state).toEqual({
         ...initialState,
         forVersionId: version.id,
-        tree: buildFileTree(version),
-      });
-    });
-
-    it('builds and loads a treePathList', () => {
-      const version = createInternalVersion(fakeVersion);
-      let state = reducer(undefined, actions.buildTree({ version }));
-      const tree = getTree(state, version.id) as DirectoryNode;
-      state = reducer(
-        state,
-        actions.buildTreePathList({ versionId: version.id }),
-      );
-
-      expect(state).toEqual({
-        ...initialState,
-        forVersionId: version.id,
-        tree: buildFileTree(version),
-        treePathList: buildTreePathList(tree),
+        tree: {
+          nodes,
+          pathList: buildTreePathList(nodes),
+        },
       });
     });
   });
@@ -52,8 +38,12 @@ describe(__filename, () => {
     it('returns a tree', () => {
       const version = createInternalVersion(fakeVersion);
       const state = reducer(undefined, actions.buildTree({ version }));
+      const nodes = buildFileTree(version);
 
-      expect(getTree(state, version.id)).toEqual(buildFileTree(version));
+      expect(getTree(state, version.id)).toEqual({
+        nodes,
+        pathList: buildTreePathList(nodes),
+      });
     });
 
     it('returns undefined if there is no tree loaded', () => {
@@ -72,45 +62,6 @@ describe(__filename, () => {
       );
 
       expect(getTree(state, version1.id)).toEqual(undefined);
-    });
-  });
-
-  describe('getTreePathList', () => {
-    it('returns a treePathList', () => {
-      const version = createInternalVersion(fakeVersion);
-      let state = reducer(undefined, actions.buildTree({ version }));
-      const tree = getTree(state, version.id) as DirectoryNode;
-      state = reducer(
-        state,
-        actions.buildTreePathList({ versionId: version.id }),
-      );
-
-      expect(getTreePathList(state, version.id)).toEqual(
-        buildTreePathList(tree),
-      );
-    });
-
-    it('returns undefined if there is no treePathList loaded', () => {
-      const version = createInternalVersion(fakeVersion);
-      const state = reducer(undefined, actions.buildTree({ version }));
-
-      expect(getTreePathList(state, version.id)).toEqual(undefined);
-    });
-
-    it('returns undefined if a version is requested that has not been loaded', () => {
-      const version1id = 1;
-      const version2id = 2;
-      const version1 = createInternalVersion({
-        ...fakeVersion,
-        id: version1id,
-      });
-      let state = reducer(undefined, actions.buildTree({ version: version1 }));
-      state = reducer(
-        state,
-        actions.buildTreePathList({ versionId: version1id }),
-      );
-
-      expect(getTreePathList(state, version2id)).toEqual(undefined);
     });
   });
 

--- a/src/reducers/fileTree.tsx
+++ b/src/reducers/fileTree.tsx
@@ -49,7 +49,7 @@ export const getRootPath = (version: Version) => {
   return `root-${getVersionName(version)}`;
 };
 
-export const buildFileTree = (version: Version): DirectoryNode => {
+export const buildFileTreeNodes = (version: Version): DirectoryNode => {
   const { entries } = version;
   const root: DirectoryNode = {
     id: getRootPath(version),
@@ -149,6 +149,14 @@ export const buildTreePathList = (nodes: DirectoryNode): string[] => {
   return treePathList;
 };
 
+export const buildFileTree = (version: Version): FileTree => {
+  const nodes = buildFileTreeNodes(version);
+  return {
+    nodes,
+    pathList: buildTreePathList(nodes),
+  };
+};
+
 export type FileTree = {
   nodes: DirectoryNode | void;
   pathList: string[] | void;
@@ -187,13 +195,12 @@ const reducer: Reducer<FileTreeState, ActionType<typeof actions>> = (
   switch (action.type) {
     case getType(actions.buildTree): {
       const { version } = action.payload;
-      const nodes = buildFileTree(version);
-      const pathList = buildTreePathList(nodes);
+      const tree = buildFileTree(version);
 
       return {
         ...state,
         forVersionId: version.id,
-        tree: { nodes, pathList },
+        tree,
       };
     }
     default:


### PR DESCRIPTION
Fixes #538 

This builds a list of file paths that can then be used for keyboard navigation. Note that the `FileTree` component does not currently use the `treePathList` prop, but it does need it to know whether to request that the path list be built by the reducer. 
