### PR TITLE
Configure lockfile maintenance PRs for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":maintainLockFilesWeekly",
+    ":prNotPending"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
This tells Renovate to send a lockfile maintenance PR once a week (on
Monday). The second added option tells Renovate to wait until branch
tests have passed or failed before opening a PR.