### PR TITLE
Create actions for selecting the next and previous file in the tree

### DIFF
--- a/src/reducers/fileTree.spec.tsx
+++ b/src/reducers/fileTree.spec.tsx
@@ -5,12 +5,14 @@ import reducer, {
   buildFileTree,
   buildFileTreeNodes,
   buildTreePathList,
+  getRelativePath,
   getRootPath,
-  initialState,
   getTree,
+  initialState,
 } from './fileTree';
 import { createInternalVersion, createInternalVersionEntry } from './versions';
 import {
+  createFakeLogger,
   createVersionWithEntries,
   fakeVersion,
   fakeVersionEntry,
@@ -456,6 +458,58 @@ describe(__filename, () => {
         `${folder1}/${file2}`,
         file1,
       ]);
+    });
+  });
+
+  describe('getRelativePath', () => {
+    const file1 = 'file1.js';
+    const file2 = 'file2.js';
+    const file3 = 'file3.js';
+    const pathList = [file1, file2, file3];
+
+    it('returns the next file in the list', () => {
+      expect(
+        getRelativePath({ currentPath: file2, pathList, position: 'next' }),
+      ).toEqual(file3);
+    });
+
+    it('returns the previous file in the list', () => {
+      expect(
+        getRelativePath({ currentPath: file2, pathList, position: 'previous' }),
+      ).toEqual(file1);
+    });
+
+    it('wraps around to the first file in the list', () => {
+      expect(
+        getRelativePath({ currentPath: file3, pathList, position: 'next' }),
+      ).toEqual(file1);
+    });
+
+    it('wraps around to the last file in the list', () => {
+      expect(
+        getRelativePath({ currentPath: file1, pathList, position: 'previous' }),
+      ).toEqual(file3);
+    });
+
+    it('returns undefined if the currentPath is not found', () => {
+      expect(
+        getRelativePath({
+          currentPath: 'bad-file-name',
+          pathList,
+          position: 'previous',
+        }),
+      ).toEqual(undefined);
+    });
+
+    it('logs a debug message if the currentPath is not found', () => {
+      const _log = createFakeLogger();
+      getRelativePath({
+        _log,
+        currentPath: 'bad-file-name',
+        pathList,
+        position: 'previous',
+      });
+      expect(_log.debug).toHaveBeenCalled();
     });
   });
 });

--- a/src/reducers/fileTree.tsx
+++ b/src/reducers/fileTree.tsx
@@ -160,7 +160,7 @@ export const buildFileTree = (version: Version): FileTree => {
 };
 
 type GetRelativePathParams = {
-  _log: typeof log;
+  _log?: typeof log;
   currentPath: string;
   pathList: string[];
   position: 'previous' | 'next';
@@ -173,7 +173,7 @@ export const getRelativePath = ({
   position,
 }: GetRelativePathParams): string | void => {
   const currentIndex = pathList.indexOf(currentPath);
-  if (!currentIndex) {
+  if (currentIndex < 0) {
     _log.debug(`Cannot find ${currentPath} in pathList: ${pathList}`);
     return undefined;
   }

--- a/src/reducers/fileTree.tsx
+++ b/src/reducers/fileTree.tsx
@@ -172,15 +172,13 @@ type GetRelativePathParams = {
 };
 
 export const getRelativePath = ({
-  _log = log,
   currentPath,
   pathList,
   position,
-}: GetRelativePathParams): string | void => {
+}: GetRelativePathParams): string => {
   const currentIndex = pathList.indexOf(currentPath);
   if (currentIndex < 0) {
-    _log.debug(`Cannot find ${currentPath} in pathList: ${pathList}`);
-    return undefined;
+    throw new Error(`Cannot find ${currentPath} in pathList: ${pathList}`);
   }
   let newIndex =
     position === RelativePathPosition.previous
@@ -201,7 +199,6 @@ export const getRelativePath = ({
 
 type GoToRelativeFileParams = {
   _getRelativePath?: typeof getRelativePath;
-  _log?: typeof log;
   currentPath: string;
   pathList: string[];
   position: RelativePathPosition;
@@ -210,7 +207,6 @@ type GoToRelativeFileParams = {
 
 export const goToRelativeFile = ({
   _getRelativePath = getRelativePath,
-  _log = log,
   currentPath,
   pathList,
   position,
@@ -218,19 +214,10 @@ export const goToRelativeFile = ({
 }: GoToRelativeFileParams): ThunkActionCreator => {
   return async (dispatch) => {
     const nextPath = _getRelativePath({
-      _log,
       currentPath,
       pathList,
       position,
     });
-
-    if (!nextPath) {
-      // This will only happen if currentPath is not found in pathList, which
-      // should never happen, so I think we can just ignore this and log a debug
-      // message.
-      _log.debug(`Cannot find ${currentPath} in pathList: ${pathList}`);
-      return;
-    }
 
     dispatch(
       versionActions.updateSelectedPath({

--- a/src/reducers/fileTree.tsx
+++ b/src/reducers/fileTree.tsx
@@ -177,13 +177,18 @@ export const getRelativePath = ({
     _log.debug(`Cannot find ${currentPath} in pathList: ${pathList}`);
     return undefined;
   }
-  const newIndex =
-    position === 'previous' ? currentIndex - 1 : currentIndex + 1;
-  const validIndex = newIndex >= 0 && pathList.length >= newIndex;
-  if (!validIndex) {
-    _log.debug(`There is not a ${position} file wrt ${currentPath}`);
+  let newIndex = position === 'previous' ? currentIndex - 1 : currentIndex + 1;
+  if (newIndex < 0) {
+    // We are at the first file and the user selected 'previous', so go to the
+    // last file.
+    newIndex = pathList.length - 1;
+  } else if (newIndex >= pathList.length) {
+    // We are at the last file and the user selected 'next', so go to the
+    // first file.
+    newIndex = 0;
   }
-  return validIndex ? pathList[newIndex] : undefined;
+
+  return pathList[newIndex];
 };
 
 type GoToNextFileParams = {


### PR DESCRIPTION
Fixes #471 

This is just a proof of concept for executing this action which needs data from both the `fileTree` state and the `versions` state, and needs to modify the `versions` state, which I am doing by dispatching `versionActions.updateSelectedPath`. 

I thought I could get away with not having to access `getState` in the thunk, by accepting `currentPath` as a parameter, but we still need it to access the internal state of the `fileTree` reducer, because we also need to dispatch.

I may have gotten a number of things wrong here, because it still seems a bit convoluted to me. Submitting this for feedback on the approach.

@willdurand this is something I discussed with @kumar303 via Vidyo today, but please feel free to comment if you have any suggestions.
