### PR TITLE
The fileTree reducer should not store an empty FileTree object 

### DIFF
--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -39,7 +39,7 @@ export type DefaultProps = {
 };
 
 type PropsFromState = {
-  treeNodes: FileTree['nodes'] | void;
+  tree: FileTree | void;
   version: Version | void;
 };
 
@@ -67,9 +67,9 @@ export class FileTreeBase extends React.Component<Props> {
   }
 
   _loadData = () => {
-    const { dispatch, treeNodes, version } = this.props;
+    const { dispatch, tree, version } = this.props;
 
-    if (version && !treeNodes) {
+    if (version && !tree) {
       dispatch(fileTreeActions.buildTree({ version }));
     }
   };
@@ -133,9 +133,9 @@ export class FileTreeBase extends React.Component<Props> {
   };
 
   render() {
-    const { treeNodes, version } = this.props;
+    const { tree, version } = this.props;
 
-    if (!version || !treeNodes) {
+    if (!version || !tree) {
       return <Loading message={gettext('Loading version...')} />;
     }
 
@@ -164,7 +164,7 @@ export class FileTreeBase extends React.Component<Props> {
           </Button>
         </div>
         <Treefold
-          nodes={[treeNodes]}
+          nodes={[tree.nodes]}
           render={this.renderNode}
           isNodeExpanded={this.isNodeExpanded}
           onToggleExpand={this.onToggleExpand}
@@ -190,10 +190,9 @@ const mapStateToProps = (
   }
 
   const tree = version ? getTree(state.fileTree, version.id) : undefined;
-  const treeNodes = tree ? tree.nodes : undefined;
 
   return {
-    treeNodes,
+    tree,
     version,
   };
 };

--- a/src/reducers/fileTree.tsx
+++ b/src/reducers/fileTree.tsx
@@ -229,18 +229,18 @@ export const goToRelativeFile = ({
 };
 
 export type FileTree = {
-  nodes: DirectoryNode | void;
-  pathList: string[] | void;
+  nodes: DirectoryNode;
+  pathList: string[];
 };
 
 export type FileTreeState = {
   forVersionId: void | number;
-  tree: FileTree;
+  tree: void | FileTree;
 };
 
 export const initialState: FileTreeState = {
   forVersionId: undefined,
-  tree: { nodes: undefined, pathList: undefined },
+  tree: undefined,
 };
 
 export const actions = {


### PR DESCRIPTION
Fixes #552 
~~Depends on #547~~

Only the final commit in this PR is relevant to this patch.

Note that this change is being made to simplify the changes required for #459, which will require that the `FileTree` component also have access to `pathList` from the `fileTree` state.