### PR TITLE
Use common functions to get code line anchors

### DIFF
--- a/src/components/CodeView/index.spec.tsx
+++ b/src/components/CodeView/index.spec.tsx
@@ -10,7 +10,7 @@ import LinterMessage from '../LinterMessage';
 import LinterProvider, { LinterProviderInfo } from '../LinterProvider';
 import { ExternalLinterMessage, getMessageMap } from '../../reducers/linter';
 import { createInternalVersion } from '../../reducers/versions';
-import { mapWithDepth } from './utils';
+import { getCodeLineAnchor, getCodeLineAnchorID, mapWithDepth } from './utils';
 import { getLanguageFromMimeType } from '../../utils';
 import {
   createContextWithFakeRouter,
@@ -187,13 +187,21 @@ describe(__filename, () => {
     const root = renderWithLinterProvider({ content: 'line 1\nline 2' });
 
     expect(root.find(`.${styles.line}`)).toHaveLength(2);
-    expect(root.find(`.${styles.line}`).at(0)).toHaveProp('id', 'L1');
-    expect(root.find(`.${styles.line}`).at(1)).toHaveProp('id', 'L2');
+    expect(root.find(`.${styles.line}`).at(0)).toHaveProp(
+      'id',
+      getCodeLineAnchorID(1),
+    );
+    expect(root.find(`.${styles.line}`).at(1)).toHaveProp(
+      'id',
+      getCodeLineAnchorID(2),
+    );
   });
 
   it('marks a row as selected', () => {
     const selectedLine = 2;
-    const location = createFakeLocation({ hash: `#L${selectedLine}` });
+    const location = createFakeLocation({
+      hash: getCodeLineAnchor(selectedLine),
+    });
 
     const root = renderWithLinterProvider({
       content: 'line 1\nline 2',
@@ -203,7 +211,7 @@ describe(__filename, () => {
     expect(root.find(`.${styles.selectedLine}`)).toHaveLength(1);
     expect(root.find(`.${styles.selectedLine}`)).toHaveProp(
       'id',
-      `L${selectedLine}`,
+      getCodeLineAnchorID(selectedLine),
     );
   });
 
@@ -214,26 +222,28 @@ describe(__filename, () => {
     expect(root.find(`.${styles.lineNumber}`).find(Link)).toHaveLength(1);
     expect(root.find(`.${styles.lineNumber}`).find(Link)).toHaveProp(
       'to',
-      '#L1',
+      getCodeLineAnchor(1),
     );
     // This is an anchor on the table row. This is a bit confusing here because
     // `#` refers to the ID (CSS) selector and not the hash. The ID value is
     // `L1`.
-    expect(root.find('#L1')).toHaveLength(1);
+    expect(root.find(`#${getCodeLineAnchorID(1)}`)).toHaveLength(1);
   });
 
   it('calls _scrollToSelectedLine() when rendering a selected line', () => {
     const selectedLine = 2;
     const lines = ['first', 'second'];
     const content = lines.join('\n');
-    const location = createFakeLocation({ hash: `#L${selectedLine}` });
+    const location = createFakeLocation({
+      hash: getCodeLineAnchor(selectedLine),
+    });
     const _scrollToSelectedLine = jest.fn();
 
     // We need `mount()` because `ref` is only used in a DOM environment.
     const root = renderWithMount({ _scrollToSelectedLine, content, location });
 
     expect(_scrollToSelectedLine).toHaveBeenCalledWith(
-      root.find(`#L${selectedLine}`).getDOMNode(),
+      root.find(`#${getCodeLineAnchorID(selectedLine)}`).getDOMNode(),
     );
   });
 

--- a/src/components/CodeView/index.tsx
+++ b/src/components/CodeView/index.tsx
@@ -4,7 +4,12 @@ import makeClassName from 'classnames';
 
 import styles from './styles.module.scss';
 import LinterMessage from '../LinterMessage';
-import { getLines, mapWithDepth } from './utils';
+import {
+  getCodeLineAnchor,
+  getCodeLineAnchorID,
+  getLines,
+  mapWithDepth,
+} from './utils';
 import refractor from '../../refractor';
 import { getLanguageFromMimeType } from '../../utils';
 import { Version } from '../../reducers/versions';
@@ -76,7 +81,7 @@ export class CodeViewBase extends React.Component<Props> {
                 const line = i + 1;
 
                 let rowProps: RowProps = {
-                  id: `L${line}`,
+                  id: getCodeLineAnchorID(line),
                   className: styles.line,
                 };
 
@@ -95,7 +100,7 @@ export class CodeViewBase extends React.Component<Props> {
                   <React.Fragment key={`fragment-${line}`}>
                     <tr {...rowProps}>
                       <td className={styles.lineNumber}>
-                        <Link to={`#L${line}`}>{`${line}`}</Link>
+                        <Link to={getCodeLineAnchor(line)}>{`${line}`}</Link>
                       </td>
 
                       <td className={styles.code}>

--- a/src/components/CodeView/utils.spec.tsx
+++ b/src/components/CodeView/utils.spec.tsx
@@ -1,7 +1,13 @@
 import { RefractorNode } from 'refractor';
 import makeClassName from 'classnames';
 
-import { mapWithDepth, mapChild, getLines } from './utils';
+import {
+  getCodeLineAnchor,
+  getCodeLineAnchorID,
+  mapWithDepth,
+  mapChild,
+  getLines,
+} from './utils';
 
 describe(__filename, () => {
   describe('getLines', () => {
@@ -165,6 +171,18 @@ describe(__filename, () => {
 
         expect(_mapChild).toHaveBeenCalledWith(child, index, depth);
       });
+    });
+  });
+
+  describe('getCodeLineAnchorID', () => {
+    it('gets an anchor ID', () => {
+      expect(getCodeLineAnchorID(23)).toEqual('L23');
+    });
+  });
+
+  describe('getCodeLineAnchor', () => {
+    it('gets an anchor', () => {
+      expect(getCodeLineAnchor(23)).toEqual('#L23');
     });
   });
 });

--- a/src/components/CodeView/utils.tsx
+++ b/src/components/CodeView/utils.tsx
@@ -37,16 +37,10 @@ export const getLines = (content: string) => {
   return content.replace('\r\n', '\n').split('\n');
 };
 
-/*
- * This gets an ID (for a DOM element) representing a line of code.
- */
 export const getCodeLineAnchorID = (line: number) => {
   return `L${line}`;
 };
 
-/*
- * This gets an anchor HREF to a line of code.
- */
 export const getCodeLineAnchor = (line: number) => {
   return `#${getCodeLineAnchorID(line)}`;
 };

--- a/src/components/CodeView/utils.tsx
+++ b/src/components/CodeView/utils.tsx
@@ -36,3 +36,17 @@ export const mapWithDepth = (depth: number, _mapChild = mapChild) => {
 export const getLines = (content: string) => {
   return content.replace('\r\n', '\n').split('\n');
 };
+
+/*
+ * This gets an ID (for a DOM element) representing a line of code.
+ */
+export const getCodeLineAnchorID = (line: number) => {
+  return `L${line}`;
+};
+
+/*
+ * This gets an anchor HREF to a line of code.
+ */
+export const getCodeLineAnchor = (line: number) => {
+  return `#${getCodeLineAnchorID(line)}`;
+};


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/546

This seems like a small thing to add a function for but it will help to synchronize the line linking functionality between `Browse` and the forthcoming code overview component (see https://github.com/mozilla/addons-code-manager/pull/542/files#diff-4a3375c826127680658868411c3f42d3R236).