### PR TITLE
Add `?path` to query string when selecting a file

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "loglevel": "1.6.1",
     "node-sass": "4.11.0",
     "prop-types": "15.7.2",
+    "query-string": "6.4.2",
     "raven-js": "3.27.0",
     "react": "16.8.6",
     "react-bootstrap": "1.0.0-beta.8",

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -48,7 +48,7 @@ describe(__filename, () => {
     _fetchVersion?: BrowseProps['_fetchVersion'];
     _fetchVersionFile?: BrowseProps['_fetchVersionFile'];
     _log?: BrowseProps['_log'];
-    _updateSelectedPath?: BrowseProps['_updateSelectedPath'];
+    _viewVersionFile?: BrowseProps['_viewVersionFile'];
     addonId?: string;
     history?: History;
     store?: Store;
@@ -59,7 +59,7 @@ describe(__filename, () => {
     _fetchVersion,
     _fetchVersionFile,
     _log,
-    _updateSelectedPath,
+    _viewVersionFile,
     addonId = '999',
     history = createFakeHistory(),
     store = configureStore(),
@@ -73,7 +73,7 @@ describe(__filename, () => {
       _fetchVersion,
       _fetchVersionFile,
       _log,
-      _updateSelectedPath,
+      _viewVersionFile,
     };
 
     return shallowUntilTarget(<Browse {...props} />, BrowseBase, {
@@ -240,7 +240,7 @@ describe(__filename, () => {
     expect(root.find(Loading)).toHaveProp('message', 'Loading content...');
   });
 
-  it('dispatches updateSelectedPath() when a file is selected', () => {
+  it('dispatches viewVersionFile when a file is selected', () => {
     const addonId = 123456;
     const version = { ...fakeVersion, id: 98765 };
     const path = 'some-path';
@@ -250,10 +250,10 @@ describe(__filename, () => {
     const dispatch = spyOn(store, 'dispatch');
 
     const fakeThunk = createFakeThunk();
-    const _updateSelectedPath = fakeThunk.createThunk;
+    const _viewVersionFile = fakeThunk.createThunk;
 
     const root = render({
-      _updateSelectedPath,
+      _viewVersionFile,
       store,
       addonId: String(addonId),
       versionId: String(version.id),
@@ -266,7 +266,7 @@ describe(__filename, () => {
     onSelectFile(path);
 
     expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(_updateSelectedPath).toHaveBeenCalledWith({
+    expect(_viewVersionFile).toHaveBeenCalledWith({
       selectedPath: path,
       versionId: version.id,
     });
@@ -418,7 +418,7 @@ describe(__filename, () => {
     expect(dispatch).not.toHaveBeenCalled();
   });
 
-  it('dispatches updateSelectedPath on mount if the query string contains a `path` that is different than `version.selectedPath`', () => {
+  it('dispatches viewVersionFile on mount if the query string contains a `path` that is different than `version.selectedPath`', () => {
     const path = 'a/different/file.js';
     const version = fakeVersion;
     const history = createFakeHistory({
@@ -431,10 +431,10 @@ describe(__filename, () => {
     const dispatch = spyOn(store, 'dispatch');
 
     const fakeThunk = createFakeThunk();
-    const _updateSelectedPath = fakeThunk.createThunk;
+    const _viewVersionFile = fakeThunk.createThunk;
 
     render({
-      _updateSelectedPath,
+      _viewVersionFile,
       history,
       store,
       versionId: String(version.id),
@@ -442,13 +442,13 @@ describe(__filename, () => {
 
     expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
     expect(dispatch).toHaveBeenCalledTimes(1);
-    expect(_updateSelectedPath).toHaveBeenCalledWith({
+    expect(_viewVersionFile).toHaveBeenCalledWith({
       versionId: version.id,
       selectedPath: path,
     });
   });
 
-  it('does not dispatch updateSelectedPath on mount when the query string does not contain a `path`', () => {
+  it('does not dispatch viewVersionFile on mount when the query string does not contain a `path`', () => {
     const version = fakeVersion;
     const history = createFakeHistory({
       location: createFakeLocation({
@@ -464,7 +464,7 @@ describe(__filename, () => {
     expect(dispatch).not.toHaveBeenCalled();
   });
 
-  it('does not dispatch updateSelectedPath on mount when `path` is equal to the selected path', () => {
+  it('does not dispatch viewVersionFile on mount when `path` is equal to the selected path', () => {
     const version = fakeVersion;
     const history = createFakeHistory({
       location: createFakeLocation({ search: '' }),
@@ -478,7 +478,7 @@ describe(__filename, () => {
     expect(dispatch).not.toHaveBeenCalled();
   });
 
-  it('dispatches updateSelectedPath on update if the query string contains a `path` that is different than `version.selectedPath`', () => {
+  it('dispatches viewVersionFile on update if the query string contains a `path` that is different than `version.selectedPath`', () => {
     const { renderAndUpdate, version } = setUpVersionFileUpdate({
       loadVersionAndFile: true,
     });
@@ -490,19 +490,19 @@ describe(__filename, () => {
     });
 
     const fakeThunk = createFakeThunk();
-    const _updateSelectedPath = fakeThunk.createThunk;
+    const _viewVersionFile = fakeThunk.createThunk;
 
-    const { dispatchSpy } = renderAndUpdate({ _updateSelectedPath, history });
+    const { dispatchSpy } = renderAndUpdate({ _viewVersionFile, history });
 
     expect(dispatchSpy).toHaveBeenCalledWith(fakeThunk.thunk);
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
-    expect(_updateSelectedPath).toHaveBeenCalledWith({
+    expect(_viewVersionFile).toHaveBeenCalledWith({
       versionId: version.id,
       selectedPath: path,
     });
   });
 
-  it('does not dispatch updateSelectedPath on update if the query string does not contain a `path`', () => {
+  it('does not dispatch viewVersionFile on update if the query string does not contain a `path`', () => {
     const { renderAndUpdate } = setUpVersionFileUpdate({
       loadVersionAndFile: true,
     });
@@ -515,7 +515,7 @@ describe(__filename, () => {
     expect(dispatchSpy).not.toHaveBeenCalled();
   });
 
-  it('does not dispatch updateSelectedPath on update if `path` is equal to the selected path', () => {
+  it('does not dispatch viewVersionFile on update if `path` is equal to the selected path', () => {
     const { renderAndUpdate, version } = setUpVersionFileUpdate({
       loadVersionAndFile: true,
     });

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -16,7 +16,7 @@ import {
   getVersionFile,
   getVersionInfo,
   isFileLoading,
-  updateSelectedPath,
+  viewVersionFile,
 } from '../../reducers/versions';
 import { gettext, getPathFromQueryString } from '../../utils';
 import Loading from '../../components/Loading';
@@ -30,7 +30,7 @@ export type DefaultProps = {
   _fetchVersion: typeof fetchVersion;
   _fetchVersionFile: typeof fetchVersionFile;
   _log: typeof log;
-  _updateSelectedPath: typeof updateSelectedPath;
+  _viewVersionFile: typeof viewVersionFile;
 };
 
 type PropsFromRouter = {
@@ -56,7 +56,7 @@ export class BrowseBase extends React.Component<Props> {
     _fetchVersion: fetchVersion,
     _fetchVersionFile: fetchVersionFile,
     _log: log,
-    _updateSelectedPath: updateSelectedPath,
+    _viewVersionFile: viewVersionFile,
   };
 
   componentDidMount() {
@@ -110,11 +110,11 @@ export class BrowseBase extends React.Component<Props> {
   }
 
   onSelectFile = (path: string) => {
-    const { _updateSelectedPath, dispatch, match } = this.props;
+    const { _viewVersionFile, dispatch, match } = this.props;
     const { versionId } = match.params;
 
     dispatch(
-      _updateSelectedPath({
+      _viewVersionFile({
         versionId: parseInt(versionId, 10),
         selectedPath: path,
       }),

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -94,7 +94,7 @@ export class BrowseBase extends React.Component<Props> {
     const path = getPathFromQueryString(history);
 
     if (path && path !== version.selectedPath) {
-      this.onSelectFile(path);
+      this.viewVersionFile(path);
       return;
     }
 
@@ -109,7 +109,7 @@ export class BrowseBase extends React.Component<Props> {
     }
   }
 
-  onSelectFile = (path: string) => {
+  viewVersionFile = (path: string) => {
     const { _viewVersionFile, dispatch, match } = this.props;
     const { versionId } = match.params;
 
@@ -137,7 +137,10 @@ export class BrowseBase extends React.Component<Props> {
         <Col md="3">
           <Row>
             <Col>
-              <FileTree onSelect={this.onSelectFile} versionId={version.id} />
+              <FileTree
+                onSelect={this.viewVersionFile}
+                versionId={version.id}
+              />
             </Col>
           </Row>
           {file && (

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -18,7 +18,7 @@ import {
   isFileLoading,
   updateSelectedPath,
 } from '../../reducers/versions';
-import { gettext } from '../../utils';
+import { gettext, getPathFromQueryString } from '../../utils';
 import Loading from '../../components/Loading';
 import CodeView from '../../components/CodeView';
 import FileMetadata from '../../components/FileMetadata';
@@ -74,6 +74,7 @@ export class BrowseBase extends React.Component<Props> {
       dispatch,
       file,
       fileIsLoading,
+      history,
       match,
       version,
     } = this.props;
@@ -87,6 +88,13 @@ export class BrowseBase extends React.Component<Props> {
           versionId: parseInt(versionId, 10),
         }),
       );
+      return;
+    }
+
+    const path = getPathFromQueryString(history);
+
+    if (path && path !== version.selectedPath) {
+      this.onSelectFile(path);
       return;
     }
 

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -11,12 +11,12 @@ import FileTree from '../../components/FileTree';
 import {
   Version,
   VersionFile,
-  actions,
   fetchVersion,
   fetchVersionFile,
   getVersionFile,
   getVersionInfo,
   isFileLoading,
+  updateSelectedPath,
 } from '../../reducers/versions';
 import { gettext } from '../../utils';
 import Loading from '../../components/Loading';
@@ -30,6 +30,7 @@ export type DefaultProps = {
   _fetchVersion: typeof fetchVersion;
   _fetchVersionFile: typeof fetchVersionFile;
   _log: typeof log;
+  _updateSelectedPath: typeof updateSelectedPath;
 };
 
 type PropsFromRouter = {
@@ -55,24 +56,20 @@ export class BrowseBase extends React.Component<Props> {
     _fetchVersion: fetchVersion,
     _fetchVersionFile: fetchVersionFile,
     _log: log,
+    _updateSelectedPath: updateSelectedPath,
   };
 
   componentDidMount() {
-    const { _fetchVersion, dispatch, match } = this.props;
-    const { addonId, versionId } = match.params;
-
-    // This also fetches / loads the default version file.
-    // Example: manifest.json
-    dispatch(
-      _fetchVersion({
-        addonId: parseInt(addonId, 10),
-        versionId: parseInt(versionId, 10),
-      }),
-    );
+    this.loadData();
   }
 
   componentDidUpdate() {
+    this.loadData();
+  }
+
+  loadData() {
     const {
+      _fetchVersion,
       _fetchVersionFile,
       dispatch,
       file,
@@ -81,12 +78,19 @@ export class BrowseBase extends React.Component<Props> {
       version,
     } = this.props;
 
-    if (
-      version &&
-      version.selectedPath &&
-      !fileIsLoading &&
-      file === undefined
-    ) {
+    if (!version) {
+      const { addonId, versionId } = match.params;
+
+      dispatch(
+        _fetchVersion({
+          addonId: parseInt(addonId, 10),
+          versionId: parseInt(versionId, 10),
+        }),
+      );
+      return;
+    }
+
+    if (version.selectedPath && !fileIsLoading && file === undefined) {
       dispatch(
         _fetchVersionFile({
           addonId: parseInt(match.params.addonId, 10),
@@ -98,11 +102,11 @@ export class BrowseBase extends React.Component<Props> {
   }
 
   onSelectFile = (path: string) => {
-    const { dispatch, match } = this.props;
+    const { _updateSelectedPath, dispatch, match } = this.props;
     const { versionId } = match.params;
 
     dispatch(
-      actions.updateSelectedPath({
+      _updateSelectedPath({
         versionId: parseInt(versionId, 10),
         selectedPath: path,
       }),

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -63,7 +63,7 @@ describe(__filename, () => {
 
   type RenderParams = {
     _fetchDiff?: PublicProps['_fetchDiff'];
-    _updateSelectedPath?: PublicProps['_updateSelectedPath'];
+    _viewVersionFile?: PublicProps['_viewVersionFile'];
     addonId?: string;
     baseVersionId?: string;
     headVersionId?: string;
@@ -74,7 +74,7 @@ describe(__filename, () => {
 
   const render = ({
     _fetchDiff,
-    _updateSelectedPath,
+    _viewVersionFile,
     addonId = '999',
     baseVersionId = '1',
     headVersionId = '2',
@@ -88,7 +88,7 @@ describe(__filename, () => {
         params: { lang, addonId, baseVersionId, headVersionId },
       }),
       _fetchDiff,
-      _updateSelectedPath,
+      _viewVersionFile,
     };
 
     return shallowUntilTarget(<Compare {...props} />, CompareBase, {
@@ -408,7 +408,7 @@ describe(__filename, () => {
     });
   });
 
-  it('dispatches updateSelectedPath() when a file is selected', () => {
+  it('dispatches viewVersionFile() when a file is selected', () => {
     const version = fakeVersionWithDiff;
     const headVersionId = version.id;
     const path = 'new-path.js';
@@ -418,10 +418,10 @@ describe(__filename, () => {
     const dispatch = spyOn(store, 'dispatch');
 
     const fakeThunk = createFakeThunk();
-    const _updateSelectedPath = fakeThunk.createThunk;
+    const _viewVersionFile = fakeThunk.createThunk;
 
     const root = render({
-      _updateSelectedPath,
+      _viewVersionFile,
       ...getRouteParams({ headVersionId }),
       store,
     });
@@ -432,7 +432,7 @@ describe(__filename, () => {
     onSelectFile(path);
 
     expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(_updateSelectedPath).toHaveBeenCalledWith({
+    expect(_viewVersionFile).toHaveBeenCalledWith({
       selectedPath: path,
       versionId: headVersionId,
     });

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -14,14 +14,14 @@ import {
   Version,
   fetchDiff,
   getVersionInfo,
-  updateSelectedPath,
+  viewVersionFile,
 } from '../../reducers/versions';
 import { gettext } from '../../utils';
 import styles from './styles.module.scss';
 
 export type PublicProps = {
   _fetchDiff: typeof fetchDiff;
-  _updateSelectedPath: typeof updateSelectedPath;
+  _viewVersionFile: typeof viewVersionFile;
 };
 
 type PropsFromRouter = {
@@ -47,7 +47,7 @@ type Props = RouteComponentProps<PropsFromRouter> &
 export class CompareBase extends React.Component<Props> {
   static defaultProps = {
     _fetchDiff: fetchDiff,
-    _updateSelectedPath: updateSelectedPath,
+    _viewVersionFile: viewVersionFile,
   };
 
   componentDidMount() {
@@ -98,11 +98,11 @@ export class CompareBase extends React.Component<Props> {
   }
 
   onSelectFile = (path: string) => {
-    const { _updateSelectedPath, dispatch, match } = this.props;
+    const { _viewVersionFile, dispatch, match } = this.props;
     const { headVersionId } = match.params;
 
     dispatch(
-      _updateSelectedPath({
+      _viewVersionFile({
         selectedPath: path,
         versionId: parseInt(headVersionId, 10),
       }),

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -12,15 +12,16 @@ import VersionChooser from '../../components/VersionChooser';
 import {
   CompareInfo,
   Version,
-  actions,
   fetchDiff,
   getVersionInfo,
+  updateSelectedPath,
 } from '../../reducers/versions';
 import { gettext } from '../../utils';
 import styles from './styles.module.scss';
 
 export type PublicProps = {
   _fetchDiff: typeof fetchDiff;
+  _updateSelectedPath: typeof updateSelectedPath;
 };
 
 type PropsFromRouter = {
@@ -46,6 +47,7 @@ type Props = RouteComponentProps<PropsFromRouter> &
 export class CompareBase extends React.Component<Props> {
   static defaultProps = {
     _fetchDiff: fetchDiff,
+    _updateSelectedPath: updateSelectedPath,
   };
 
   componentDidMount() {
@@ -96,11 +98,11 @@ export class CompareBase extends React.Component<Props> {
   }
 
   onSelectFile = (path: string) => {
-    const { dispatch, match } = this.props;
+    const { _updateSelectedPath, dispatch, match } = this.props;
     const { headVersionId } = match.params;
 
     dispatch(
-      actions.updateSelectedPath({
+      _updateSelectedPath({
         selectedPath: path,
         versionId: parseInt(headVersionId, 10),
       }),

--- a/src/reducers/fileTree.spec.tsx
+++ b/src/reducers/fileTree.spec.tsx
@@ -525,7 +525,7 @@ describe(__filename, () => {
   describe('goToRelativeFile', () => {
     const _goToRelativeFile = ({
       _getRelativePath = jest.fn(),
-      _updateSelectedPath = jest.fn(),
+      _viewVersionFile = jest.fn(),
       currentPath = 'file1.js',
       pathList = ['file1.js'],
       position = RelativePathPosition.next,
@@ -533,7 +533,7 @@ describe(__filename, () => {
     } = {}) => {
       return goToRelativeFile({
         _getRelativePath,
-        _updateSelectedPath,
+        _viewVersionFile,
         currentPath,
         pathList,
         position,
@@ -566,19 +566,19 @@ describe(__filename, () => {
       });
     });
 
-    it('dispatches updateSelectedPath()', async () => {
+    it('dispatches viewVersionFile()', async () => {
       const nextPath = 'file2.js';
       const _getRelativePath = jest.fn().mockReturnValue(nextPath);
       const versionId = 123;
 
       const fakeThunk = createFakeThunk();
-      const _updateSelectedPath = fakeThunk.createThunk;
+      const _viewVersionFile = fakeThunk.createThunk;
 
       const { dispatch, thunk } = thunkTester({
         createThunk: () =>
           _goToRelativeFile({
             _getRelativePath,
-            _updateSelectedPath,
+            _viewVersionFile,
             versionId,
           }),
       });
@@ -586,7 +586,7 @@ describe(__filename, () => {
       await thunk();
 
       expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
-      expect(_updateSelectedPath).toHaveBeenCalledWith({
+      expect(_viewVersionFile).toHaveBeenCalledWith({
         selectedPath: nextPath,
         versionId,
       });

--- a/src/reducers/fileTree.tsx
+++ b/src/reducers/fileTree.tsx
@@ -2,7 +2,7 @@ import log from 'loglevel';
 import { Reducer } from 'redux';
 import { ActionType, createAction, getType } from 'typesafe-actions';
 
-import { Version, updateSelectedPath } from './versions';
+import { Version, viewVersionFile } from './versions';
 import { ThunkActionCreator } from '../configureStore';
 import { getLocalizedString } from '../utils';
 
@@ -199,7 +199,7 @@ export const getRelativePath = ({
 
 type GoToRelativeFileParams = {
   _getRelativePath?: typeof getRelativePath;
-  _updateSelectedPath?: typeof updateSelectedPath;
+  _viewVersionFile?: typeof viewVersionFile;
   currentPath: string;
   pathList: string[];
   position: RelativePathPosition;
@@ -210,7 +210,7 @@ export const goToRelativeFile = ({
   /* istanbul ignore next */
   _getRelativePath = getRelativePath,
   /* istanbul ignore next */
-  _updateSelectedPath = updateSelectedPath,
+  _viewVersionFile = viewVersionFile,
   currentPath,
   pathList,
   position,
@@ -224,7 +224,7 @@ export const goToRelativeFile = ({
     });
 
     dispatch(
-      _updateSelectedPath({
+      _viewVersionFile({
         selectedPath: nextPath,
         versionId,
       }),

--- a/src/reducers/fileTree.tsx
+++ b/src/reducers/fileTree.tsx
@@ -207,7 +207,9 @@ type GoToRelativeFileParams = {
 };
 
 export const goToRelativeFile = ({
+  /* istanbul ignore next */
   _getRelativePath = getRelativePath,
+  /* istanbul ignore next */
   _updateSelectedPath = updateSelectedPath,
   currentPath,
   pathList,

--- a/src/reducers/fileTree.tsx
+++ b/src/reducers/fileTree.tsx
@@ -2,7 +2,7 @@ import log from 'loglevel';
 import { Reducer } from 'redux';
 import { ActionType, createAction, getType } from 'typesafe-actions';
 
-import { Version, actions as versionActions } from './versions';
+import { Version, updateSelectedPath } from './versions';
 import { ThunkActionCreator } from '../configureStore';
 import { getLocalizedString } from '../utils';
 
@@ -199,6 +199,7 @@ export const getRelativePath = ({
 
 type GoToRelativeFileParams = {
   _getRelativePath?: typeof getRelativePath;
+  _updateSelectedPath?: typeof updateSelectedPath;
   currentPath: string;
   pathList: string[];
   position: RelativePathPosition;
@@ -207,6 +208,7 @@ type GoToRelativeFileParams = {
 
 export const goToRelativeFile = ({
   _getRelativePath = getRelativePath,
+  _updateSelectedPath = updateSelectedPath,
   currentPath,
   pathList,
   position,
@@ -220,7 +222,7 @@ export const goToRelativeFile = ({
     });
 
     dispatch(
-      versionActions.updateSelectedPath({
+      _updateSelectedPath({
         selectedPath: nextPath,
         versionId,
       }),

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -1,4 +1,5 @@
 import { getType } from 'typesafe-actions';
+import { push } from 'connected-react-router';
 
 import { actions as errorsActions } from './errors';
 import reducer, {
@@ -21,10 +22,15 @@ import reducer, {
   getVersionInfo,
   initialState,
   isFileLoading,
+  updateSelectedPath,
 } from './versions';
 import { getRootPath } from './fileTree';
+import configureStore from '../configureStore';
 import {
   createFakeEntry,
+  createFakeHistory,
+  createFakeLocation,
+  createFakeLogger,
   fakeExternalDiff,
   fakeVersion,
   fakeVersionAddon,
@@ -33,7 +39,6 @@ import {
   fakeVersionWithDiff,
   fakeVersionsList,
   fakeVersionsListItem,
-  createFakeLogger,
   thunkTester,
 } from '../test-helpers';
 
@@ -1412,6 +1417,34 @@ describe(__filename, () => {
       );
 
       expect(isFileLoading(state, versionId, path)).toEqual(false);
+    });
+  });
+
+  describe('updateSelectedPath', () => {
+    it('dispatches updateSelectedPath and pushes a new URL', async () => {
+      const selectedPath = 'some-path';
+      const versionId = fakeVersion.id;
+
+      const pathname = '/some/path/to/a/page';
+      const location = createFakeLocation({ pathname });
+      const history = createFakeHistory({ location });
+
+      const { dispatch, thunk } = thunkTester({
+        createThunk: () => updateSelectedPath({ selectedPath, versionId }),
+        store: configureStore({ history }),
+      });
+
+      await thunk();
+
+      expect(dispatch).toHaveBeenCalledWith(
+        actions.updateSelectedPath({
+          selectedPath,
+          versionId,
+        }),
+      );
+      expect(dispatch).toHaveBeenCalledWith(
+        push(`${pathname}?path=${selectedPath}`),
+      );
     });
   });
 });

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -1421,11 +1421,11 @@ describe(__filename, () => {
   });
 
   describe('viewVersionFile', () => {
-    it('dispatches updateSelectedPath and pushes a new URL', async () => {
-      const selectedPath = 'some-path';
-      const versionId = fakeVersion.id;
+    const selectedPath = 'some-path';
+    const versionId = fakeVersion.id;
+    const pathname = '/some/path/to/a/page';
 
-      const pathname = '/some/path/to/a/page';
+    it('dispatches updateSelectedPath and pushes a new URL', async () => {
       const location = createFakeLocation({ pathname });
       const history = createFakeHistory({ location });
 
@@ -1444,6 +1444,23 @@ describe(__filename, () => {
       );
       expect(dispatch).toHaveBeenCalledWith(
         push(`${pathname}?path=${selectedPath}`),
+      );
+    });
+
+    it('preserves the existing query parameters', async () => {
+      const search = '?a=1&b=2';
+      const location = createFakeLocation({ pathname, search });
+      const history = createFakeHistory({ location });
+
+      const { dispatch, thunk } = thunkTester({
+        createThunk: () => viewVersionFile({ selectedPath, versionId }),
+        store: configureStore({ history }),
+      });
+
+      await thunk();
+
+      expect(dispatch).toHaveBeenCalledWith(
+        push(`${pathname}${search}&path=${selectedPath}`),
       );
     });
   });

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -22,7 +22,7 @@ import reducer, {
   getVersionInfo,
   initialState,
   isFileLoading,
-  updateSelectedPath,
+  viewVersionFile,
 } from './versions';
 import { getRootPath } from './fileTree';
 import configureStore from '../configureStore';
@@ -1420,7 +1420,7 @@ describe(__filename, () => {
     });
   });
 
-  describe('updateSelectedPath', () => {
+  describe('viewVersionFile', () => {
     it('dispatches updateSelectedPath and pushes a new URL', async () => {
       const selectedPath = 'some-path';
       const versionId = fakeVersion.id;
@@ -1430,7 +1430,7 @@ describe(__filename, () => {
       const history = createFakeHistory({ location });
 
       const { dispatch, thunk } = thunkTester({
-        createThunk: () => updateSelectedPath({ selectedPath, versionId }),
+        createThunk: () => viewVersionFile({ selectedPath, versionId }),
         store: configureStore({ history }),
       });
 

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -616,7 +616,7 @@ type UpdateSelectedPathParams = {
   selectedPath: string;
 };
 
-export const updateSelectedPath = ({
+export const viewVersionFile = ({
   versionId,
   selectedPath,
 }: UpdateSelectedPathParams): ThunkActionCreator => {

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -612,7 +612,7 @@ export const fetchDiff = ({
   };
 };
 
-type UpdateSelectedPathParams = {
+type ViewVersionFileParams = {
   versionId: number;
   selectedPath: string;
 };
@@ -620,7 +620,7 @@ type UpdateSelectedPathParams = {
 export const viewVersionFile = ({
   versionId,
   selectedPath,
-}: UpdateSelectedPathParams): ThunkActionCreator => {
+}: ViewVersionFileParams): ThunkActionCreator => {
   return async (dispatch, getState) => {
     const { router } = getState();
     const queryParams = {

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -3,6 +3,7 @@ import { ActionType, createAction, getType } from 'typesafe-actions';
 import log from 'loglevel';
 import { DiffInfo, DiffInfoType } from 'react-diff-view';
 import { push } from 'connected-react-router';
+import queryString from 'query-string';
 
 import { ThunkActionCreator } from '../configureStore';
 import { getDiff, getVersion, getVersionsList, isErrorResponse } from '../api';
@@ -622,9 +623,15 @@ export const viewVersionFile = ({
 }: UpdateSelectedPathParams): ThunkActionCreator => {
   return async (dispatch, getState) => {
     const { router } = getState();
+    const queryParams = {
+      ...queryString.parse(router.location.search),
+      path: selectedPath,
+    };
 
     dispatch(actions.updateSelectedPath({ versionId, selectedPath }));
-    dispatch(push(`${router.location.pathname}?path=${selectedPath}`));
+    dispatch(
+      push(`${router.location.pathname}?${queryString.stringify(queryParams)}`),
+    );
   };
 };
 

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -2,6 +2,7 @@ import { Reducer } from 'redux';
 import { ActionType, createAction, getType } from 'typesafe-actions';
 import log from 'loglevel';
 import { DiffInfo, DiffInfoType } from 'react-diff-view';
+import { push } from 'connected-react-router';
 
 import { ThunkActionCreator } from '../configureStore';
 import { getDiff, getVersion, getVersionsList, isErrorResponse } from '../api';
@@ -607,6 +608,23 @@ export const fetchDiff = ({
         }),
       );
     }
+  };
+};
+
+type UpdateSelectedPathParams = {
+  versionId: number;
+  selectedPath: string;
+};
+
+export const updateSelectedPath = ({
+  versionId,
+  selectedPath,
+}: UpdateSelectedPathParams): ThunkActionCreator => {
+  return async (dispatch, getState) => {
+    const { router } = getState();
+
+    dispatch(actions.updateSelectedPath({ versionId, selectedPath }));
+    dispatch(push(`${router.location.pathname}?path=${selectedPath}`));
   };
 };
 

--- a/src/utils.spec.tsx
+++ b/src/utils.spec.tsx
@@ -1,12 +1,15 @@
 import filesize from 'filesize';
+import queryString from 'query-string';
 
 import {
   formatFilesize,
   getLanguageFromMimeType,
   getLocalizedString,
+  getPathFromQueryString,
   nl2br,
   sanitizeHTML,
 } from './utils';
+import { createFakeHistory, createFakeLocation } from './test-helpers';
 
 describe(__filename, () => {
   describe('getLocalizedString', () => {
@@ -152,6 +155,37 @@ describe(__filename, () => {
     it('returns a size formatted using the iec standard', () => {
       const size = 12345;
       expect(formatFilesize(size)).toEqual(filesize(size, { standard: 'iec' }));
+    });
+  });
+
+  describe('getPathFromQueryString', () => {
+    it('returns the `path` if it exists in the query string', () => {
+      const path = 'some/path/to/file.js';
+      const history = createFakeHistory({
+        location: createFakeLocation({
+          search: queryString.stringify({ path }),
+        }),
+      });
+
+      expect(getPathFromQueryString(history)).toEqual(path);
+    });
+
+    it('returns `null` if there is no `path` in the query string', () => {
+      const history = createFakeHistory({
+        location: createFakeLocation({ search: '' }),
+      });
+
+      expect(getPathFromQueryString(history)).toEqual(null);
+    });
+
+    it('returns `null` if `path` is empty in the query string', () => {
+      const history = createFakeHistory({
+        location: createFakeLocation({
+          search: queryString.stringify({ path: '' }),
+        }),
+      });
+
+      expect(getPathFromQueryString(history)).toEqual(null);
     });
   });
 });

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,5 +1,7 @@
 import filesize from 'filesize';
 import purify from 'dompurify';
+import { History } from 'history';
+import queryString from 'query-string';
 
 export type LocalizedStringMap = {
   [lang: string]: string;
@@ -48,4 +50,10 @@ export const nl2br = (text: string | null) => {
 
 export const formatFilesize = (size: number): string => {
   return filesize(size, { standard: 'iec' });
+};
+
+export const getPathFromQueryString = (history: History) => {
+  const { path } = queryString.parse(history.location.search);
+
+  return typeof path === 'string' && path.length ? path : null;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11948,6 +11948,15 @@ qs@^6.5.1, qs@^6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+query-string@6.4.2:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.4.2.tgz#8be1dbd105306aebf86022144f575a29d516b713"
+  integrity sha512-DfJqAen17LfLA3rQ+H5S4uXphrF+ANU1lT2ijds4V/Tj4gZxA3gx5/tg1bz7kYCmwna7LyJNCYqO7jNRzo3aLw==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 query-string@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
@@ -13645,6 +13654,11 @@ spdy@^4.0.0:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+split-on-first@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.0.0.tgz#648af4ce9a28fbcaadd43274455f298b55025fc6"
+  integrity sha512-mjA57TQtdWztVZ9THAjGNpgbuIrNfsNrGa5IyK94NoPaT4N14M+GI4jD7t4arLjFkYRQWdETC5RxFzLWouoB3A==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -13800,6 +13814,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes #286
~~⚠️ depends on #48~~

---

This patch adds a new `?path` parameter to the query string when a file is selected. It works in all pages, with keyboard navigation and mouse selection. This patch also allows to load a specific file **in the browse page only**.

Note 1: this patch also has a fix for #551 (only browse component)
Note 2: I'll file an issue to add this feature to the Compare page too