### PR TITLE
Preserve query parameters and hash in CodeView/Browse

### DIFF
--- a/src/components/CodeView/index.spec.tsx
+++ b/src/components/CodeView/index.spec.tsx
@@ -216,14 +216,15 @@ describe(__filename, () => {
   });
 
   it('renders a link for each line number', () => {
-    const root = renderWithLinterProvider({ content: 'single line' });
+    const location = createFakeLocation();
+    const root = renderWithLinterProvider({ content: 'single line', location });
 
     expect(root.find(`.${styles.lineNumber}`)).toHaveLength(1);
     expect(root.find(`.${styles.lineNumber}`).find(Link)).toHaveLength(1);
-    expect(root.find(`.${styles.lineNumber}`).find(Link)).toHaveProp(
-      'to',
-      getCodeLineAnchor(1),
-    );
+    expect(root.find(`.${styles.lineNumber}`).find(Link)).toHaveProp('to', {
+      ...location,
+      hash: getCodeLineAnchor(1),
+    });
     // This is an anchor on the table row. This is a bit confusing here because
     // `#` refers to the ID (CSS) selector and not the hash. The ID value is
     // `L1`.

--- a/src/components/CodeView/index.tsx
+++ b/src/components/CodeView/index.tsx
@@ -100,7 +100,12 @@ export class CodeViewBase extends React.Component<Props> {
                   <React.Fragment key={`fragment-${line}`}>
                     <tr {...rowProps}>
                       <td className={styles.lineNumber}>
-                        <Link to={getCodeLineAnchor(line)}>{`${line}`}</Link>
+                        <Link
+                          to={{
+                            ...location,
+                            hash: getCodeLineAnchor(line),
+                          }}
+                        >{`${line}`}</Link>
                       </td>
 
                       <td className={styles.code}>

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -269,6 +269,7 @@ describe(__filename, () => {
     expect(_viewVersionFile).toHaveBeenCalledWith({
       selectedPath: path,
       versionId: version.id,
+      preserveHash: false,
     });
   });
 
@@ -445,6 +446,7 @@ describe(__filename, () => {
     expect(_viewVersionFile).toHaveBeenCalledWith({
       versionId: version.id,
       selectedPath: path,
+      preserveHash: true,
     });
   });
 
@@ -499,6 +501,7 @@ describe(__filename, () => {
     expect(_viewVersionFile).toHaveBeenCalledWith({
       versionId: version.id,
       selectedPath: path,
+      preserveHash: true,
     });
   });
 

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -240,7 +240,7 @@ describe(__filename, () => {
     expect(root.find(Loading)).toHaveProp('message', 'Loading content...');
   });
 
-  it('dispatches viewVersionFile when a file is selected', () => {
+  it('dispatches viewVersionFile without preserving the URL hash when a file is selected', () => {
     const addonId = 123456;
     const version = { ...fakeVersion, id: 98765 };
     const path = 'some-path';

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -94,7 +94,7 @@ export class BrowseBase extends React.Component<Props> {
     const path = getPathFromQueryString(history);
 
     if (path && path !== version.selectedPath) {
-      this.viewVersionFile(path);
+      this.viewVersionFile(path, { preserveHash: true });
       return;
     }
 
@@ -109,7 +109,7 @@ export class BrowseBase extends React.Component<Props> {
     }
   }
 
-  viewVersionFile = (path: string) => {
+  viewVersionFile = (path: string, { preserveHash = false } = {}) => {
     const { _viewVersionFile, dispatch, match } = this.props;
     const { versionId } = match.params;
 
@@ -117,6 +117,7 @@ export class BrowseBase extends React.Component<Props> {
       _viewVersionFile({
         versionId: parseInt(versionId, 10),
         selectedPath: path,
+        preserveHash,
       }),
     );
   };

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -1521,7 +1521,11 @@ describe(__filename, () => {
         }),
       );
       expect(dispatch).toHaveBeenCalledWith(
-        push(`${pathname}?path=${selectedPath}`),
+        push({
+          ...location,
+          search: `?path=${selectedPath}`,
+          hash: undefined,
+        }),
       );
     });
 
@@ -1538,7 +1542,54 @@ describe(__filename, () => {
       await thunk();
 
       expect(dispatch).toHaveBeenCalledWith(
-        push(`${pathname}${search}&path=${selectedPath}`),
+        push({
+          ...location,
+          search: `${search}&path=${selectedPath}`,
+          hash: undefined,
+        }),
+      );
+    });
+
+    it('does not preserve the location hash by default', async () => {
+      const hash = '#some-hash';
+      const location = createFakeLocation({ pathname, hash });
+      const history = createFakeHistory({ location });
+
+      const { dispatch, thunk } = thunkTester({
+        createThunk: () => viewVersionFile({ selectedPath, versionId }),
+        store: configureStore({ history }),
+      });
+
+      await thunk();
+
+      expect(dispatch).toHaveBeenCalledWith(
+        push({
+          ...location,
+          search: `?path=${selectedPath}`,
+          hash: undefined,
+        }),
+      );
+    });
+
+    it('preserves the location hash when `preserveHash` is `true', async () => {
+      const hash = '#some-hash';
+      const location = createFakeLocation({ pathname, hash });
+      const history = createFakeHistory({ location });
+
+      const { dispatch, thunk } = thunkTester({
+        createThunk: () =>
+          viewVersionFile({ selectedPath, versionId, preserveHash: true }),
+        store: configureStore({ history }),
+      });
+
+      await thunk();
+
+      expect(dispatch).toHaveBeenCalledWith(
+        push({
+          ...location,
+          search: `?path=${selectedPath}`,
+          hash,
+        }),
       );
     });
   });

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -615,11 +615,13 @@ export const fetchDiff = ({
 type ViewVersionFileParams = {
   versionId: number;
   selectedPath: string;
+  preserveHash?: boolean;
 };
 
 export const viewVersionFile = ({
   versionId,
   selectedPath,
+  preserveHash = false,
 }: ViewVersionFileParams): ThunkActionCreator => {
   return async (dispatch, getState) => {
     const { router } = getState();
@@ -627,11 +629,19 @@ export const viewVersionFile = ({
       ...queryString.parse(router.location.search),
       path: selectedPath,
     };
+    const newLocation = {
+      ...router.location,
+      search: `?${queryString.stringify(queryParams)}`,
+    };
+
+    // We do not want to preserve the hash when we select a new file for
+    // instance, but we want to keep it when we load a file via its path.
+    if (!preserveHash) {
+      delete newLocation.hash;
+    }
 
     dispatch(actions.updateSelectedPath({ versionId, selectedPath }));
-    dispatch(
-      push(`${router.location.pathname}?${queryString.stringify(queryParams)}`),
-    );
+    dispatch(push(newLocation));
   };
 };
 


### PR DESCRIPTION
Fixes #593

---

This patch makes sure the query string is kept in the `CodeView` line anchors. It also ensures we can load any file with a specific line selected. Last but not least, when selecting a new file, it removes the `hash` from the URL.