### PR TITLE
Compare load file

### DIFF
--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -480,9 +480,7 @@ describe(__filename, () => {
     expect(dispatch).not.toHaveBeenCalled();
   });
 
-  // This could happen when a keyboard navigation updates the selected path. We
-  // do not want to update the selected path again, so we apply this logic to
-  // the first render (mount) only.
+  // This could happen when a keyboard navigation updates the selected path.
   it('does not dispatch viewVersionFile on update if the query string contains a `path` that is different than `version.selectedPath`', () => {
     const { renderAndUpdate } = setUpVersionFileUpdate({
       loadVersionAndFile: true,

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -480,8 +480,11 @@ describe(__filename, () => {
     expect(dispatch).not.toHaveBeenCalled();
   });
 
-  it('dispatches viewVersionFile on update if the query string contains a `path` that is different than `version.selectedPath`', () => {
-    const { renderAndUpdate, version } = setUpVersionFileUpdate({
+  // This could happen when a keyboard navigation updates the selected path. We
+  // do not want to update the selected path again, so we apply this logic to
+  // the first render (mount) only.
+  it('does not dispatch viewVersionFile on update if the query string contains a `path` that is different than `version.selectedPath`', () => {
+    const { renderAndUpdate } = setUpVersionFileUpdate({
       loadVersionAndFile: true,
     });
     const path = 'a/different/file.js';
@@ -491,18 +494,9 @@ describe(__filename, () => {
       }),
     });
 
-    const fakeThunk = createFakeThunk();
-    const _viewVersionFile = fakeThunk.createThunk;
+    const { dispatchSpy } = renderAndUpdate({ history });
 
-    const { dispatchSpy } = renderAndUpdate({ _viewVersionFile, history });
-
-    expect(dispatchSpy).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(dispatchSpy).toHaveBeenCalledTimes(1);
-    expect(_viewVersionFile).toHaveBeenCalledWith({
-      versionId: version.id,
-      selectedPath: path,
-      preserveHash: true,
-    });
+    expect(dispatchSpy).not.toHaveBeenCalled();
   });
 
   it('does not dispatch viewVersionFile on update if the query string does not contain a `path`', () => {

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -93,9 +93,12 @@ export class BrowseBase extends React.Component<Props> {
 
     const path = getPathFromQueryString(history);
 
+    // We do not want to update the selected path again (e.g., when a keyboard
+    // navigation updates the selected path), so we apply this logic to the
+    // first render (mount) only.
     if (!prevProps && path && path !== version.selectedPath) {
       // We preserve the hash in the URL (if any) when we load the file from an
-      // URL that has likely be shared.
+      // URL that has likely been shared.
       this.viewVersionFile(path, { preserveHash: true });
       return;
     }

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -63,11 +63,11 @@ export class BrowseBase extends React.Component<Props> {
     this.loadData();
   }
 
-  componentDidUpdate() {
-    this.loadData();
+  componentDidUpdate(prevProps: Props) {
+    this.loadData(prevProps);
   }
 
-  loadData() {
+  loadData(prevProps?: Props) {
     const {
       _fetchVersion,
       _fetchVersionFile,
@@ -93,7 +93,9 @@ export class BrowseBase extends React.Component<Props> {
 
     const path = getPathFromQueryString(history);
 
-    if (path && path !== version.selectedPath) {
+    if (!prevProps && path && path !== version.selectedPath) {
+      // We preserve the hash in the URL (if any) when we load the file from an
+      // URL that has likely be shared.
       this.viewVersionFile(path, { preserveHash: true });
       return;
     }
@@ -109,6 +111,8 @@ export class BrowseBase extends React.Component<Props> {
     }
   }
 
+  // When selecting a new file to view, we do not want to preserve the hash in
+  // the URL (this hash highlights a specific line of code).
   viewVersionFile = (path: string, { preserveHash = false } = {}) => {
     const { _viewVersionFile, dispatch, match } = this.props;
     const { versionId } = match.params;

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -546,9 +546,7 @@ describe(__filename, () => {
     });
   });
 
-  // This could happen when a keyboard navigation updates the selected path. We
-  // do not want to update the selected path again, so we apply this logic to
-  // the first render (mount) only.
+  // This could happen when a keyboard navigation updates the selected path.
   it('does not dispatch viewVersionFile() on update if the query string contains a `path` that is different than `version.selectedPath`', () => {
     const { dispatchSpy, root } = loadDiffAndRender();
 

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -87,6 +87,9 @@ export class CompareBase extends React.Component<Props> {
       return;
     }
 
+    // We do not want to update the selected path again (e.g., when a keyboard
+    // navigation updates the selected path), so we apply this logic to the
+    // first render (mount) only.
     if (!prevProps) {
       if (path && path !== version.selectedPath) {
         // We preserve the hash in the URL (if any) when we load the file from


### PR DESCRIPTION
Fixes #590
Fixes #551
~~⚠️ depends on #593~~

---

I found new bugs after having fixed other unrelated bugs and rebased 😞 Now, both `Browse` and `Compare` components have a similar behavior and the keyboard navigation works for both as intended and without any side effect (hopefully).

It seemed easier to fix #551 as part of this patch, but it resulted in a bigger diff than expected. Sorry about that..