### PR TITLE
Make sure we run fetchLinterMessages only once

### DIFF
--- a/src/reducers/linter.spec.tsx
+++ b/src/reducers/linter.spec.tsx
@@ -22,6 +22,7 @@ import linterReducer, {
 } from './linter';
 import { actions as errorsActions } from './errors';
 import { makeApiURL } from '../api';
+import configureStore from '../configureStore';
 
 describe(__filename, () => {
   const createExternalLinterResult = (
@@ -500,6 +501,22 @@ describe(__filename, () => {
       expect(dispatch).toHaveBeenCalledWith(
         actions.abortFetchLinterResult({ versionId }),
       );
+    });
+
+    it('early returns and does not do anything when linter messages are already being fetched', async () => {
+      const url = '/some/url';
+      const versionId = 123;
+      const store = configureStore();
+      store.dispatch(actions.beginFetchLinterResult({ versionId }));
+
+      const { dispatch, thunk } = thunkTester({
+        createThunk: () => fetchLinterMessages({ url, versionId }),
+        store,
+      });
+
+      await thunk();
+
+      expect(dispatch).not.toHaveBeenCalled();
     });
   });
 

--- a/src/reducers/linter.tsx
+++ b/src/reducers/linter.tsx
@@ -177,7 +177,12 @@ export const fetchLinterMessages = ({
   url: string;
   versionId: number;
 }): ThunkActionCreator => {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
+    // See: https://github.com/mozilla/addons-code-manager/issues/591
+    if (getState().linter.isLoading) {
+      return;
+    }
+
     dispatch(actions.beginFetchLinterResult({ versionId }));
 
     // This is a special URL and returns a non-standard JSON response.


### PR DESCRIPTION
Fixes #591

---

This patch fixes an issue with the `LinterProvider` dispatching too many asynchronous actions.