### PR TITLE
Dispatch begin/abort actions when fetching a version and avoid infinite fetch/error loop

### DIFF
--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -41,7 +41,7 @@ export type DefaultProps = {
 
 type PropsFromState = {
   tree: FileTree | void;
-  version: Version | void;
+  version: Version | void | null;
 };
 
 type Props = PublicProps & DefaultProps & PropsFromState & ConnectedReduxProps;

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -524,4 +524,31 @@ describe(__filename, () => {
 
     expect(dispatchSpy).not.toHaveBeenCalled();
   });
+
+  it('does not dispatch anything on mount when an API error has occured', () => {
+    const versionId = 4321;
+    const store = configureStore();
+    store.dispatch(versionsActions.beginFetchVersion({ versionId }));
+    // Simulate an API error.
+    store.dispatch(versionsActions.abortFetchVersion({ versionId }));
+    const dispatch = spyOn(store, 'dispatch');
+
+    render({ store, versionId: String(versionId) });
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch anything on update when an API error has occured', () => {
+    const version = fakeVersion;
+    const store = configureStore();
+    _loadVersionAndFile({ store, version });
+
+    const root = render({ store, versionId: String(version.id) });
+
+    const dispatch = spyOn(store, 'dispatch');
+    // An API error will lead to `version` being set to `null`.
+    root.setProps({ version: null });
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
 });

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -42,7 +42,7 @@ type PropsFromState = {
   apiState: ApiState;
   file: VersionFile | null | void;
   fileIsLoading: boolean;
-  version: Version | void;
+  version: Version | void | null;
 };
 
 export type Props = RouteComponentProps<PropsFromRouter> &
@@ -79,7 +79,12 @@ export class BrowseBase extends React.Component<Props> {
       version,
     } = this.props;
 
-    if (!version) {
+    if (version === null) {
+      // An error has occured when fetching the version.
+      return;
+    }
+
+    if (version === undefined) {
       const { addonId, versionId } = match.params;
 
       dispatch(

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -35,7 +35,7 @@ type PropsFromState = {
   addonId: number;
   compareInfo: CompareInfo | null | void;
   isLoading: boolean;
-  version: Version | void;
+  version: Version | void | null;
 };
 
 type Props = RouteComponentProps<PropsFromRouter> &

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -127,7 +127,7 @@ describe(__filename, () => {
           undefined,
           actions.updateSelectedPath({ selectedPath: 'pa/th', versionId: 123 }),
         );
-      }).toThrow();
+      }).toThrow(/Version missing/);
     });
 
     it('expands all parent folders when updateSelectedPath is dispatched', () => {
@@ -184,7 +184,7 @@ describe(__filename, () => {
           undefined,
           actions.toggleExpandedPath({ path: 'pa/th', versionId: 123 }),
         );
-      }).toThrow();
+      }).toThrow(/Version missing/);
     });
 
     it('does not duplicate paths in expandedPaths when updateSelectedPath is dispatched', () => {
@@ -317,7 +317,7 @@ describe(__filename, () => {
     it('throws an error when expandTree is called for an unknown version', () => {
       expect(() => {
         reducer(undefined, actions.expandTree({ versionId: 123 }));
-      }).toThrow();
+      }).toThrow(/Version missing/);
     });
 
     it('does not add paths for files to expandedPaths when expandTree is dispatched', () => {
@@ -364,7 +364,7 @@ describe(__filename, () => {
     it('throws an error when collapseTree is called for an unknown version', () => {
       expect(() => {
         reducer(initialState, actions.collapseTree({ versionId: 123 }));
-      }).toThrow();
+      }).toThrow(/Version missing/);
     });
 
     it('stores lists of versions by add-on ID', () => {
@@ -469,7 +469,7 @@ describe(__filename, () => {
             version,
           }),
         );
-      }).toThrow();
+      }).toThrow(/Entry missing for headVersionId/);
     });
 
     it('throws an error message when headVersion is missing on loadDiff()', () => {
@@ -488,7 +488,7 @@ describe(__filename, () => {
             version,
           }),
         );
-      }).toThrow();
+      }).toThrow(/Version missing for headVersionId/);
     });
   });
 

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -121,18 +121,13 @@ describe(__filename, () => {
       );
     });
 
-    it('logs an error when updateSelectedPath is called for an unknown version', () => {
-      const _log = createFakeLogger();
-      const state = reducer(
-        initialState,
-        actions.updateSelectedPath({ selectedPath: 'pa/th', versionId: 123 }),
-        // TS looks confused about the third optional argument.
-        // @ts-ignore
-        { _log },
-      );
-
-      expect(_log.error).toHaveBeenCalled();
-      expect(state).toEqual(initialState);
+    it('throws an error when updateSelectedPath is called for an unknown version', () => {
+      expect(() => {
+        reducer(
+          undefined,
+          actions.updateSelectedPath({ selectedPath: 'pa/th', versionId: 123 }),
+        );
+      }).toThrow();
     });
 
     it('expands all parent folders when updateSelectedPath is dispatched', () => {
@@ -183,18 +178,13 @@ describe(__filename, () => {
       ]);
     });
 
-    it('logs an error when toggleExpandedPath is called for an unknown version', () => {
-      const _log = createFakeLogger();
-      const state = reducer(
-        initialState,
-        actions.toggleExpandedPath({ path: 'pa/th', versionId: 123 }),
-        // TS looks confused about the third optional argument.
-        // @ts-ignore
-        { _log },
-      );
-
-      expect(_log.error).toHaveBeenCalled();
-      expect(state).toEqual(initialState);
+    it('throws an error when toggleExpandedPath is called for an unknown version', () => {
+      expect(() => {
+        reducer(
+          undefined,
+          actions.toggleExpandedPath({ path: 'pa/th', versionId: 123 }),
+        );
+      }).toThrow();
     });
 
     it('does not duplicate paths in expandedPaths when updateSelectedPath is dispatched', () => {
@@ -324,18 +314,10 @@ describe(__filename, () => {
       ]);
     });
 
-    it('logs an error when expandTree is called for an unknown version', () => {
-      const _log = createFakeLogger();
-      const state = reducer(
-        initialState,
-        actions.expandTree({ versionId: 123 }),
-        // TS looks confused about the third optional argument.
-        // @ts-ignore
-        { _log },
-      );
-
-      expect(_log.error).toHaveBeenCalled();
-      expect(state).toEqual(initialState);
+    it('throws an error when expandTree is called for an unknown version', () => {
+      expect(() => {
+        reducer(undefined, actions.expandTree({ versionId: 123 }));
+      }).toThrow();
     });
 
     it('does not add paths for files to expandedPaths when expandTree is dispatched', () => {
@@ -379,18 +361,10 @@ describe(__filename, () => {
       );
     });
 
-    it('logs an error when collapseTree is called for an unknown version', () => {
-      const _log = createFakeLogger();
-      const state = reducer(
-        initialState,
-        actions.collapseTree({ versionId: 123 }),
-        // TS looks confused about the third optional argument.
-        // @ts-ignore
-        { _log },
-      );
-
-      expect(_log.error).toHaveBeenCalled();
-      expect(state).toEqual(initialState);
+    it('throws an error when collapseTree is called for an unknown version', () => {
+      expect(() => {
+        reducer(initialState, actions.collapseTree({ versionId: 123 }));
+      }).toThrow();
     });
 
     it('stores lists of versions by add-on ID', () => {
@@ -465,11 +439,10 @@ describe(__filename, () => {
       });
     });
 
-    it('logs a debug message when entry is missing on loadDiff()', () => {
+    it('throws an error when entry is missing on loadDiff()', () => {
       const addonId = 1;
       const baseVersionId = 2;
       const path = 'some/other/file.js';
-      const _log = createFakeLogger();
 
       const version = {
         ...fakeVersionWithDiff,
@@ -485,45 +458,37 @@ describe(__filename, () => {
         undefined,
         actions.loadVersionInfo({ version }),
       );
-      const versionsState = reducer(
-        previousState,
-        actions.loadDiff({
-          addonId,
-          baseVersionId,
-          headVersionId,
-          version,
-        }),
-        // TS looks confused about the third optional argument.
-        // @ts-ignore
-        { _log },
-      );
 
-      expect(_log.debug).toHaveBeenCalled();
-      expect(versionsState).toEqual(previousState);
+      expect(() => {
+        reducer(
+          previousState,
+          actions.loadDiff({
+            addonId,
+            baseVersionId,
+            headVersionId,
+            version,
+          }),
+        );
+      }).toThrow();
     });
 
-    it('logs an error message when headVersion is missing on loadDiff()', () => {
+    it('throws an error message when headVersion is missing on loadDiff()', () => {
       const addonId = 1;
       const baseVersionId = 2;
       const version = fakeVersionWithDiff;
       const headVersionId = version.id;
-      const _log = createFakeLogger();
 
-      const versionsState = reducer(
-        undefined,
-        actions.loadDiff({
-          addonId,
-          baseVersionId,
-          headVersionId,
-          version,
-        }),
-        // TS looks confused about the third optional argument.
-        // @ts-ignore
-        { _log },
-      );
-
-      expect(_log.error).toHaveBeenCalled();
-      expect(versionsState).toEqual(initialState);
+      expect(() => {
+        reducer(
+          undefined,
+          actions.loadDiff({
+            addonId,
+            baseVersionId,
+            headVersionId,
+            version,
+          }),
+        );
+      }).toThrow();
     });
   });
 

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -668,7 +668,6 @@ export const viewVersionFile = ({
 const reducer: Reducer<VersionsState, ActionType<typeof actions>> = (
   state = initialState,
   action,
-  { _log = log } = {},
 ): VersionsState => {
   switch (action.type) {
     case getType(actions.beginFetchVersion): {
@@ -766,8 +765,7 @@ const reducer: Reducer<VersionsState, ActionType<typeof actions>> = (
       const version = state.versionInfo[versionId];
 
       if (!version) {
-        _log.error(`Version missing for versionId: ${versionId}`);
-        return state;
+        throw new Error(`Version missing for versionId: ${versionId}`);
       }
 
       const { expandedPaths } = version;
@@ -795,8 +793,7 @@ const reducer: Reducer<VersionsState, ActionType<typeof actions>> = (
       const version = state.versionInfo[versionId];
 
       if (!version) {
-        _log.error(`Version missing for versionId: ${versionId}`);
-        return state;
+        throw new Error(`Version missing for versionId: ${versionId}`);
       }
 
       const { expandedPaths } = version;
@@ -820,8 +817,7 @@ const reducer: Reducer<VersionsState, ActionType<typeof actions>> = (
       const version = state.versionInfo[versionId];
 
       if (!version) {
-        _log.error(`Version missing for versionId: ${versionId}`);
-        return state;
+        throw new Error(`Version missing for versionId: ${versionId}`);
       }
 
       const expandedPaths = version.entries
@@ -846,8 +842,7 @@ const reducer: Reducer<VersionsState, ActionType<typeof actions>> = (
       const version = state.versionInfo[versionId];
 
       if (!version) {
-        _log.error(`Version missing for versionId: ${versionId}`);
-        return state;
+        throw new Error(`Version missing for versionId: ${versionId}`);
       }
 
       return {
@@ -889,16 +884,14 @@ const reducer: Reducer<VersionsState, ActionType<typeof actions>> = (
 
       const headVersion = getVersionInfo(state, headVersionId);
       if (!headVersion) {
-        _log.error(`Version missing for headVersionId: ${headVersionId}`);
-        return state;
+        throw new Error(`Version missing for headVersionId: ${headVersionId}`);
       }
 
       const { entries, selectedPath } = headVersion;
       const entry = entries.find((e) => e.path === selectedPath);
 
       if (!entry) {
-        _log.debug(`Entry missing for headVersionId: ${headVersionId}`);
-        return state;
+        throw new Error(`Entry missing for headVersionId: ${headVersionId}`);
       }
 
       return {


### PR DESCRIPTION
Fixes #602
Fixes #556 

---

This patch is similar to the one merged to solve https://github.com/mozilla/addons-code-manager/issues/565. I added a bunch of early returns in the `reducer` (with `log.error` calls and test cases).