### PR TITLE
Introduce a Skeleton component

### DIFF
--- a/src/components/Skeleton/index.spec.tsx
+++ b/src/components/Skeleton/index.spec.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+
+import styles from './styles.module.scss';
+
+import Skeleton from '.';
+
+describe(__filename, () => {
+  const render = () => {
+    return shallow(<Skeleton />);
+  };
+
+  it('renders correctly', () => {
+    const root = render();
+
+    expect(root).toHaveClassName(`.${styles.skeleton}`);
+  });
+});

--- a/src/components/Skeleton/index.tsx
+++ b/src/components/Skeleton/index.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+import styles from './styles.module.scss';
+
+const SkeletonBase = () => {
+  return <div className={styles.skeleton} />;
+};
+
+export default SkeletonBase;

--- a/src/components/Skeleton/styles.module.scss
+++ b/src/components/Skeleton/styles.module.scss
@@ -1,0 +1,21 @@
+@import '../../scss/variables';
+
+.skeleton {
+  animation: pulse 1s infinite ease-in-out;
+  border-radius: $border-radius;
+  height: 100%;
+  min-height: 1rem;
+  width: 100%;
+}
+
+@keyframes pulse {
+  0% {
+    background-color: rgba($light-gray, 0.5);
+  }
+  50% {
+    background-color: rgba($light-gray, 1);
+  }
+  100% {
+    background-color: rgba($light-gray, 0.5);
+  }
+}

--- a/src/components/VersionChooser/index.spec.tsx
+++ b/src/components/VersionChooser/index.spec.tsx
@@ -4,7 +4,6 @@ import { History } from 'history';
 
 import configureStore from '../../configureStore';
 import VersionSelect from '../VersionSelect';
-import Loading from '../Loading';
 import {
   ExternalVersionsList,
   ExternalVersionsListItem,
@@ -100,11 +99,12 @@ describe(__filename, () => {
     store.dispatch(versionActions.loadVersionsList({ addonId, versions }));
   };
 
-  it('renders a loading message when lists of versions are not loaded', () => {
+  it('sets the `isLoading` prop to `true`  when lists of versions are not loaded', () => {
     const root = render();
 
-    expect(root.find(VersionSelect)).toHaveLength(0);
-    expect(root.find(Loading)).toHaveLength(1);
+    expect(root.find(VersionSelect)).toHaveLength(2);
+    expect(root.find(VersionSelect).at(0)).toHaveProp('isLoading', true);
+    expect(root.find(VersionSelect).at(1)).toHaveProp('isLoading', true);
   });
 
   it('renders two VersionSelect components when lists of versions are loaded', () => {

--- a/src/components/VersionChooser/index.tsx
+++ b/src/components/VersionChooser/index.tsx
@@ -3,7 +3,6 @@ import { Col, Form, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 
-import Loading from '../Loading';
 import { ApplicationState } from '../../reducers';
 import { ConnectedReduxProps } from '../../configureStore';
 import VersionSelect from '../VersionSelect';
@@ -100,6 +99,9 @@ export class VersionChooserBase extends React.Component<Props> {
     } = this.props;
     const { baseVersionId, headVersionId } = match.params;
 
+    const listedVersions = versionsMap ? versionsMap.listed : [];
+    const unlistedVersions = versionsMap ? versionsMap.unlisted : [];
+
     return (
       <div className={styles.VersionChooser}>
         <Form>
@@ -109,34 +111,30 @@ export class VersionChooserBase extends React.Component<Props> {
             </Col>
           </Row>
 
-          {versionsMap ? (
-            <Form.Row>
-              <VersionSelect
-                className={styles.baseVersionSelect}
-                isSelectable={_lowerVersionsThan(headVersionId)}
-                label={gettext('Choose an old version')}
-                listedVersions={versionsMap.listed}
-                onChange={this.onOldVersionChange}
-                unlistedVersions={versionsMap.unlisted}
-                value={baseVersionId}
-              />
-
-              <VersionSelect
-                className={styles.headVersionSelect}
-                isSelectable={_higherVersionsThan(baseVersionId)}
-                label={gettext('Choose a new version')}
-                listedVersions={versionsMap.listed}
-                onChange={this.onNewVersionChange}
-                unlistedVersions={versionsMap.unlisted}
-                value={headVersionId}
-                withLeftArrow
-              />
-            </Form.Row>
-          ) : (
-            <Loading
-              message={gettext('Retrieving all the versions of this add-on...')}
+          <Form.Row>
+            <VersionSelect
+              className={styles.baseVersionSelect}
+              isLoading={!versionsMap}
+              isSelectable={_lowerVersionsThan(headVersionId)}
+              label={gettext('Choose an old version')}
+              listedVersions={listedVersions}
+              onChange={this.onOldVersionChange}
+              unlistedVersions={unlistedVersions}
+              value={baseVersionId}
             />
-          )}
+
+            <VersionSelect
+              className={styles.headVersionSelect}
+              isLoading={!versionsMap}
+              isSelectable={_higherVersionsThan(baseVersionId)}
+              label={gettext('Choose a new version')}
+              listedVersions={listedVersions}
+              onChange={this.onNewVersionChange}
+              unlistedVersions={unlistedVersions}
+              value={headVersionId}
+              withLeftArrow
+            />
+          </Form.Row>
         </Form>
       </div>
     );

--- a/src/components/VersionSelect/index.spec.tsx
+++ b/src/components/VersionSelect/index.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { Form } from 'react-bootstrap';
 
+import Skeleton from '../Skeleton';
 import {
   ExternalVersionsList,
   createVersionsMap,
@@ -24,6 +25,7 @@ describe(__filename, () => {
 
   const render = ({
     className = undefined,
+    isLoading = false,
     isSelectable = jest.fn().mockReturnValue(true),
     label = 'select a version',
     onChange = jest.fn(),
@@ -35,6 +37,7 @@ describe(__filename, () => {
 
     const allProps = {
       className,
+      isLoading,
       isSelectable,
       label,
       listedVersions: versionsMap.listed,
@@ -209,5 +212,12 @@ describe(__filename, () => {
 
     expect(root.find('option').at(0)).toHaveProp('disabled', true);
     expect(root.find('option').at(1)).toHaveProp('disabled', false);
+  });
+
+  it('renders a Skeleton when component is in a loading state', () => {
+    const root = render({ isLoading: true });
+
+    expect(root.find('.form-control')).toHaveLength(1);
+    expect(root.find(Skeleton)).toHaveLength(1);
   });
 });

--- a/src/components/VersionSelect/index.tsx
+++ b/src/components/VersionSelect/index.tsx
@@ -23,7 +23,6 @@ export type PublicProps = {
 
 class VersionSelectBase extends React.Component<PublicProps> {
   static defaultProps = {
-    isLoading: false,
     withLeftArrow: false,
   };
 

--- a/src/components/VersionSelect/index.tsx
+++ b/src/components/VersionSelect/index.tsx
@@ -4,12 +4,14 @@ import { Col, Form } from 'react-bootstrap';
 import { FormControlProps } from 'react-bootstrap/lib/FormControl';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
+import Skeleton from '../Skeleton';
 import { VersionsList, VersionsListItem } from '../../reducers/versions';
 import { gettext } from '../../utils';
 import styles from './styles.module.scss';
 
 export type PublicProps = {
   className?: string;
+  isLoading: boolean;
   isSelectable: (version: VersionsListItem) => boolean;
   label: string;
   listedVersions: VersionsList;
@@ -21,6 +23,7 @@ export type PublicProps = {
 
 class VersionSelectBase extends React.Component<PublicProps> {
   static defaultProps = {
+    isLoading: false,
     withLeftArrow: false,
   };
 
@@ -47,6 +50,7 @@ class VersionSelectBase extends React.Component<PublicProps> {
   render() {
     const {
       className,
+      isLoading,
       label,
       listedVersions,
       unlistedVersions,
@@ -64,24 +68,31 @@ class VersionSelectBase extends React.Component<PublicProps> {
 
         <Form.Group as={Col} className={className}>
           <Form.Label>{label}</Form.Label>
-          <Form.Control as="select" value={value} onChange={this.onChange}>
-            {listedVersions.length && (
-              <optgroup
-                className={styles.listedGroup}
-                label={gettext('Listed')}
-              >
-                {listedVersions.map(this.renderOption)}
-              </optgroup>
-            )}
-            {unlistedVersions.length && (
-              <optgroup
-                className={styles.unlistedGroup}
-                label={gettext('Unlisted')}
-              >
-                {unlistedVersions.map(this.renderOption)}
-              </optgroup>
-            )}
-          </Form.Control>
+
+          {isLoading ? (
+            <div className="form-control">
+              <Skeleton />
+            </div>
+          ) : (
+            <Form.Control as="select" value={value} onChange={this.onChange}>
+              {listedVersions.length && (
+                <optgroup
+                  className={styles.listedGroup}
+                  label={gettext('Listed')}
+                >
+                  {listedVersions.map(this.renderOption)}
+                </optgroup>
+              )}
+              {unlistedVersions.length && (
+                <optgroup
+                  className={styles.unlistedGroup}
+                  label={gettext('Unlisted')}
+                >
+                  {unlistedVersions.map(this.renderOption)}
+                </optgroup>
+              )}
+            </Form.Control>
+          )}
         </Form.Group>
       </React.Fragment>
     );

--- a/stories/Skeleton.stories.tsx
+++ b/stories/Skeleton.stories.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import Skeleton from '../src/components/Skeleton';
+
+storiesOf('Skeleton', module).addWithChapters('all variants', {
+  chapters: [
+    {
+      sections: [
+        {
+          title: 'in a 100 x 50px div',
+          sectionFn: () => (
+            <div style={{ width: '100px', height: '50px' }}>
+              <Skeleton />
+            </div>
+          ),
+        },
+        {
+          title: 'in a paragraph',
+          sectionFn: () => (
+            <p>
+              <Skeleton />
+            </p>
+          ),
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Fixes #607 
Fixes #608 

Supports #379

---

This is a very simple `Skeleton` component that should fill the place where it is added. We can iterate if we need to add constraints (like `range` and `minWidth` props) but it's only the beginning of the long journey to fix #379.

![2019-04-17 16 54 05](https://user-images.githubusercontent.com/217628/56297877-770ad080-6131-11e9-9355-c0e4c0b59590.gif)

The second commit refactors the `VersionChooser` component to see the `Skeleton` in action:

![2019-04-17 17 15 21](https://user-images.githubusercontent.com/217628/56299539-8e978880-6134-11e9-848b-ef93f6377611.gif)

![2019-04-17 17 17 09](https://user-images.githubusercontent.com/217628/56299688-d1f1f700-6134-11e9-803a-2b3349f85cb9.gif)
