### PR TITLE
Create a function to return the Uid of the next/previous message

### DIFF
--- a/src/components/FileTreeNode/index.spec.tsx
+++ b/src/components/FileTreeNode/index.spec.tsx
@@ -644,27 +644,21 @@ describe(__filename, () => {
       expect(isKnownLibrary(map, path)).toEqual(true);
     });
 
-    it('throws an error if an extra key is found in the linter message map', () => {
+    it('calls getMessagesForPath to validate the messages for unexpected keys', () => {
       const path = 'jquery.js';
       const messages = [
         {
           ...fakeExternalLinterMessage,
           file: path,
-          id: [LINTER_KNOWN_LIBRARY_CODE],
-          line: null,
+          line: 123,
           type: 'notice',
         },
       ] as ExternalLinterMessage[];
       const map = _getMessageMap(messages);
+      const _getMessagesForPath = jest.fn().mockReturnValue([map[path]]);
 
-      const unexpectedKey = 'future';
-      // Artifically inject a new key in the message map.
-      // @ts-ignore
-      map[path][unexpectedKey] = {};
-
-      expect(() => {
-        isKnownLibrary(map, path);
-      }).toThrow(new RegExp(`Unexpected key "${unexpectedKey}" found`));
+      isKnownLibrary(map, path, _getMessagesForPath);
+      expect(_getMessagesForPath).toHaveBeenCalledWith(map[path]);
     });
   });
 });

--- a/src/components/FileTreeNode/index.tsx
+++ b/src/components/FileTreeNode/index.tsx
@@ -68,6 +68,9 @@ export const isKnownLibrary = (
   // unexpected keys.
   const messages = _getMessagesForPath(m);
   if (messages.length > 1 || messages[0].line !== null) {
+    // Even though this file could be a known library, return false so that the
+    // UI does not hide the file. The file should not be hidden when there are
+    // multiple linter messages.
     return false;
   }
 

--- a/src/components/FileTreeNode/index.tsx
+++ b/src/components/FileTreeNode/index.tsx
@@ -11,6 +11,7 @@ import {
   LinterMessage,
   LinterMessageMap,
   findMostSevereType,
+  getMessagesForPath,
 } from '../../reducers/linter';
 import styles from './styles.module.scss';
 
@@ -55,23 +56,18 @@ export const LINTER_KNOWN_LIBRARY_CODE = 'KNOWN_LIBRARY';
 export const isKnownLibrary = (
   linterMessageMap: LinterMessageMap,
   path: string,
+  _getMessagesForPath: typeof getMessagesForPath = getMessagesForPath,
 ): boolean => {
-  if (!linterMessageMap[path]) {
+  const m = linterMessageMap[path];
+
+  if (!m) {
     return false;
   }
 
-  const m = linterMessageMap[path];
-
-  // This is useful to make sure we do not miss linter messages if
-  // `LinterMessageMap` is updated with new maps of messages.
-  const allowedKeys = ['global', 'byLine'];
-  Object.keys(m).forEach((key) => {
-    if (!allowedKeys.includes(key)) {
-      throw new Error(`Unexpected key "${key}" found.`);
-    }
-  });
-
-  if (m.global.length > 1 || Object.keys(m.byLine).length > 0) {
+  // The call to getMessagesForPath checks that the messages do not have any
+  // unexpected keys.
+  const messages = _getMessagesForPath(m);
+  if (messages.length > 1 || messages[0].line !== null) {
     return false;
   }
 

--- a/src/reducers/fileTree.spec.tsx
+++ b/src/reducers/fileTree.spec.tsx
@@ -662,6 +662,31 @@ describe(__filename, () => {
       }).toThrow(`No messages found for current path: ${currentPath}`);
     });
 
+    it('throws an error with an empty pathList', () => {
+      const externalMessages1 = [
+        { line: null, uid: global1 },
+        { line: line1, uid: line1FirstUid },
+      ];
+      const externalMessages2 = [{ line: null, uid: global2 }];
+
+      const messageMap = createMessageMap([
+        { path: file1, messages: externalMessages1 },
+        { path: file3, messages: externalMessages2 },
+      ]);
+
+      expect(() => {
+        _getRelativeMessageUid({
+          currentMessageUid: global2,
+          currentPath: file3,
+          messageMap,
+          pathList: [],
+          position: RelativePathPosition.next,
+        });
+      }).toThrow(
+        `findRelativeMessageUid was unable to find a message using currentPath: ${file3}`,
+      );
+    });
+
     it('returns the first global message if no currentMessageUid exists', () => {
       const externalMessages = [
         { line: null, uid: global1 },
@@ -676,6 +701,27 @@ describe(__filename, () => {
         _getRelativeMessageUid({
           currentMessageUid: '',
           messageMap,
+        }),
+      ).toEqual(global1);
+    });
+
+    it('returns the first global message from a path with messages if no currentMessageUid exists', () => {
+      const externalMessages = [
+        { line: null, uid: global1 },
+        { line: line1, uid: line1FirstUid },
+      ];
+      const pathList = [file1, file2];
+
+      const messageMap = createMessageMap([
+        { path: file2, messages: externalMessages },
+      ]);
+
+      expect(
+        _getRelativeMessageUid({
+          currentMessageUid: '',
+          currentPath: file2,
+          messageMap,
+          pathList,
         }),
       ).toEqual(global1);
     });

--- a/src/reducers/fileTree.tsx
+++ b/src/reducers/fileTree.tsx
@@ -204,14 +204,14 @@ const findRelativeMessageUid = (
       pathList,
       position,
     });
-    const nextMessages = messageMap[nextPath];
-    if (nextMessages) {
-      const nextForPath = getMessagesForPath(nextMessages);
-      const nextIndex =
-        position === RelativePathPosition.previous ? nextForPath.length - 1 : 0;
+    const messages = messageMap[nextPath];
+    if (messages) {
+      const msgArray = getMessagesForPath(messages);
+      const msgIndex =
+        position === RelativePathPosition.previous ? msgArray.length - 1 : 0;
 
-      if (nextForPath[nextIndex]) {
-        return nextForPath[nextIndex].uid;
+      if (msgArray[msgIndex]) {
+        return msgArray[msgIndex].uid;
       }
     }
     path = nextPath;

--- a/src/reducers/linter.spec.tsx
+++ b/src/reducers/linter.spec.tsx
@@ -3,6 +3,7 @@ import log from 'loglevel';
 
 import {
   createFakeExternalLinterResult,
+  createFakeLinterMessagesByPath,
   fakeExternalLinterResult,
   fakeExternalLinterMessage,
   createFakeLogger,
@@ -17,6 +18,7 @@ import linterReducer, {
   fetchLinterMessagesIfNeeded,
   findMostSevereType,
   getMessageMap,
+  getMessagesForPath,
   initialState,
   selectMessageMap,
 } from './linter';
@@ -597,6 +599,65 @@ describe(__filename, () => {
           createMessageWithType('__unreal_type__'),
         ]);
       }).toThrow(/unknown types/);
+    });
+  });
+
+  describe('getMessagesForPath', () => {
+    const uid1 = 'global1';
+    const uid2 = 'global2';
+    const uid3 = 'line1-1';
+    const uid4 = 'line1-2';
+    const uid5 = 'line2';
+    const message1 = { line: null, uid: uid1 };
+    const message2 = { line: null, uid: uid2 };
+    const message3 = { line: 1, uid: uid3 };
+    const message4 = { line: 1, uid: uid4 };
+    const message5 = { line: 2, uid: uid5 };
+
+    it('aggregates global and byLine messages', () => {
+      const externalMessages = [
+        message1,
+        message2,
+        message3,
+        message4,
+        message5,
+      ];
+      const messages = createFakeLinterMessagesByPath({
+        messages: externalMessages,
+      });
+
+      const messagesForPath = getMessagesForPath(messages);
+      expect(messagesForPath.length).toEqual(5);
+      expect(messagesForPath[0]).toHaveProperty('uid', uid1);
+      expect(messagesForPath[1]).toHaveProperty('uid', uid2);
+      expect(messagesForPath[2]).toHaveProperty('uid', uid3);
+      expect(messagesForPath[3]).toHaveProperty('uid', uid4);
+      expect(messagesForPath[4]).toHaveProperty('uid', uid5);
+    });
+
+    it('returns with only global messages', () => {
+      const externalMessages = [message1, message2];
+      const messages = createFakeLinterMessagesByPath({
+        messages: externalMessages,
+      });
+
+      const messagesForPath = getMessagesForPath(messages);
+      expect(messagesForPath.length).toEqual(2);
+      expect(messagesForPath[0]).toHaveProperty('uid', uid1);
+      expect(messagesForPath[1]).toHaveProperty('uid', uid2);
+    });
+
+    it('returns with only byLine messages', () => {
+      const externalMessages = [message3, message4, message5];
+      const messages = createFakeLinterMessagesByPath({
+        messages: externalMessages,
+      });
+
+      const messagesForPath = getMessagesForPath(messages);
+      expect(messagesForPath.length).toEqual(3);
+      expect(messagesForPath[0]).toHaveProperty('uid', uid3);
+      expect(messagesForPath[1]).toHaveProperty('uid', uid4);
+      expect(messagesForPath[2]).toHaveProperty('uid', uid5);
     });
   });
 });

--- a/src/reducers/linter.spec.tsx
+++ b/src/reducers/linter.spec.tsx
@@ -608,11 +608,6 @@ describe(__filename, () => {
     const uid3 = 'line1-1';
     const uid4 = 'line1-2';
     const uid5 = 'line2';
-    const message1 = { line: null, uid: uid1 };
-    const message2 = { line: null, uid: uid2 };
-    const message3 = { line: 1, uid: uid3 };
-    const message4 = { line: 1, uid: uid4 };
-    const message5 = { line: 2, uid: uid5 };
 
     it('throws an error if an extra key is found in the linter message map', () => {
       const messages = createFakeLinterMessagesByPath({
@@ -631,11 +626,11 @@ describe(__filename, () => {
 
     it('aggregates global and byLine messages', () => {
       const externalMessages = [
-        message1,
-        message2,
-        message3,
-        message4,
-        message5,
+        { line: null, uid: uid1 },
+        { line: null, uid: uid2 },
+        { line: 1, uid: uid3 },
+        { line: 1, uid: uid4 },
+        { line: 2, uid: uid5 },
       ];
       const messages = createFakeLinterMessagesByPath({
         messages: externalMessages,
@@ -651,7 +646,10 @@ describe(__filename, () => {
     });
 
     it('returns with only global messages', () => {
-      const externalMessages = [message1, message2];
+      const externalMessages = [
+        { line: null, uid: uid1 },
+        { line: null, uid: uid2 },
+      ];
       const messages = createFakeLinterMessagesByPath({
         messages: externalMessages,
       });
@@ -663,7 +661,11 @@ describe(__filename, () => {
     });
 
     it('returns with only byLine messages', () => {
-      const externalMessages = [message3, message4, message5];
+      const externalMessages = [
+        { line: 1, uid: uid3 },
+        { line: 1, uid: uid4 },
+        { line: 2, uid: uid5 },
+      ];
       const messages = createFakeLinterMessagesByPath({
         messages: externalMessages,
       });

--- a/src/reducers/linter.spec.tsx
+++ b/src/reducers/linter.spec.tsx
@@ -14,7 +14,6 @@ import linterReducer, {
   ExternalLinterResult,
   LinterMessage,
   actions,
-  checkMessageKeys,
   createInternalMessage,
   fetchLinterMessagesIfNeeded,
   findMostSevereType,
@@ -615,15 +614,19 @@ describe(__filename, () => {
     const message4 = { line: 1, uid: uid4 };
     const message5 = { line: 2, uid: uid5 };
 
-    it('calls checkMessageKeys to validate the messages for unexpected keys', () => {
-      const _checkMessageKeys = jest.fn();
-      const externalMessages = [message1, message2];
+    it('throws an error if an extra key is found in the linter message map', () => {
       const messages = createFakeLinterMessagesByPath({
-        messages: externalMessages,
+        messages: [{ line: null, uid: '123' }],
       });
 
-      getMessagesForPath(messages, _checkMessageKeys);
-      expect(_checkMessageKeys).toHaveBeenCalledWith(messages);
+      const unexpectedKey = 'future';
+      // Artifically inject a new key in the message map.
+      // @ts-ignore
+      messages[unexpectedKey] = {};
+
+      expect(() => {
+        getMessagesForPath(messages);
+      }).toThrow(new RegExp(`Unexpected key "${unexpectedKey}" found`));
     });
 
     it('aggregates global and byLine messages', () => {
@@ -670,23 +673,6 @@ describe(__filename, () => {
       expect(messagesForPath[0]).toHaveProperty('uid', uid3);
       expect(messagesForPath[1]).toHaveProperty('uid', uid4);
       expect(messagesForPath[2]).toHaveProperty('uid', uid5);
-    });
-  });
-
-  describe('checkMessageKeys', () => {
-    it('throws an error if an extra key is found in the linter message map', () => {
-      const messages = createFakeLinterMessagesByPath({
-        messages: [{ line: null, uid: '123' }],
-      });
-
-      const unexpectedKey = 'future';
-      // Artifically inject a new key in the message map.
-      // @ts-ignore
-      messages[unexpectedKey] = {};
-
-      expect(() => {
-        checkMessageKeys(messages);
-      }).toThrow(new RegExp(`Unexpected key "${unexpectedKey}" found`));
     });
   });
 });

--- a/src/reducers/linter.tsx
+++ b/src/reducers/linter.tsx
@@ -139,7 +139,9 @@ export const findMostSevereType = (
   );
 };
 
-export const checkMessageKeys = (messages: LinterMessagesByPath): void => {
+export const getMessagesForPath = (
+  messages: LinterMessagesByPath,
+): LinterMessage[] => {
   // This is useful to make sure we do not miss linter messages if
   // `LinterMessageMap` is updated with new maps of messages.
   const allowedKeys = ['global', 'byLine'];
@@ -148,14 +150,6 @@ export const checkMessageKeys = (messages: LinterMessagesByPath): void => {
       throw new Error(`Unexpected key "${key}" found.`);
     }
   });
-};
-
-export const getMessagesForPath = (
-  messages: LinterMessagesByPath,
-  _checkMessageKeys: typeof checkMessageKeys = checkMessageKeys,
-): LinterMessage[] => {
-  // Make sure the messages do not have any unexpected keys.
-  _checkMessageKeys(messages);
 
   const allMessages = [...messages.global];
 

--- a/src/reducers/linter.tsx
+++ b/src/reducers/linter.tsx
@@ -139,6 +139,18 @@ export const findMostSevereType = (
   );
 };
 
+export const getMessagesForPath = (
+  messages: LinterMessagesByPath,
+): LinterMessage[] => {
+  const allMessages = [...messages.global];
+
+  Object.keys(messages.byLine).forEach((key) => {
+    allMessages.push(...messages.byLine[parseInt(key, 10)]);
+  });
+
+  return allMessages;
+};
+
 export type LinterState = {
   forVersionId: void | number;
   isLoading: boolean;

--- a/src/reducers/linter.tsx
+++ b/src/reducers/linter.tsx
@@ -139,9 +139,24 @@ export const findMostSevereType = (
   );
 };
 
+export const checkMessageKeys = (messages: LinterMessagesByPath): void => {
+  // This is useful to make sure we do not miss linter messages if
+  // `LinterMessageMap` is updated with new maps of messages.
+  const allowedKeys = ['global', 'byLine'];
+  Object.keys(messages).forEach((key) => {
+    if (!allowedKeys.includes(key)) {
+      throw new Error(`Unexpected key "${key}" found.`);
+    }
+  });
+};
+
 export const getMessagesForPath = (
   messages: LinterMessagesByPath,
+  _checkMessageKeys: typeof checkMessageKeys = checkMessageKeys,
 ): LinterMessage[] => {
+  // Make sure the messages do not have any unexpected keys.
+  _checkMessageKeys(messages);
+
   const allMessages = [...messages.global];
 
   Object.keys(messages.byLine).forEach((key) => {


### PR DESCRIPTION
Fixes #609 

I have written a lot of tests for this, testing the various situations that might exist when navigating between messages. I'm not sure if I have too many, not enough, or just the right number of tests, so that's something to check.

There are some paths as yet untested, for example some errors (I think), but I wanted to submit this for an initial review before going any further with it.

I created an internal function called `findRelativeMessageUid`, but I didn't export it and didn't write any tests for it. I think it makes more sense to just write the tests for `getRelativeMessageUid` to test every scenario, rather than a suite of tests for `findRelativeMessageUid` and then also use `findRelativeMessageUid` in the tests for `getRelativeMessageUid`. And yes, I know those names are kind of confusing and can probably be improved upon.
