### PR TITLE
Add linter message support to CodeOverview

### DIFF
--- a/src/components/CodeOverview/index.spec.tsx
+++ b/src/components/CodeOverview/index.spec.tsx
@@ -275,6 +275,64 @@ describe(__filename, () => {
     expect(link).toHaveProp('title', `Jump to line ${line}`);
   });
 
+  it('links to the first line that has a linter message', () => {
+    const firstLineWithMsg = 5;
+
+    const { innerRoot } = renderWithMessages({
+      // Create a file with 6 lines.
+      contentLines: generateFileLines({ count: 6 }),
+      // Make a grid of height 2 so that each row will contain 3 lines.
+      overviewHeight: 2,
+      // Put a linter message on line 5.
+      messages: [{ line: firstLineWithMsg }],
+      // Normalize the grid parameters.
+      rowHeight: 1,
+      overviewPadding: 0,
+      rowTopPadding: 0,
+    });
+
+    const allLinks = innerRoot.find(Link);
+    expect(allLinks).toHaveLength(2);
+
+    const link = allLinks.at(1);
+
+    expect(link).toHaveProp(
+      'to',
+      expect.objectContaining({
+        hash: getCodeLineAnchor(firstLineWithMsg),
+      }),
+    );
+  });
+
+  it('links to the first of multiple lines containing linter messages', () => {
+    const firstLineWithMsg = 5;
+
+    const { innerRoot } = renderWithMessages({
+      // Create a file with 6 lines.
+      contentLines: generateFileLines({ count: 6 }),
+      // Make a grid of height 2 so that each row will contain 3 lines.
+      overviewHeight: 2,
+      // Put a linter message on line 5 and line 6.
+      messages: [{ line: firstLineWithMsg }, { line: 6 }],
+      // Normalize the grid parameters.
+      rowHeight: 1,
+      overviewPadding: 0,
+      rowTopPadding: 0,
+    });
+
+    const allLinks = innerRoot.find(Link);
+    expect(allLinks).toHaveLength(2);
+
+    const link = allLinks.at(1);
+
+    expect(link).toHaveProp(
+      'to',
+      expect.objectContaining({
+        hash: getCodeLineAnchor(firstLineWithMsg),
+      }),
+    );
+  });
+
   it('sets link styles', () => {
     const rowHeight = 10;
     const rowTopPadding = 2;

--- a/src/components/CodeOverview/index.spec.tsx
+++ b/src/components/CodeOverview/index.spec.tsx
@@ -477,7 +477,7 @@ describe(__filename, () => {
     expect(links.at(1).find(CodeLineShapes)).toHaveLength(0);
   });
 
-  it('uses the most severe linter type', () => {
+  it('uses the most severe linter message type', () => {
     const line = 1;
     const { innerRoot } = renderWithMessages({
       messages: [

--- a/src/components/CodeOverview/index.tsx
+++ b/src/components/CodeOverview/index.tsx
@@ -1,9 +1,14 @@
 import * as React from 'react';
 import { withRouter, Link, RouteComponentProps } from 'react-router-dom';
+import makeClassName from 'classnames';
 import chunk from 'lodash.chunk';
 import debounce from 'lodash.debounce';
 
 import { getCodeLineAnchor, getLines } from '../CodeView/utils';
+import {
+  LinterMessage as LinterMessageType,
+  findMostSevereType,
+} from '../../reducers/linter';
 import styles from './styles.module.scss';
 import { gettext } from '../../utils';
 import { Version } from '../../reducers/versions';

--- a/src/components/CodeOverview/index.tsx
+++ b/src/components/CodeOverview/index.tsx
@@ -185,12 +185,24 @@ export class CodeOverviewBase extends React.Component<Props, State> {
       const line =
         shapes && shapes.length ? shapes[shapeIndex].line : undefined;
 
+      let linkableLine = line;
+      if (line && selectedMessageMap) {
+        // Look for the first line with a linter message on it and link to
+        // that instead.
+        const firstMsg = shapes.filter(
+          (s) => selectedMessageMap.byLine[s.line],
+        )[0];
+        if (firstMsg) {
+          linkableLine = firstMsg.line;
+        }
+      }
+
       overview.push(
         <Link
           className={styles.line}
           to={{
             ...location,
-            hash: line ? getCodeLineAnchor(line) : '#',
+            hash: linkableLine ? getCodeLineAnchor(linkableLine) : '#',
           }}
           key={rowIndex}
           style={{

--- a/src/components/CodeOverview/index.tsx
+++ b/src/components/CodeOverview/index.tsx
@@ -128,9 +128,29 @@ export class CodeOverviewBase extends React.Component<Props, State> {
       return null;
     }
 
-    // TODO: render linter messages here by looking at all shapes
-    // in groupOflineShapes.
-    // See https://github.com/mozilla/addons-code-manager/issues/523
+    const messages = selectedMessageMap
+      ? groupOflineShapes.reduce((matches: LinterMessageType[], shape) => {
+          if (selectedMessageMap.byLine[shape.line]) {
+            return matches.concat(selectedMessageMap.byLine[shape.line]);
+          }
+
+          return matches;
+        }, [])
+      : [];
+
+    if (messages.length) {
+      const type = findMostSevereType(messages);
+      return (
+        <div
+          key={messages.map((m) => m.uid).join(':')}
+          className={makeClassName(styles.linterMessage, {
+            [styles.linterError]: type === 'error',
+            [styles.linterWarning]: type === 'warning',
+            [styles.linterNotice]: type === 'notice',
+          })}
+        />
+      );
+    }
 
     const lineShapes = groupOflineShapes[shapeIndex];
 

--- a/src/components/CodeOverview/styles.module.scss
+++ b/src/components/CodeOverview/styles.module.scss
@@ -14,3 +14,20 @@
   line-height: 1;
   width: 100%;
 }
+
+.linterMessage {
+  border-radius: $border-radius;
+  width: 100%;
+}
+
+.linterError {
+  background-color: $red;
+}
+
+.linterNotice {
+  background-color: darken($alert-secondary-bg-color, 40);
+}
+
+.linterWarning {
+  background-color: $orange;
+}

--- a/stories/CodeOverview.stories.tsx
+++ b/stories/CodeOverview.stories.tsx
@@ -22,24 +22,22 @@ const render = ({
   messages = [],
   store = configureStore(),
 }: {
-  store?: Store;
   content?: string;
   messages?: Partial<LinterMessage>[];
+  store?: Store;
 } = {}) => {
-  let version = createInternalVersion(fakeVersion);
+  const path = 'background.js';
+  const version = createInternalVersion({
+    ...fakeVersion,
+    file: {
+      ...fakeVersionFile,
+      entries: { [path]: { ...fakeVersionEntry, path } },
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      selected_file: path,
+    },
+  });
 
   if (messages.length) {
-    const path = 'background.js';
-    version = createInternalVersion({
-      ...fakeVersion,
-      file: {
-        ...fakeVersionFile,
-        entries: { [path]: { ...fakeVersionEntry, path } },
-        // eslint-disable-next-line @typescript-eslint/camelcase
-        selected_file: path,
-      },
-    });
-
     const result = createFakeExternalLinterResult({
       messages: messages.map((msg) => {
         return { uid: newLinterMessageUID(), ...msg, file: path };

--- a/stories/CodeOverview.stories.tsx
+++ b/stories/CodeOverview.stories.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import { Store } from 'redux';
+import { storiesOf } from '@storybook/react';
+
+import { LinterMessage, actions } from '../src/reducers/linter';
+import longFileSample from './fixtures/long-file-sample';
+import CodeOverview from '../src/components/CodeOverview';
+import CodeView from '../src/components/CodeView';
+import configureStore from '../src/configureStore';
+import { JS_SAMPLE } from './CodeView.stories';
+import { createInternalVersion } from '../src/reducers/versions';
+import {
+  createFakeExternalLinterResult,
+  fakeVersion,
+  fakeVersionFile,
+  fakeVersionEntry,
+} from '../src/test-helpers';
+import { newLinterMessageUID, renderWithStoreAndRouter } from './utils';
+
+const render = ({
+  content = JS_SAMPLE,
+  messages = [],
+  store = configureStore(),
+}: {
+  store?: Store;
+  content?: string;
+  messages?: Partial<LinterMessage>[];
+} = {}) => {
+  let version = createInternalVersion(fakeVersion);
+
+  if (messages.length) {
+    const path = 'background.js';
+    version = createInternalVersion({
+      ...fakeVersion,
+      file: {
+        ...fakeVersionFile,
+        entries: { [path]: { ...fakeVersionEntry, path } },
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        selected_file: path,
+      },
+    });
+
+    const result = createFakeExternalLinterResult({
+      messages: messages.map((msg) => {
+        return { uid: newLinterMessageUID(), ...msg, file: path };
+      }),
+    });
+
+    store.dispatch(actions.loadLinterResult({ versionId: version.id, result }));
+  }
+
+  return renderWithStoreAndRouter(
+    <div className="CodeOverview-container">
+      <div>
+        <CodeView
+          content={content}
+          mimeType="application/javascript"
+          version={version}
+        />
+      </div>
+      <CodeOverview content={content} version={version} />
+    </div>,
+    store,
+  );
+};
+
+storiesOf('CodeOverview', module)
+  .add('short file', () => {
+    return render({ content: JS_SAMPLE });
+  })
+  .add('long file', () => {
+    return render({ content: longFileSample });
+  })
+  .add('long file with messages', () => {
+    return render({
+      content: longFileSample,
+      messages: [
+        {
+          line: 27,
+          type: 'warning',
+          message: 'Use of console.log() detected',
+          description: ['This call to console.log() is pretty much Okay.'],
+        },
+        {
+          line: 66,
+          type: 'notice',
+          message: 'Bizarre use of undefined',
+          description: ["...but I guess it's fine"],
+        },
+        {
+          line: 151,
+          type: 'error',
+          message: 'Use of queryTabs() is not permitted',
+          description: [
+            'Calls to queryTabs() will not work in a future version',
+          ],
+        },
+      ],
+    });
+  });

--- a/stories/CodeView.stories.tsx
+++ b/stories/CodeView.stories.tsx
@@ -16,7 +16,7 @@ import {
   fakeVersionFile,
 } from '../src/test-helpers';
 
-const JS = `/**
+export const JS_SAMPLE = `/**
  * There was an error executing the script.
  * Display the popup's error message, and hide the normal UI.
  */
@@ -51,7 +51,7 @@ const render = ({
   ...moreProps
 }: { store?: Store } & Partial<CodeViewProps> = {}) => {
   const props: CodeViewProps = {
-    content: JS,
+    content: JS_SAMPLE,
     mimeType: 'application/javascript',
     version: createInternalVersion(fakeVersion),
     ...moreProps,
@@ -86,7 +86,7 @@ const renderJSWithMessages = (
 
   return render({
     store,
-    content: JS,
+    content: JS_SAMPLE,
     mimeType: 'application/javascript',
     version,
     ...moreProps,
@@ -100,12 +100,15 @@ storiesOf('CodeView', module)
         sections: [
           {
             title: 'unsupported mime type',
-            sectionFn: () => render({ mimeType: '', content: JS }),
+            sectionFn: () => render({ mimeType: '', content: JS_SAMPLE }),
           },
           {
             title: 'application/javascript',
             sectionFn: () =>
-              render({ mimeType: 'application/javascript', content: JS }),
+              render({
+                mimeType: 'application/javascript',
+                content: JS_SAMPLE,
+              }),
           },
           {
             title: 'text/css',

--- a/stories/fixtures/long-file-sample.tsx
+++ b/stories/fixtures/long-file-sample.tsx
@@ -1,5 +1,4 @@
-export default `/* @flow */
-import type {BrowserTab} from './tab';
+export default `import type {BrowserTab} from './tab';
 
 export type TabListMessage = {|
   action: 'tabListChanged',

--- a/stories/fixtures/long-file-sample.tsx
+++ b/stories/fixtures/long-file-sample.tsx
@@ -1,0 +1,193 @@
+export default `/* @flow */
+import type {BrowserTab} from './tab';
+
+export type TabListMessage = {|
+  action: 'tabListChanged',
+  data: {tabs: Array<BrowserTab>},
+|};
+
+class Background {
+  tabList: Array<BrowserTab>;
+  visitedTabs: Array<BrowserTab>;
+  popupIsOpen: boolean;
+
+  constructor() {
+    this.visitedTabs = [];
+    this.tabList = [];
+    this.popupIsOpen = false;
+
+    chrome.tabs.onActivated.addListener(this.onActivated);
+    chrome.tabs.onUpdated.addListener(this.onTabsUpdated);
+    chrome.tabs.onRemoved.addListener(this.onTabRemoved);
+
+    chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+      if (!message.background) {
+        return;
+      }
+      console.log('Background: got message:', message);
+
+      let readMessage;
+      switch (message.action) {
+        case 'getTabs':
+          readMessage = this.getTabsForPopup();
+          break;
+        case 'openPopup':
+          readMessage = this.onPopupOpen();
+          break;
+        case 'closePopup':
+          readMessage = this.onPopupClose();
+          break;
+        default:
+          throw new Error(
+            \`Background got an unexpected action\`);
+      }
+
+      readMessage.then(reply => sendResponse(reply))
+        .catch(error => {
+          console.error('Background: error reading message', error);
+        });
+
+      return true;
+    });
+  }
+
+  onPopupOpen() {
+    this.popupIsOpen = true;
+    return Promise.resolve();
+  }
+
+  onPopupClose() {
+    this.popupIsOpen = false;
+    return Promise.resolve();
+  }
+
+  sendToPopup(message) {
+    return new Promise((resolve, reject) => {
+      const id = undefined;
+      const options = undefined;
+      chrome.runtime.sendMessage(
+        id,
+        {
+          popup: true,
+          ...message,
+        },
+        options,
+        (result) => {
+          if (chrome.runtime.lastError) {
+            console.log(
+              'background: got error:', chrome.runtime.lastError);
+            reject(chrome.runtime.lastError);
+          } else {
+            resolve(result);
+          }
+        }
+      );
+    });
+  }
+
+  onTabsUpdated = (tabId, changeInfo, tab) => {
+    console.log(\`background: Tab was updated\`, changeInfo);
+    this.visitedTabs = this.visitedTabs.map(
+      oldTab => oldTab.id === tab.id ? tab : oldTab);
+    this.tabList = this.tabList.map(
+      oldTab => oldTab.id === tab.id ? tab : oldTab);
+
+    if (this.popupIsOpen) {
+      const message: TabListMessage = {
+        action: 'tabListChanged',
+        data: {tabs: this.tabList},
+      };
+      this.sendToPopup(message);
+    }
+  }
+
+  onTabRemoved = (tabId) => {
+    console.log(\`background: Tab was removed\`);
+    this.visitedTabs = this.visitedTabs.filter(tab => tab.id !== tabId);
+    this.tabList = this.tabList.filter(tab => tab.id !== tabId);
+
+    if (this.popupIsOpen) {
+      this.sendToPopup({
+        action: 'tabListChanged',
+        data: {tabs: this.tabList},
+      });
+    }
+  }
+
+  onActivated = (activeInfo) => {
+    const {tabId} = activeInfo
+    this.getTab(tabId).then(tab => {
+      this.visitedTabs.unshift(tab);
+      if (this.visitedTabs.length > 2) {
+        this.visitedTabs.pop();
+      }
+      console.log(\`background: Active tab changed\`);
+    });
+  }
+
+  getTab(tabId) {
+    return new Promise((resolve, reject) => {
+      chrome.tabs.get(tabId, tab => {
+        if (chrome.runtime.lastError) {
+          return reject(chrome.runtime.lastError);
+        }
+        resolve(tab);
+      });
+    });
+  }
+
+  queryTabs(query) {
+    return new Promise((resolve, reject) => {
+      chrome.tabs.query(query, tabs => {
+        if (chrome.runtime.lastError) {
+          return reject(chrome.runtime.lastError);
+        }
+        resolve(tabs);
+      });
+    });
+  }
+
+  getTabsForPopup = () => {
+    return this.queryTabs({audible: true})
+      .then((audibleTabs) => {
+        const newTabList = [];
+        if (this.visitedTabs[1]) {
+          // Put the last viewed site at the top of the list so you
+          // can easily jump between what you're working on and what
+          // you're listening to.
+          newTabList.push(this.visitedTabs[1]);
+        }
+
+        function addUniqueTabs(tabList) {
+          const existingIds = new Set(newTabList.map(tab => tab.id));
+          tabList.forEach(tab => {
+            if (!existingIds.has(tab.id)) {
+              newTabList.push(tab);
+            }
+          });
+        }
+
+        addUniqueTabs(audibleTabs);
+        // Keep inaudible tabs around since the music may have just been paused
+        addUniqueTabs(this.tabList);
+
+        while (newTabList.length > 10) {
+          newTabList.pop();
+        }
+
+        this.tabList = newTabList;
+        return this.tabList;
+      })
+      .catch((error) => {
+        console.log('background: getTabsForPopup: error:', error);
+      });
+  }
+
+  listen() {
+    console.log('background: listening for info about audible websites');
+  }
+}
+
+const background = new Background();
+background.listen();
+`;

--- a/stories/setup/styles.scss
+++ b/stories/setup/styles.scss
@@ -71,3 +71,9 @@ body.fullscreen {
 .FullscreenGridStory-AltPanel {
   background-color: lighten(green, 68);
 }
+
+.CodeOverview-container {
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+  grid-gap: 10px;
+}


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/523
Fixes https://github.com/mozilla/addons-code-manager/issues/622
Fixes https://github.com/mozilla/addons-code-manager/issues/665

~~⚠️ depends on https://github.com/mozilla/addons-code-manager/pull/623~~

Storybook sample:

<img width="1019" alt="Screenshot 2019-04-23 10 36 15" src="https://user-images.githubusercontent.com/55398/56595227-e1999180-65b3-11e9-9e46-94d115168109.png">
