### PR TITLE
Fix infinite loops in compare page

### DIFF
--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -516,45 +516,22 @@ describe(__filename, () => {
     });
   });
 
-  // This could happen when a keyboard navigation updates the selected path.
-  it('does not dispatch viewVersionFile() on update if the query string contains a `path` that is different than `version.selectedPath`', () => {
-    const { dispatchSpy, root } = loadDiffAndRender();
+  it('does not dispatch anything on mount when an API error has occured', () => {
+    const addonId = 9999;
+    const baseVersionId = 1;
+    const headVersionId = baseVersionId + 1;
 
-    const path = 'a/different/file.js';
-    const history = createFakeHistory({
-      location: createFakeLocation({
-        search: queryString.stringify({ path }),
-      }),
+    const store = configureStore();
+    store.dispatch(versionsActions.beginFetchDiff());
+    // Simulate an API error.
+    store.dispatch(versionsActions.abortFetchDiff());
+    const dispatch = spyOn(store, 'dispatch');
+
+    render({
+      ...getRouteParams({ addonId, baseVersionId, headVersionId }),
+      store,
     });
 
-    root.setProps({ history });
-
-    expect(dispatchSpy).not.toHaveBeenCalled();
-  });
-
-  it('does not dispatch viewVersionFile() on update when `path` is equal to the selected path', () => {
-    const { dispatchSpy, root, version } = loadDiffAndRender();
-
-    const history = createFakeHistory({
-      location: createFakeLocation({
-        search: queryString.stringify({ path: version.file.selected_file }),
-      }),
-    });
-
-    root.setProps({ history });
-
-    expect(dispatchSpy).not.toHaveBeenCalled();
-  });
-
-  it('does not dispatch viewVersionFile() on update when the query string does not contain a `path`', () => {
-    const { dispatchSpy, root } = loadDiffAndRender();
-
-    const history = createFakeHistory({
-      location: createFakeLocation({ search: '' }),
-    });
-
-    root.setProps({ history });
-
-    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -24,7 +24,7 @@ import Loading from '../../components/Loading';
 import VersionChooser from '../../components/VersionChooser';
 import styles from './styles.module.scss';
 
-import Compare, { CompareBase, PublicProps } from '.';
+import Compare, { CompareBase, PublicProps, mapStateToProps } from '.';
 
 describe(__filename, () => {
   type GetRouteParamsParams = {
@@ -350,7 +350,7 @@ describe(__filename, () => {
     expect(dispatchSpy).not.toHaveBeenCalled();
   });
 
-  it('dispatches fetchDiff() on update if compareInfo is undefined', () => {
+  it('dispatches fetchDiff() on update when baseVersionId changes', () => {
     const {
       _fetchDiff,
       addonId,
@@ -359,16 +359,147 @@ describe(__filename, () => {
       fakeThunk,
       headVersionId,
       root,
+      store,
     } = loadDiffAndRender();
 
-    root.setProps({ compareInfo: undefined });
+    const newBaseVersionId = baseVersionId + 1;
+    const routerProps = {
+      ...createFakeRouteComponentProps({
+        params: getRouteParams({
+          addonId,
+          baseVersionId: newBaseVersionId,
+          headVersionId,
+        }),
+      }),
+    };
+
+    root.setProps({
+      ...routerProps,
+      ...mapStateToProps(store.getState(), {
+        ...root.instance().props,
+        ...routerProps,
+      }),
+    });
 
     expect(dispatchSpy).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(_fetchDiff).toHaveBeenCalledWith({
+    expect(_fetchDiff).toHaveBeenCalledWith(
+      expect.objectContaining({ baseVersionId: newBaseVersionId }),
+    );
+  });
+
+  it('dispatches fetchDiff() on update when headVersionId changes', () => {
+    const {
+      _fetchDiff,
       addonId,
       baseVersionId,
+      dispatchSpy,
+      fakeThunk,
       headVersionId,
+      root,
+      store,
+    } = loadDiffAndRender();
+
+    const newHeadVersionId = headVersionId + 1;
+    const routerProps = {
+      ...createFakeRouteComponentProps({
+        params: getRouteParams({
+          addonId,
+          baseVersionId,
+          headVersionId: newHeadVersionId,
+        }),
+      }),
+    };
+
+    root.setProps({
+      ...routerProps,
+      ...mapStateToProps(store.getState(), {
+        ...root.instance().props,
+        ...routerProps,
+      }),
     });
+
+    expect(dispatchSpy).toHaveBeenCalledWith(fakeThunk.thunk);
+    expect(_fetchDiff).toHaveBeenCalledWith(
+      expect.objectContaining({ headVersionId: newHeadVersionId }),
+    );
+  });
+
+  it('dispatches fetchDiff() on update when addonId changes', () => {
+    const {
+      _fetchDiff,
+      addonId,
+      baseVersionId,
+      dispatchSpy,
+      fakeThunk,
+      headVersionId,
+      root,
+      store,
+    } = loadDiffAndRender();
+
+    const newAddonId = addonId + 1;
+    const routerProps = {
+      ...createFakeRouteComponentProps({
+        params: getRouteParams({
+          addonId: newAddonId,
+          baseVersionId,
+          headVersionId,
+        }),
+      }),
+    };
+
+    root.setProps({
+      ...routerProps,
+      ...mapStateToProps(store.getState(), {
+        ...root.instance().props,
+        ...routerProps,
+      }),
+    });
+
+    expect(dispatchSpy).toHaveBeenCalledWith(fakeThunk.thunk);
+    expect(_fetchDiff).toHaveBeenCalledWith(
+      expect.objectContaining({ addonId: newAddonId }),
+    );
+  });
+
+  it('dispatches fetchDiff() on update when path changes', () => {
+    const {
+      _fetchDiff,
+      addonId,
+      baseVersionId,
+      dispatchSpy,
+      fakeThunk,
+      headVersionId,
+      root,
+      store,
+    } = loadDiffAndRender();
+
+    const path = 'some-new-path';
+    const history = createFakeHistory({
+      location: createFakeLocation({
+        search: queryString.stringify({ path }),
+      }),
+    });
+    const routerProps = {
+      ...createFakeRouteComponentProps({
+        history,
+        params: getRouteParams({
+          addonId,
+          baseVersionId,
+          headVersionId,
+        }),
+      }),
+    };
+
+    root.setProps({
+      ...routerProps,
+      ...mapStateToProps(store.getState(), {
+        ...root.instance().props,
+        ...routerProps,
+      }),
+    });
+
+    expect(dispatchSpy).toHaveBeenCalledWith(fakeThunk.thunk);
+    expect(_fetchDiff).toHaveBeenCalledWith(expect.objectContaining({ path }));
   });
 
   it('dispatches viewVersionFile() when a file is selected', () => {

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -256,10 +256,34 @@ describe(__filename, () => {
   });
 
   it('renders an error when fetching a diff has failed', () => {
-    const store = configureStore();
-    store.dispatch(versionsActions.abortFetchDiff());
+    const addonId = 9999;
+    const baseVersionId = 1;
+    const headVersionId = baseVersionId + 1;
 
-    const root = render({ store });
+    const store = configureStore();
+    store.dispatch(
+      versionsActions.beginFetchDiff({
+        addonId,
+        baseVersionId,
+        headVersionId,
+      }),
+    );
+    store.dispatch(
+      versionsActions.abortFetchDiff({
+        addonId,
+        baseVersionId,
+        headVersionId,
+      }),
+    );
+
+    const root = render({
+      ...getRouteParams({
+        addonId,
+        baseVersionId,
+        headVersionId,
+      }),
+      store,
+    });
 
     expect(
       getContentShellPanel(root, 'mainSidePanel').find(`.${styles.error}`),
@@ -318,15 +342,15 @@ describe(__filename, () => {
     expect(dispatch).not.toHaveBeenCalled();
   });
 
-  it('does not dispatch fetchDiff() on update if no URL parameter has changed', () => {
-    const { dispatchSpy, root, params } = loadDiffAndRender();
+  it('does not dispatch anything on update if nothing has changed', () => {
+    const { dispatchSpy, root } = loadDiffAndRender();
 
-    root.setProps({ match: { params } });
+    root.setProps({});
 
     expect(dispatchSpy).not.toHaveBeenCalled();
   });
 
-  it('dispatches fetchDiff() on update if base version is different', () => {
+  it('dispatches fetchDiff() on update if compareInfo is undefined', () => {
     const {
       _fetchDiff,
       addonId,
@@ -335,90 +359,15 @@ describe(__filename, () => {
       fakeThunk,
       headVersionId,
       root,
-      version,
     } = loadDiffAndRender();
 
-    const newBaseVersionId = baseVersionId - 1;
-    root.setProps({
-      match: {
-        params: getRouteParams({
-          addonId,
-          baseVersionId: newBaseVersionId,
-          headVersionId,
-        }),
-      },
-    });
-
-    expect(dispatchSpy).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(_fetchDiff).toHaveBeenCalledWith({
-      addonId,
-      baseVersionId: newBaseVersionId,
-      headVersionId,
-      path: version.file.selected_file,
-    });
-  });
-
-  it('dispatches fetchDiff() on update if head version is different', () => {
-    const {
-      _fetchDiff,
-      addonId,
-      baseVersionId,
-      dispatchSpy,
-      fakeThunk,
-      headVersionId,
-      root,
-      version,
-    } = loadDiffAndRender();
-
-    const newHeadVersionId = headVersionId + 1;
-    root.setProps({
-      match: {
-        params: getRouteParams({
-          addonId,
-          baseVersionId,
-          headVersionId: newHeadVersionId,
-        }),
-      },
-    });
+    root.setProps({ compareInfo: undefined });
 
     expect(dispatchSpy).toHaveBeenCalledWith(fakeThunk.thunk);
     expect(_fetchDiff).toHaveBeenCalledWith({
       addonId,
       baseVersionId,
-      headVersionId: newHeadVersionId,
-      path: version.file.selected_file,
-    });
-  });
-
-  it('dispatches fetchDiff() on update if addon ID is different', () => {
-    const {
-      _fetchDiff,
-      addonId,
-      baseVersionId,
-      dispatchSpy,
-      fakeThunk,
       headVersionId,
-      root,
-      version,
-    } = loadDiffAndRender();
-
-    const newAddonId = addonId + 1;
-    root.setProps({
-      match: {
-        params: getRouteParams({
-          addonId: newAddonId,
-          baseVersionId,
-          headVersionId,
-        }),
-      },
-    });
-
-    expect(dispatchSpy).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(_fetchDiff).toHaveBeenCalledWith({
-      addonId: newAddonId,
-      baseVersionId,
-      headVersionId,
-      path: version.file.selected_file,
     });
   });
 
@@ -522,9 +471,21 @@ describe(__filename, () => {
     const headVersionId = baseVersionId + 1;
 
     const store = configureStore();
-    store.dispatch(versionsActions.beginFetchDiff());
+    store.dispatch(
+      versionsActions.beginFetchDiff({
+        addonId,
+        baseVersionId,
+        headVersionId,
+      }),
+    );
     // Simulate an API error.
-    store.dispatch(versionsActions.abortFetchDiff());
+    store.dispatch(
+      versionsActions.abortFetchDiff({
+        addonId,
+        baseVersionId,
+        headVersionId,
+      }),
+    );
     const dispatch = spyOn(store, 'dispatch');
 
     render({

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -484,42 +484,6 @@ describe(__filename, () => {
     expect(dispatchSpy).not.toHaveBeenCalled();
   });
 
-  it('dispatches viewVersionFile() on mount if the query string contains a `path` that is different than `version.selectedPath`', () => {
-    const path = 'a/different/file.js';
-    const history = createFakeHistory({
-      location: createFakeLocation({
-        search: queryString.stringify({ path }),
-      }),
-    });
-    const {
-      _viewVersionFile,
-      dispatchSpy,
-      fakeThunk,
-      version,
-    } = loadDiffAndRender({ history });
-
-    expect(dispatchSpy).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(dispatchSpy).toHaveBeenCalledTimes(1);
-    expect(_viewVersionFile).toHaveBeenCalledWith({
-      versionId: version.id,
-      selectedPath: path,
-      preserveHash: true,
-    });
-  });
-
-  it('does not dispatch viewVersionFile() on mount when `path` is equal to the selected path', () => {
-    const version = fakeVersionWithDiff;
-    const history = createFakeHistory({
-      location: createFakeLocation({
-        search: queryString.stringify({ path: version.file.selected_file }),
-      }),
-    });
-
-    const { dispatchSpy } = loadDiffAndRender({ history });
-
-    expect(dispatchSpy).not.toHaveBeenCalled();
-  });
-
   it('dispatches fetchDiff() with the path specified in the URL on mount', () => {
     const addonId = 9999;
     const baseVersionId = 1;

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -75,7 +75,12 @@ export class CompareBase extends React.Component<Props> {
 
     const path = getPathFromQueryString(history);
 
-    if (!version) {
+    if (version === null) {
+      // An error has occured when fetching the version.
+      return;
+    }
+
+    if (version === undefined) {
       dispatch(
         _fetchDiff({
           addonId: parseInt(addonId, 10),
@@ -87,18 +92,14 @@ export class CompareBase extends React.Component<Props> {
       return;
     }
 
-    // We do not want to update the selected path again (e.g., when a keyboard
-    // navigation updates the selected path), so we apply this logic to the
-    // first render (mount) only.
     if (!prevProps) {
-      if (path && path !== version.selectedPath) {
-        // We preserve the hash in the URL (if any) when we load the file from
-        // an URL that has likely be shared.
-        this.viewVersionFile(path, { preserveHash: true });
-      }
-    } else if (
-      (prevProps.version &&
-        version.selectedPath !== prevProps.version.selectedPath) ||
+      return;
+    }
+
+    if (
+      (prevProps &&
+        (prevProps.version &&
+          version.selectedPath !== prevProps.version.selectedPath)) ||
       addonId !== prevProps.match.params.addonId ||
       baseVersionId !== prevProps.match.params.baseVersionId ||
       headVersionId !== prevProps.match.params.headVersionId

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -155,7 +155,7 @@ export class CompareBase extends React.Component<Props> {
   }
 }
 
-const mapStateToProps = (
+export const mapStateToProps = (
   state: ApplicationState,
   ownProps: RouteComponentProps<PropsFromRouter>,
 ): PropsFromState => {

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -386,13 +386,21 @@ describe(__filename, () => {
       expect(state.byAddonId[addonId]).toEqual(createVersionsMap(versions));
     });
 
-    it('sets the compare info to `null` nd the loading flag to `false` on abortFetchDiff()', () => {
+    it('sets the compare info to `null` and the loading flag to `false` on abortFetchDiff()', () => {
       const addonId = 1;
       const baseVersionId = 2;
       const headVersionId = 2;
 
-      const versionsState = reducer(
+      let versionsState = reducer(
         undefined,
+        actions.beginFetchDiff({
+          addonId,
+          baseVersionId,
+          headVersionId,
+        }),
+      );
+      versionsState = reducer(
+        versionsState,
         actions.abortFetchDiff({
           addonId,
           baseVersionId,
@@ -1447,7 +1455,11 @@ describe(__filename, () => {
       const baseVersionId = 2;
       const headVersionId = 3;
 
-      const { dispatch, thunk } = _fetchDiff();
+      const { dispatch, thunk } = _fetchDiff({
+        addonId,
+        baseVersionId,
+        headVersionId,
+      });
       await thunk();
 
       expect(dispatch).toHaveBeenCalledWith(
@@ -1513,7 +1525,12 @@ describe(__filename, () => {
       const baseVersionId = 2;
       const headVersionId = version.id;
 
-      const { dispatch, thunk } = _fetchDiff({ version });
+      const { dispatch, thunk } = _fetchDiff({
+        addonId,
+        baseVersionId,
+        headVersionId,
+        version,
+      });
       await thunk();
 
       expect(dispatch).toHaveBeenCalledWith(
@@ -1558,7 +1575,11 @@ describe(__filename, () => {
       const baseVersionId = 2;
       const headVersionId = 3;
 
-      const { dispatch, thunk, store } = _fetchDiff();
+      const { dispatch, thunk, store } = _fetchDiff({
+        addonId,
+        baseVersionId,
+        headVersionId,
+      });
       // This simulates another previous call to `fetchDiff()`.
       store.dispatch(
         actions.beginFetchDiff({ addonId, baseVersionId, headVersionId }),
@@ -2167,6 +2188,24 @@ describe(__filename, () => {
           headVersionId,
         ),
       ).toEqual(false);
+    });
+
+    it('returns true when loading compare info', () => {
+      const addonId = 123;
+      const baseVersionId = 1;
+      const headVersionId = 2;
+      const state = reducer(
+        undefined,
+        actions.beginFetchDiff({
+          addonId,
+          baseVersionId,
+          headVersionId,
+        }),
+      );
+
+      expect(
+        isCompareInfoLoading(state, addonId, baseVersionId, headVersionId),
+      ).toEqual(true);
     });
   });
 });

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -751,7 +751,7 @@ export const fetchDiff = ({
         path,
       )
     ) {
-      log.debug('Aborting because diff is already being fetched');
+      log.debug('Aborting because the diff is already being fetched');
       return;
     }
 

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -684,8 +684,8 @@ export const fetchDiff = ({
     });
 
     if (isErrorResponse(response)) {
-      dispatch(errorsActions.addError({ error: response.error }));
       dispatch(actions.abortFetchDiff());
+      dispatch(errorsActions.addError({ error: response.error }));
     } else {
       if (!getVersionInfo(versionsState, response.id)) {
         dispatch(actions.loadVersionInfo({ version: response }));


### PR DESCRIPTION
Fixes #638
Fixes #628 

---

While the code looked nice and the test suite was covering all the branches, it appears that most of the code was not needed because loading a file from the URL is done by `fetchDiff`, which takes an optional `path`. Given that there is no URL update triggered by our code, the URL stayed the same and everything just worked as intended. This was nice but complicated and not needed, so I removed it.

The fix for the infinite loop is mostly in `src/reducers/versions.tsx`. Because we load a file, we should abort this action too in case of an error. This allows the `loadData()` method to check the status of the `version` prop.

I added some commits to fix #628 too. I believe it works (i.e. I cannot trigger an infinite loop) but the UI sometimes lags. I covered the following scenarios:

- loading an URL with a path in the query string, http://localhost:3000/en-US/compare/502955/versions/1541794...1541798/?path=META-INF%2Fmanifest.mf
- loading an URL with a path in the query string and a hash (for the line), http://localhost:3000/en-US/compare/502955/versions/1541794...1541798/?path=META-INF%2Fmanifest.mf#I55
- loading a default compare page, http://localhost:3000/en-US/compare/502955/versions/1541794...1541798/
- loading a compare page and hitting `j` twice to end up in a file with some content, http://localhost:3000/en-US/compare/502955/versions/1541794...1541798/?path=META-INF%2Fcose.manifest

~~I think protecting the thunk with a loading flag would help.~~ I've done that in the last commit.