### PR TITLE
Fix regression in Browse component

### DIFF
--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -419,112 +419,6 @@ describe(__filename, () => {
     expect(dispatch).not.toHaveBeenCalled();
   });
 
-  it('dispatches viewVersionFile on mount if the query string contains a `path` that is different than `version.selectedPath`', () => {
-    const path = 'a/different/file.js';
-    const version = fakeVersion;
-    const history = createFakeHistory({
-      location: createFakeLocation({
-        search: queryString.stringify({ path }),
-      }),
-    });
-    const store = configureStore();
-    _loadVersionAndFile({ store, version });
-    const dispatch = spyOn(store, 'dispatch');
-
-    const fakeThunk = createFakeThunk();
-    const _viewVersionFile = fakeThunk.createThunk;
-
-    render({
-      _viewVersionFile,
-      history,
-      store,
-      versionId: String(version.id),
-    });
-
-    expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(dispatch).toHaveBeenCalledTimes(1);
-    expect(_viewVersionFile).toHaveBeenCalledWith({
-      versionId: version.id,
-      selectedPath: path,
-      preserveHash: true,
-    });
-  });
-
-  it('does not dispatch viewVersionFile on mount when `path` is equal to the selected path', () => {
-    const version = fakeVersion;
-    const history = createFakeHistory({
-      location: createFakeLocation({
-        search: queryString.stringify({ path: version.file.selected_file }),
-      }),
-    });
-    const store = configureStore();
-    _loadVersionAndFile({ store, version });
-    const dispatch = spyOn(store, 'dispatch');
-
-    render({ store, versionId: String(version.id), history });
-
-    expect(dispatch).not.toHaveBeenCalled();
-  });
-
-  it('does not dispatch viewVersionFile on mount when the query string does not contain a `path`', () => {
-    const version = fakeVersion;
-    const history = createFakeHistory({
-      location: createFakeLocation({ search: '' }),
-    });
-    const store = configureStore();
-    _loadVersionAndFile({ store, version });
-    const dispatch = spyOn(store, 'dispatch');
-
-    render({ store, versionId: String(version.id), history });
-
-    expect(dispatch).not.toHaveBeenCalled();
-  });
-
-  // This could happen when a keyboard navigation updates the selected path.
-  it('does not dispatch viewVersionFile on update if the query string contains a `path` that is different than `version.selectedPath`', () => {
-    const { renderAndUpdate } = setUpVersionFileUpdate({
-      loadVersionAndFile: true,
-    });
-    const path = 'a/different/file.js';
-    const history = createFakeHistory({
-      location: createFakeLocation({
-        search: queryString.stringify({ path }),
-      }),
-    });
-
-    const { dispatchSpy } = renderAndUpdate({ history });
-
-    expect(dispatchSpy).not.toHaveBeenCalled();
-  });
-
-  it('does not dispatch viewVersionFile on update if the query string does not contain a `path`', () => {
-    const { renderAndUpdate } = setUpVersionFileUpdate({
-      loadVersionAndFile: true,
-    });
-    const history = createFakeHistory({
-      location: createFakeLocation({ search: '' }),
-    });
-
-    const { dispatchSpy } = renderAndUpdate({ history });
-
-    expect(dispatchSpy).not.toHaveBeenCalled();
-  });
-
-  it('does not dispatch viewVersionFile on update if `path` is equal to the selected path', () => {
-    const { renderAndUpdate, version } = setUpVersionFileUpdate({
-      loadVersionAndFile: true,
-    });
-    const history = createFakeHistory({
-      location: createFakeLocation({
-        search: queryString.stringify({ path: version.file.selected_file }),
-      }),
-    });
-
-    const { dispatchSpy } = renderAndUpdate({ history });
-
-    expect(dispatchSpy).not.toHaveBeenCalled();
-  });
-
   it('does not dispatch anything on mount when an API error has occured', () => {
     const versionId = 4321;
     const store = configureStore();
@@ -550,5 +444,31 @@ describe(__filename, () => {
     root.setProps({ version: null });
 
     expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('passes the path contained in the URL to fetchVersion()', () => {
+    const addonId = 9876;
+    const versionId = 4321;
+    const path = 'background.js';
+    const history = createFakeHistory({
+      location: createFakeLocation({ search: queryString.stringify({ path }) }),
+    });
+
+    const store = configureStore();
+    const dispatch = spyOn(store, 'dispatch');
+
+    const fakeThunk = createFakeThunk();
+    const _fetchVersion = fakeThunk.createThunk;
+
+    render({
+      _fetchVersion,
+      addonId: String(addonId),
+      history,
+      store,
+      versionId: String(versionId),
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
+    expect(_fetchVersion).toHaveBeenCalledWith({ addonId, versionId, path });
   });
 });

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -118,6 +118,8 @@ export class BrowseBase extends React.Component<Props> {
       _viewVersionFile({
         versionId: parseInt(versionId, 10),
         selectedPath: path,
+        // When selecting a new file to view, we do not want to preserve the
+        // hash in the URL (this hash highlights a specific line of code).
         preserveHash: false,
       }),
     );

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -63,11 +63,11 @@ export class BrowseBase extends React.Component<Props> {
     this.loadData();
   }
 
-  componentDidUpdate(prevProps: Props) {
-    this.loadData(prevProps);
+  componentDidUpdate() {
+    this.loadData();
   }
 
-  loadData(prevProps?: Props) {
+  loadData() {
     const {
       _fetchVersion,
       _fetchVersionFile,
@@ -78,6 +78,8 @@ export class BrowseBase extends React.Component<Props> {
       match,
       version,
     } = this.props;
+
+    const path = getPathFromQueryString(history);
 
     if (version === null) {
       // An error has occured when fetching the version.
@@ -91,20 +93,9 @@ export class BrowseBase extends React.Component<Props> {
         _fetchVersion({
           addonId: parseInt(addonId, 10),
           versionId: parseInt(versionId, 10),
+          path: path || undefined,
         }),
       );
-      return;
-    }
-
-    const path = getPathFromQueryString(history);
-
-    // We do not want to update the selected path again (e.g., when a keyboard
-    // navigation updates the selected path), so we apply this logic to the
-    // first render (mount) only.
-    if (!prevProps && path && path !== version.selectedPath) {
-      // We preserve the hash in the URL (if any) when we load the file from an
-      // URL that has likely been shared.
-      this.viewVersionFile(path, { preserveHash: true });
       return;
     }
 
@@ -119,9 +110,7 @@ export class BrowseBase extends React.Component<Props> {
     }
   }
 
-  // When selecting a new file to view, we do not want to preserve the hash in
-  // the URL (this hash highlights a specific line of code).
-  viewVersionFile = (path: string, { preserveHash = false } = {}) => {
+  viewVersionFile = (path: string) => {
     const { _viewVersionFile, dispatch, match } = this.props;
     const { versionId } = match.params;
 
@@ -129,7 +118,7 @@ export class BrowseBase extends React.Component<Props> {
       _viewVersionFile({
         versionId: parseInt(versionId, 10),
         selectedPath: path,
-        preserveHash,
+        preserveHash: false,
       }),
     );
   };

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -737,6 +737,20 @@ describe(__filename, () => {
   });
 
   describe('fetchVersion', () => {
+    const _fetchVersion = ({
+      addonId = 123,
+      version = fakeVersion,
+      _getVersion = jest.fn().mockReturnValue(Promise.resolve(version)),
+      path = undefined as string | undefined,
+    } = {}) => {
+      return fetchVersion({
+        _getVersion,
+        addonId,
+        path,
+        versionId: version.id,
+      });
+    };
+
     it('dispatches beginFetchVersionFile', async () => {
       const version = fakeVersion;
       const _getVersion = jest.fn().mockReturnValue(Promise.resolve(version));
@@ -780,26 +794,22 @@ describe(__filename, () => {
     });
 
     it('calls getVersion with a given path', async () => {
-      const version = fakeVersion;
+      const _getVersion = jest
+        .fn()
+        .mockReturnValue(Promise.resolve(fakeVersion));
       const path = 'some/file.js';
-      const _getVersion = jest.fn().mockReturnValue(Promise.resolve(version));
 
-      const addonId = 123;
-      const versionId = version.id;
-
-      const { store, thunk } = thunkTester({
-        createThunk: () =>
-          fetchVersion({ _getVersion, addonId, versionId, path }),
+      const { thunk } = thunkTester({
+        createThunk: () => _fetchVersion({ _getVersion, path }),
       });
 
       await thunk();
 
-      expect(_getVersion).toHaveBeenCalledWith({
-        addonId,
-        apiState: store.getState().api,
-        path,
-        versionId,
-      });
+      expect(_getVersion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path,
+        }),
+      );
     });
 
     it('dispatches loadVersionInfo() when API response is successful', async () => {

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -779,6 +779,29 @@ describe(__filename, () => {
       });
     });
 
+    it('calls getVersion with a given path', async () => {
+      const version = fakeVersion;
+      const path = 'some/file.js';
+      const _getVersion = jest.fn().mockReturnValue(Promise.resolve(version));
+
+      const addonId = 123;
+      const versionId = version.id;
+
+      const { store, thunk } = thunkTester({
+        createThunk: () =>
+          fetchVersion({ _getVersion, addonId, versionId, path }),
+      });
+
+      await thunk();
+
+      expect(_getVersion).toHaveBeenCalledWith({
+        addonId,
+        apiState: store.getState().api,
+        path,
+        versionId,
+      });
+    });
+
     it('dispatches loadVersionInfo() when API response is successful', async () => {
       const version = fakeVersion;
       const _getVersion = jest.fn().mockReturnValue(Promise.resolve(version));

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -427,12 +427,14 @@ type FetchVersionParams = {
   _getVersion?: typeof getVersion;
   addonId: number;
   versionId: number;
+  path?: string;
 };
 
 export const fetchVersion = ({
   _getVersion = getVersion,
   addonId,
   versionId,
+  path,
 }: FetchVersionParams): ThunkActionCreator => {
   return async (dispatch, getState) => {
     const { api: apiState } = getState();
@@ -442,6 +444,7 @@ export const fetchVersion = ({
     const response = await _getVersion({
       addonId,
       apiState,
+      path,
       versionId,
     });
 


### PR DESCRIPTION
Fixes #626

---

A regression has been recently merged, breaking the `Browse` component when loading a file from the URL. The regression was supposed to fix an issue but introduced a new one. This patch should solve all the known issues:

- it brings the feature back
- it avoids the issue related to too many actions dispatched when updating the selected path
- it prevents the component to enter an infinite loop in case of an error