### PR TITLE
View an image file

### DIFF
--- a/src/components/ImageView/index.spec.tsx
+++ b/src/components/ImageView/index.spec.tsx
@@ -36,36 +36,15 @@ describe(__filename, () => {
     );
   });
 
-  it('does not render an img tag when btoa fails', () => {
+  it('throws an error when btoa fails', () => {
+    const message = 'An error message';
     const _btoa = jest.fn().mockImplementation(() => {
-      throw new Error();
+      throw new Error(message);
     });
 
-    const root = render({ _btoa });
-
-    expect(root.find('img')).toHaveLength(0);
-  });
-
-  it('renders a message when btoa fails', () => {
-    const _btoa = jest.fn().mockImplementation(() => {
-      throw new Error();
-    });
-
-    const root = render({ _btoa });
-
-    expect(root.find('p')).toHaveText('Unrecognized image format');
-  });
-
-  it('logs an error message when btoa fails', () => {
-    const _btoa = jest.fn().mockImplementation(() => {
-      throw new Error();
-    });
-    const _log = createFakeLogger();
-
-    render({ _btoa, _log });
-
-    expect(_btoa).toHaveBeenCalled();
-    expect(_log.error).toHaveBeenCalled();
+    expect(() => {
+      render({ _btoa });
+    }).toThrow(message);
   });
 
   it('logs an error message if an image has an invalid mimeType', () => {

--- a/src/components/ImageView/index.spec.tsx
+++ b/src/components/ImageView/index.spec.tsx
@@ -46,6 +46,16 @@ describe(__filename, () => {
     expect(root.find('img')).toHaveLength(0);
   });
 
+  it('renders a message when btoa fails', () => {
+    const _btoa = jest.fn().mockImplementation(() => {
+      throw new Error();
+    });
+
+    const root = render({ _btoa });
+
+    expect(root.find('p')).toHaveText('Unrecognized image format');
+  });
+
   it('logs an error message when btoa fails', () => {
     const _btoa = jest.fn().mockImplementation(() => {
       throw new Error();
@@ -58,10 +68,18 @@ describe(__filename, () => {
     expect(_log.error).toHaveBeenCalled();
   });
 
-  it('throws an error if an image has an invalid mimeType', () => {
-    expect(() => {
-      render({ mimeType: 'invalid/type' });
-    }).toThrow('Unexpected mimeType: "invalid/type"');
+  it('logs an error message if an image has an invalid mimeType', () => {
+    const _log = createFakeLogger();
+
+    render({ _log, mimeType: 'invalid/type' });
+
+    expect(_log.error).toHaveBeenCalled();
+  });
+
+  it('renders a message if an image has an invalid mimeType', () => {
+    const root = render({ mimeType: 'invalid/type' });
+
+    expect(root.find('p')).toHaveText('Unrecognized image format');
   });
 
   it('calls sanitize on svg files', () => {

--- a/src/components/ImageView/index.spec.tsx
+++ b/src/components/ImageView/index.spec.tsx
@@ -9,6 +9,7 @@ describe(__filename, () => {
   const render = ({
     _btoa = btoa,
     _log = createFakeLogger(),
+    _sanitize = jest.fn(),
     content = 'some image content',
     mimeType = 'mime/type',
   } = {}) => {
@@ -16,6 +17,7 @@ describe(__filename, () => {
       <ImageView
         _btoa={_btoa}
         _log={_log}
+        _sanitize={_sanitize}
         mimeType={mimeType}
         content={content}
       />,
@@ -54,5 +56,23 @@ describe(__filename, () => {
 
     expect(_btoa).toHaveBeenCalled();
     expect(_log.debug).toHaveBeenCalled();
+  });
+
+  it('calls sanitize on svg files', () => {
+    const _sanitize = jest.fn();
+    const content = 'some content';
+    const mimeType = 'image/svg+xml';
+    render({ _sanitize, content, mimeType });
+
+    expect(_sanitize).toHaveBeenCalledWith(content);
+  });
+
+  it('does not call sanitize on non-svg files', () => {
+    const _sanitize = jest.fn();
+    const content = 'some content';
+    const mimeType = 'image/png';
+    render({ _sanitize, content, mimeType });
+
+    expect(_sanitize).not.toHaveBeenCalled();
   });
 });

--- a/src/components/ImageView/index.spec.tsx
+++ b/src/components/ImageView/index.spec.tsx
@@ -36,25 +36,6 @@ describe(__filename, () => {
     );
   });
 
-  it('throws an error when btoa fails', () => {
-    const message = 'An error message';
-    const _btoa = jest.fn().mockImplementation(() => {
-      throw new Error(message);
-    });
-
-    expect(() => {
-      render({ _btoa });
-    }).toThrow(message);
-  });
-
-  it('logs an error message if an image has an invalid mimeType', () => {
-    const _log = createFakeLogger();
-
-    render({ _log, mimeType: 'invalid/type' });
-
-    expect(_log.error).toHaveBeenCalled();
-  });
-
   it('renders a message if an image has an invalid mimeType', () => {
     const root = render({ mimeType: 'invalid/type' });
 
@@ -93,8 +74,8 @@ describe(__filename, () => {
       <svg version="1.1">
         <circle fill="red" />
         <script>alert('XSS via SVG')</script>
-        </svg>
-      `;
+      </svg>
+    `;
     const root = render({ content, mimeType: 'image/svg+xml' });
 
     const img: ShallowWrapper = root.find('img');

--- a/src/components/ImageView/index.tsx
+++ b/src/components/ImageView/index.tsx
@@ -47,15 +47,10 @@ const convertImageData = ({
     return null;
   }
 
-  try {
-    return _btoa(
-      // Run sanitize on svg files.
-      mimeTypeCased === 'image/svg+xml' ? _sanitize(content) : content,
-    );
-  } catch (error) {
-    _log.error('Error converting image data to ascii:', error);
-    return null;
-  }
+  return _btoa(
+    // Run sanitize on svg files.
+    mimeTypeCased === 'image/svg+xml' ? _sanitize(content) : content,
+  );
 };
 
 const ImageViewBase = ({

--- a/src/components/ImageView/index.tsx
+++ b/src/components/ImageView/index.tsx
@@ -1,3 +1,4 @@
+import purify from 'dompurify';
 import log from 'loglevel';
 import * as React from 'react';
 
@@ -6,6 +7,7 @@ import styles from './styles.module.scss';
 type PublicProps = {
   _btoa?: typeof btoa;
   _log?: typeof log;
+  _sanitize?: typeof purify.sanitize;
   mimeType: string;
   content: string;
 };
@@ -13,24 +15,43 @@ type PublicProps = {
 type ConvertImageDataParams = {
   _btoa?: typeof btoa;
   _log?: typeof log;
+  _sanitize?: typeof purify.sanitize;
   content: string;
+  mimeType: string;
 };
 
-export const convertImageData = ({
+const convertImageData = ({
   _btoa = btoa,
   _log = log,
+  _sanitize = purify.sanitize,
   content,
+  mimeType,
 }: ConvertImageDataParams): string | null => {
   try {
-    return _btoa(content);
+    return _btoa(
+      // Run sanitize on svg files.
+      mimeType === 'image/svg+xml' ? _sanitize(content) : content,
+    );
   } catch (error) {
     _log.debug('Error converting image data to ascii:', error);
     return null;
   }
 };
 
-const ImageViewBase = ({ _btoa, _log, content, mimeType }: PublicProps) => {
-  const imageData = convertImageData({ _btoa, _log, content });
+const ImageViewBase = ({
+  _btoa,
+  _log,
+  _sanitize,
+  content,
+  mimeType,
+}: PublicProps) => {
+  const imageData = convertImageData({
+    _btoa,
+    _log,
+    _sanitize,
+    content,
+    mimeType,
+  });
   return imageData ? (
     <div className={styles.ImageView}>
       <img alt="" src={`data:${mimeType};base64,${imageData}`} />

--- a/src/components/ImageView/index.tsx
+++ b/src/components/ImageView/index.tsx
@@ -5,14 +5,6 @@ import * as React from 'react';
 import { gettext } from '../../utils';
 import styles from './styles.module.scss';
 
-export type PublicProps = {
-  _btoa?: typeof btoa;
-  _log?: typeof log;
-  _sanitize?: typeof purify.sanitize;
-  mimeType: string;
-  content: string;
-};
-
 // From https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Firefox.
 const supportedImageMimeTypes = [
   'image/jpeg',
@@ -34,6 +26,8 @@ type ConvertImageDataParams = {
   mimeType: string;
 };
 
+export type PublicProps = ConvertImageDataParams;
+
 const convertImageData = ({
   _btoa = btoa,
   _log = log,
@@ -43,7 +37,7 @@ const convertImageData = ({
 }: ConvertImageDataParams): string | null => {
   const mimeTypeCased = mimeType.toLowerCase();
   if (!supportedImageMimeTypes.includes(mimeTypeCased)) {
-    _log.error('Unrecognized mimeType :', mimeType);
+    _log.error('Unrecognized mimeType passed to convertImageData: ', mimeType);
     return null;
   }
 
@@ -53,20 +47,8 @@ const convertImageData = ({
   );
 };
 
-const ImageViewBase = ({
-  _btoa,
-  _log,
-  _sanitize,
-  content,
-  mimeType,
-}: PublicProps) => {
-  const imageData = convertImageData({
-    _btoa,
-    _log,
-    _sanitize,
-    content,
-    mimeType,
-  });
+const ImageViewBase = ({ mimeType, ...props }: PublicProps) => {
+  const imageData = convertImageData({ mimeType, ...props });
   return (
     <div className={styles.ImageView}>
       {imageData ? (

--- a/src/components/ImageView/index.tsx
+++ b/src/components/ImageView/index.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import styles from './styles.module.scss';
 
-type PublicProps = {
+export type PublicProps = {
   _btoa?: typeof btoa;
   _log?: typeof log;
   _sanitize?: typeof purify.sanitize;
@@ -27,13 +27,18 @@ const convertImageData = ({
   content,
   mimeType,
 }: ConvertImageDataParams): string | null => {
+  const mimeTypeCased = mimeType.toLowerCase();
+  if (!mimeTypeCased.startsWith('image')) {
+    throw new Error(`Unexpected mimeType: "${mimeType}"`);
+  }
+
   try {
     return _btoa(
       // Run sanitize on svg files.
-      mimeType === 'image/svg+xml' ? _sanitize(content) : content,
+      mimeTypeCased === 'image/svg+xml' ? _sanitize(content) : content,
     );
   } catch (error) {
-    _log.debug('Error converting image data to ascii:', error);
+    _log.error('Error converting image data to ascii:', error);
     return null;
   }
 };

--- a/src/components/ImageView/index.tsx
+++ b/src/components/ImageView/index.tsx
@@ -2,6 +2,7 @@ import purify from 'dompurify';
 import log from 'loglevel';
 import * as React from 'react';
 
+import { gettext } from '../../utils';
 import styles from './styles.module.scss';
 
 export type PublicProps = {
@@ -11,6 +12,19 @@ export type PublicProps = {
   mimeType: string;
   content: string;
 };
+
+// From https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Firefox.
+const supportedImageMimeTypes = [
+  'image/jpeg',
+  'image/gif',
+  'image/png',
+  'image/svg+xml',
+  'image/bmp',
+  'image/vnd.microsoft.icon',
+  // webp isn't listed in the MDN article, but is documented elsewhere.
+  // e.g., https://caniuse.com/#search=webp
+  'image/webp',
+];
 
 type ConvertImageDataParams = {
   _btoa?: typeof btoa;
@@ -28,8 +42,9 @@ const convertImageData = ({
   mimeType,
 }: ConvertImageDataParams): string | null => {
   const mimeTypeCased = mimeType.toLowerCase();
-  if (!mimeTypeCased.startsWith('image')) {
-    throw new Error(`Unexpected mimeType: "${mimeType}"`);
+  if (!supportedImageMimeTypes.includes(mimeTypeCased)) {
+    _log.error('Unrecognized mimeType :', mimeType);
+    return null;
   }
 
   try {
@@ -57,11 +72,15 @@ const ImageViewBase = ({
     content,
     mimeType,
   });
-  return imageData ? (
+  return (
     <div className={styles.ImageView}>
-      <img alt="" src={`data:${mimeType};base64,${imageData}`} />
+      {imageData ? (
+        <img alt="" src={`data:${mimeType};base64,${imageData}`} />
+      ) : (
+        <p>{gettext('Unrecognized image format')}</p>
+      )}
     </div>
-  ) : null;
+  );
 };
 
 export default ImageViewBase;

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -4,6 +4,7 @@ import queryString from 'query-string';
 import { History } from 'history';
 
 import {
+  createFakeEntry,
   createFakeHistory,
   createFakeLocation,
   createFakeThunk,
@@ -24,6 +25,7 @@ import Loading from '../../components/Loading';
 import CodeOverview from '../../components/CodeOverview';
 import CodeView from '../../components/CodeView';
 import FileMetadata from '../../components/FileMetadata';
+import ImageView from '../../components/ImageView';
 
 import Browse, { BrowseBase, Props as BrowseProps } from '.';
 
@@ -249,6 +251,33 @@ describe(__filename, () => {
       'version',
       expect.objectContaining({ id: version.id }),
     );
+  });
+
+  it('renders an image file', () => {
+    const mimeType = 'image/png';
+    const path = 'image.png';
+    const entry = createFakeEntry('image', path, mimeType);
+    const content = 'some image data';
+    const version = {
+      ...fakeVersion,
+      file: {
+        ...fakeVersionFile,
+        content,
+        entries: { [path]: entry },
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        selected_file: path,
+      },
+    };
+
+    const store = configureStore();
+    _loadVersionAndFile({ store, version });
+
+    const root = render({ store, versionId: String(version.id) });
+
+    const code = root.find(ImageView);
+    expect(code).toHaveLength(1);
+    expect(code).toHaveProp('content', content);
+    expect(code).toHaveProp('mimeType', mimeType);
   });
 
   it('renders a loading message when we do not have the content of a file yet', () => {

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -278,6 +278,16 @@ describe(__filename, () => {
     expect(code).toHaveLength(1);
     expect(code).toHaveProp('content', content);
     expect(code).toHaveProp('mimeType', mimeType);
+
+    const overview = getContentShellPanel(root, 'altSidePanel').find(
+      CodeOverview,
+    );
+    expect(overview).toHaveLength(1);
+    expect(overview).toHaveProp('content', '');
+    expect(overview).toHaveProp(
+      'version',
+      expect.objectContaining({ id: version.id }),
+    );
   });
 
   it('renders a loading message when we do not have the content of a file yet', () => {

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -171,7 +171,10 @@ export class BrowseBase extends React.Component<Props> {
         }
         altSidePanel={
           file ? (
-            <CodeOverview content={file.content} version={version} />
+            <CodeOverview
+              content={file.type === 'image' ? '' : file.content}
+              version={version}
+            />
           ) : null
         }
       >

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -24,6 +24,7 @@ import { gettext, getPathFromQueryString } from '../../utils';
 import Loading from '../../components/Loading';
 import CodeView from '../../components/CodeView';
 import FileMetadata from '../../components/FileMetadata';
+import ImageView from '../../components/ImageView';
 import styles from './styles.module.scss';
 
 export type PublicProps = {};
@@ -138,6 +139,22 @@ export class BrowseBase extends React.Component<Props> {
       );
     }
 
+    const getContent = () => {
+      if (!file) {
+        return <Loading message={gettext('Loading content...')} />;
+      }
+      if (file.type === 'image') {
+        return <ImageView content={file.content} mimeType={file.mimeType} />;
+      }
+      return (
+        <CodeView
+          mimeType={file.mimeType}
+          content={file.content}
+          version={version}
+        />
+      );
+    };
+
     return (
       <ContentShell
         mainSidePanel={
@@ -158,15 +175,7 @@ export class BrowseBase extends React.Component<Props> {
           ) : null
         }
       >
-        {file ? (
-          <CodeView
-            mimeType={file.mimeType}
-            content={file.content}
-            version={version}
-          />
-        ) : (
-          <Loading message={gettext('Loading content...')} />
-        )}
+        {getContent()}
       </ContentShell>
     );
   }

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -128,6 +128,23 @@ export class BrowseBase extends React.Component<Props> {
     );
   };
 
+  getContent() {
+    const { file, version } = this.props;
+    if (!file || !version) {
+      return <Loading message={gettext('Loading content...')} />;
+    }
+    if (file.type === 'image') {
+      return <ImageView content={file.content} mimeType={file.mimeType} />;
+    }
+    return (
+      <CodeView
+        mimeType={file.mimeType}
+        content={file.content}
+        version={version}
+      />
+    );
+  }
+
   render() {
     const { file, version } = this.props;
 
@@ -138,22 +155,6 @@ export class BrowseBase extends React.Component<Props> {
         </ContentShell>
       );
     }
-
-    const getContent = () => {
-      if (!file) {
-        return <Loading message={gettext('Loading content...')} />;
-      }
-      if (file.type === 'image') {
-        return <ImageView content={file.content} mimeType={file.mimeType} />;
-      }
-      return (
-        <CodeView
-          mimeType={file.mimeType}
-          content={file.content}
-          version={version}
-        />
-      );
-    };
 
     return (
       <ContentShell
@@ -178,7 +179,7 @@ export class BrowseBase extends React.Component<Props> {
           ) : null
         }
       >
-        {getContent()}
+        {this.getContent()}
       </ContentShell>
     );
   }

--- a/src/server/index.spec.tsx
+++ b/src/server/index.spec.tsx
@@ -156,6 +156,7 @@ describe(__filename, () => {
         expect(policy['font-src']).toEqual(["'none'"]);
         expect(policy['img-src']).toEqual([
           `${fakeEnv.PUBLIC_URL}${STATIC_PATH}`,
+          'data:',
         ]);
         expect(policy['manifest-src']).toEqual(["'none'"]);
         expect(policy['media-src']).toEqual(["'none'"]);
@@ -616,7 +617,7 @@ describe(__filename, () => {
         expect(response.header).toHaveProperty('content-security-policy');
 
         const policy = cspParser(response.header['content-security-policy']);
-        expect(policy['img-src']).toEqual(["'self'"]);
+        expect(policy['img-src']).toEqual(["'self'", 'data:']);
       });
 
       it('relaxes script-src for local dev', async () => {

--- a/src/server/index.spec.tsx
+++ b/src/server/index.spec.tsx
@@ -313,7 +313,7 @@ describe(__filename, () => {
         const response = await server.get('/');
         expect(response.status).toEqual(200);
         const policy = cspParser(response.header['content-security-policy']);
-        expect(policy['img-src']).toEqual(["'none'"]);
+        expect(policy['img-src']).toEqual(["'none'", 'data:']);
         expect(policy['script-src']).toEqual(["'none'"]);
         expect(policy['style-src']).toEqual(["'none'"]);
       });
@@ -617,7 +617,7 @@ describe(__filename, () => {
         expect(response.header).toHaveProperty('content-security-policy');
 
         const policy = cspParser(response.header['content-security-policy']);
-        expect(policy['img-src']).toEqual(["'self'", 'data:']);
+        expect(policy['img-src']).toEqual(["'none'", 'data:', "'self'"]);
       });
 
       it('relaxes script-src for local dev', async () => {

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -78,10 +78,8 @@ export const createServer = ({
   const staticSrc = env.PUBLIC_URL
     ? `${env.PUBLIC_URL}${STATIC_PATH}`
     : "'none'";
-  const imgSrc = [staticSrc];
-  if (env.PUBLIC_URL) {
-    imgSrc.push('data:');
-  }
+  const imgSrc = [staticSrc, 'data:'];
+
   const connectSrc = [
     // Relax the connect-src if using the proxy otherwise Use the env var or
     // 'none' if the API host isn't set.
@@ -252,7 +250,7 @@ export const createServer = ({
       helmet.contentSecurityPolicy({
         directives: {
           ...prodCSP,
-          imgSrc: ["'self'", 'data:'],
+          imgSrc: [...prodCSP.imgSrc, "'self'"],
           scriptSrc: ["'self'", "'unsafe-inline'"],
           styleSrc: ["'self'", "'unsafe-inline'"],
           connectSrc: ["'self'"],

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -78,6 +78,10 @@ export const createServer = ({
   const staticSrc = env.PUBLIC_URL
     ? `${env.PUBLIC_URL}${STATIC_PATH}`
     : "'none'";
+  const imgSrc = [staticSrc];
+  if (env.PUBLIC_URL) {
+    imgSrc.push('data:');
+  }
   const connectSrc = [
     // Relax the connect-src if using the proxy otherwise Use the env var or
     // 'none' if the API host isn't set.
@@ -112,7 +116,7 @@ export const createServer = ({
     formAction: ["'none'"],
     frameAncestors: ["'none'"],
     frameSrc: ["'none'"],
-    imgSrc: [staticSrc],
+    imgSrc,
     manifestSrc: ["'none'"],
     mediaSrc: ["'none'"],
     objectSrc: ["'none'"],
@@ -248,7 +252,7 @@ export const createServer = ({
       helmet.contentSecurityPolicy({
         directives: {
           ...prodCSP,
-          imgSrc: ["'self'"],
+          imgSrc: ["'self'", 'data:'],
           scriptSrc: ["'self'", "'unsafe-inline'"],
           styleSrc: ["'self'", "'unsafe-inline'"],
           connectSrc: ["'self'"],

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -78,7 +78,6 @@ export const createServer = ({
   const staticSrc = env.PUBLIC_URL
     ? `${env.PUBLIC_URL}${STATIC_PATH}`
     : "'none'";
-  const imgSrc = [staticSrc, 'data:'];
 
   const connectSrc = [
     // Relax the connect-src if using the proxy otherwise Use the env var or
@@ -114,7 +113,7 @@ export const createServer = ({
     formAction: ["'none'"],
     frameAncestors: ["'none'"],
     frameSrc: ["'none'"],
-    imgSrc,
+    imgSrc: [staticSrc, 'data:'],
     manifestSrc: ["'none'"],
     mediaSrc: ["'none'"],
     objectSrc: ["'none'"],

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -52,11 +52,13 @@ export const fakeVersionEntry: ExternalVersionEntry = Object.freeze({
 export const createFakeEntry = (
   mime_category: VersionEntryType,
   path: string,
+  mimetype: string = 'application/json',
 ): ExternalVersionEntry => {
   return {
     ...fakeVersionEntry,
     filename: path,
     mime_category,
+    mimetype,
     path,
   };
 };

--- a/stories/ImageView.stories.tsx
+++ b/stories/ImageView.stories.tsx
@@ -26,7 +26,9 @@ storiesOf('ImageView', module).addWithChapters('all variants', {
         },
         {
           title: 'jpg file',
-          sectionFn: () => <ImageView mimeType="image/jpg" content={jpgFile} />,
+          sectionFn: () => (
+            <ImageView mimeType="image/jpeg" content={jpgFile} />
+          ),
         },
         {
           title: 'png file',
@@ -36,6 +38,12 @@ storiesOf('ImageView', module).addWithChapters('all variants', {
           title: 'svg file',
           sectionFn: () => (
             <ImageView mimeType="image/svg+xml" content={svgFile} />
+          ),
+        },
+        {
+          title: 'Unrecognized mime type',
+          sectionFn: () => (
+            <ImageView mimeType="invalid/type" content={svgFile} />
           ),
         },
       ],


### PR DESCRIPTION
Fixes #109 

A couple of notes:

1. I had to modify the CSP in order to display images from `data:` URLs. I'm not sure if what I did is okay and entirely safe.
2. I only implemented this for the `Browse` page. I don't think it makes sense for the `Compare` page, because if an image was changed I imagine we'd just have a diff of the contents of the file, not a diff showing us two different images, and therefore that wouldn't really be useful to display.
