### PR TITLE
Use FullscreenGrid for everything

### DIFF
--- a/src/components/App/index.spec.tsx
+++ b/src/components/App/index.spec.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { Alert, Container } from 'react-bootstrap';
+import { Alert } from 'react-bootstrap';
 import { Store } from 'redux';
 import { Route } from 'react-router-dom';
 
 import styles from './styles.module.scss';
 import configureStore from '../../configureStore';
+import { ContentShell } from '../FullscreenGrid';
 import { actions as apiActions } from '../../reducers/api';
 import { actions as errorsActions } from '../../reducers/errors';
 import { actions as userActions } from '../../reducers/users';
@@ -55,16 +56,14 @@ describe(__filename, () => {
   it('renders without an authentication token', () => {
     const root = render({ authToken: null });
 
-    expect(root.find(Container)).toHaveClassName(styles.container);
-    expect(root.find(`.${styles.content}`)).toHaveLength(1);
+    expect(root.find(ContentShell)).toHaveLength(1);
     expect(root.find(Navbar)).toHaveLength(1);
   });
 
   it('renders with an empty authentication token', () => {
     const root = render({ authToken: '' });
 
-    expect(root.find(Container)).toHaveClassName(styles.container);
-    expect(root.find(`.${styles.content}`)).toHaveLength(1);
+    expect(root.find(ContentShell)).toHaveLength(1);
     expect(root.find(Navbar)).toHaveLength(1);
   });
 
@@ -73,7 +72,9 @@ describe(__filename, () => {
     store.dispatch(userActions.beginFetchCurrentUser());
     const root = render({ store });
 
-    expect(root).toIncludeText('Getting your workspace ready');
+    expect(root.find(ContentShell).childAt(1)).toIncludeText(
+      'Getting your workspace ready',
+    );
     expect(root.find(Navbar)).toHaveLength(0);
   });
 
@@ -113,7 +114,7 @@ describe(__filename, () => {
     const root = render({ authToken: null });
 
     expect(root.find(Route)).toHaveLength(0);
-    expect(root.find(`.${styles.loginMessage}`)).toIncludeText('Please log in');
+    expect(root.find(ContentShell).children()).toIncludeText('Please log in');
   });
 
   it('exposes more routes when the user is logged in', () => {

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Alert, Container, Col, Row } from 'react-bootstrap';
+import { Alert } from 'react-bootstrap';
 import {
   Route,
   RouteComponentProps,
   Switch,
   withRouter,
 } from 'react-router-dom';
-import makeClassName from 'classnames';
 import log from 'loglevel';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
@@ -25,6 +24,7 @@ import {
   fetchCurrentUser,
   selectCurrentUser,
 } from '../../reducers/users';
+import FullscreenGrid, { ContentShell, Header } from '../FullscreenGrid';
 import Navbar from '../Navbar';
 import Browse from '../../pages/Browse';
 import Compare from '../../pages/Compare';
@@ -80,32 +80,23 @@ export class AppBase extends React.Component<Props> {
     }
   }
 
-  renderRow(content: JSX.Element, { className = '' } = {}) {
-    return (
-      <Row className={makeClassName(styles.content, className)}>{content}</Row>
-    );
-  }
-
   renderContent() {
     const { loading, user } = this.props;
 
     if (loading) {
-      return this.renderRow(
-        <React.Fragment>
+      return (
+        <ContentShell className={styles.isLoading}>
           <p>
             <FontAwesomeIcon icon="spinner" size="3x" spin />
           </p>
           <p>{gettext('Getting your workspace ready')}</p>
           <p>{gettext("Don't turn off your computer")}</p>
-        </React.Fragment>,
-        {
-          className: styles.isLoading,
-        },
+        </ContentShell>
       );
     }
 
     if (user) {
-      return this.renderRow(
+      return (
         <Switch>
           <Route exact path="/" component={Index} />
           <Route
@@ -119,13 +110,15 @@ export class AppBase extends React.Component<Props> {
             path="/:lang/compare/:addonId/versions/:baseVersionId...:headVersionId/"
           />
           <Route component={NotFound} />
-        </Switch>,
+        </Switch>
       );
     }
 
-    return this.renderRow(<p>{gettext('Please log in to continue.')}</p>, {
-      className: styles.loginMessage,
-    });
+    return (
+      <ContentShell className={styles.loginMessage}>
+        <p>{gettext('Please log in to continue.')}</p>
+      </ContentShell>
+    );
   }
 
   dismissError = (errorId: number) => {
@@ -141,10 +134,11 @@ export class AppBase extends React.Component<Props> {
       return null;
     }
 
-    return this.renderRow(
-      <Col>
+    return (
+      <div className={styles.errors}>
         {errors.map((error) => (
           <Alert
+            className={styles.errorAlert}
             dismissible
             key={error.id}
             onClose={() => this.dismissError(error.id)}
@@ -153,10 +147,7 @@ export class AppBase extends React.Component<Props> {
             {error.message}
           </Alert>
         ))}
-      </Col>,
-      {
-        className: styles.errors,
-      },
+      </div>
     );
   }
 
@@ -164,13 +155,13 @@ export class AppBase extends React.Component<Props> {
     const { loading } = this.props;
 
     return (
-      <React.Fragment>
-        {!loading && <Navbar />}
-        <Container className={styles.container} fluid>
+      <FullscreenGrid>
+        <Header>
+          {!loading && <Navbar />}
           {this.renderErrors()}
-          {this.renderContent()}
-        </Container>
-      </React.Fragment>
+        </Header>
+        {this.renderContent()}
+      </FullscreenGrid>
     );
   }
 }

--- a/src/components/App/styles.module.scss
+++ b/src/components/App/styles.module.scss
@@ -1,6 +1,4 @@
-.container {
-  padding-top: 15px;
-}
+@import '../../scss/variables';
 
 .loginMessage,
 .isLoading {
@@ -10,10 +8,23 @@
   font-size: 1.2em;
   font-weight: 500;
   justify-content: center;
-  min-height: 100vh;
   text-align: center;
 
   p {
     margin: 4px auto;
+  }
+}
+
+.errors {
+  padding: $default-padding;
+  // Each error will have its own bottom margin.
+  padding-bottom: 0;
+}
+
+.errorAlert {
+  margin-bottom: $default-padding;
+
+  &:last-child {
+    margin-bottom: 0;
   }
 }

--- a/src/components/CodeOverview/styles.module.scss
+++ b/src/components/CodeOverview/styles.module.scss
@@ -1,9 +1,7 @@
 @import '../../scss/variables';
 
 .CodeOverview {
-  border-radius: $border-radius;
-  border: 1px solid $light-gray;
-  height: 100vh;
+  height: 100%;
   padding: 0;
   position: sticky;
   top: 0;

--- a/src/components/CodeView/styles.module.scss
+++ b/src/components/CodeView/styles.module.scss
@@ -1,12 +1,5 @@
 @import '../../scss/variables';
 
-.CodeView {
-  border-radius: $border-radius;
-  border: 1px solid $light-gray;
-  margin-bottom: $default-padding;
-  padding: $default-padding;
-}
-
 .table {
   display: block;
   width: 100%;

--- a/src/components/DiffView/styles.module.scss
+++ b/src/components/DiffView/styles.module.scss
@@ -9,7 +9,7 @@
   border-spacing: 0;
   border-style: solid;
   border-width: 0 1px 1px 1px;
-  margin-bottom: 20px;
+  margin-bottom: $default-padding;
 }
 
 .header {

--- a/src/components/FullscreenGrid/index.spec.tsx
+++ b/src/components/FullscreenGrid/index.spec.tsx
@@ -1,53 +1,109 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 
-import FullscreenGrid, { Header, NavPanel, AltPanel, ContentPanel } from '.';
-
-const allComponents: {
-  [key: string]:
-    | typeof FullscreenGrid
-    | typeof Header
-    | typeof NavPanel
-    | typeof AltPanel
-    | typeof ContentPanel;
-} = {
-  FullscreenGrid,
-  Header,
-  NavPanel,
-  AltPanel,
-  ContentPanel,
-};
+import FullscreenGrid, { Header, ContentShell } from '.';
 
 describe(__filename, () => {
-  it.each(Object.keys(allComponents))(
-    'Component <%s> renders children',
-    (componentKey) => {
-      const Component = allComponents[componentKey];
-      const childClass = 'example-class';
+  describe('FullscreenGrid', () => {
+    it('accepts a custom className', () => {
+      const className = 'MyGrid';
+      const root = shallow(
+        <FullscreenGrid className={className}>
+          <Header />
+          <ContentShell />
+        </FullscreenGrid>,
+      );
+
+      expect(root.find(`.${className}`)).toHaveLength(1);
+    });
+
+    it('renders children', () => {
+      const childClass = 'ChildExample';
 
       const root = shallow(
-        <Component>
-          <div className={childClass} />
-        </Component>,
+        <FullscreenGrid>
+          <Header />
+          <ContentShell>
+            <div className={childClass} />
+          </ContentShell>
+        </FullscreenGrid>,
       );
 
       expect(root.find(`.${childClass}`)).toHaveLength(1);
-    },
-  );
+    });
+  });
 
-  it.each(Object.keys(allComponents))(
-    'Component <%s> accepts a custom className',
-    (componentKey) => {
-      const Component = allComponents[componentKey];
-      const className = 'example-class';
+  describe('Header', () => {
+    it('accepts a custom className', () => {
+      const className = 'MyHeader';
+      const root = shallow(<Header className={className} />);
+
+      expect(root.find(`.${className}`)).toHaveLength(1);
+    });
+
+    it('renders children', () => {
+      const childClass = 'ChildExample';
 
       const root = shallow(
-        <Component className={className}>
-          <span />
-        </Component>,
+        <Header>
+          <div className={childClass} />
+        </Header>,
       );
 
-      expect(root).toHaveClassName(className);
-    },
-  );
+      expect(root.find(`.${childClass}`)).toHaveLength(1);
+    });
+  });
+
+  describe('ContentShell', () => {
+    const render = (props = {}) => {
+      return shallow(<ContentShell {...props} />);
+    };
+
+    it('accepts a custom className', () => {
+      const className = 'MyContent';
+      const root = render({ className });
+
+      expect(root.find(`.${className}`)).toHaveLength(1);
+    });
+
+    it('renders children', () => {
+      const childClass = 'ChildExample';
+
+      const root = render({ children: <div className={childClass} /> });
+
+      expect(root.find(`.${childClass}`)).toHaveLength(1);
+    });
+
+    it('renders a mainSidePanel', () => {
+      const childClass = 'ChildExample';
+
+      const root = render({ mainSidePanel: <div className={childClass} /> });
+
+      expect(root.find(`.${childClass}`)).toHaveLength(1);
+    });
+
+    it('accepts a mainSidePanelClass', () => {
+      const customClass = 'Example';
+
+      const root = render({ mainSidePanelClass: customClass });
+
+      expect(root.find(`.${customClass}`)).toHaveLength(1);
+    });
+
+    it('renders an altSidePanel', () => {
+      const childClass = 'ChildExample';
+
+      const root = render({ altSidePanel: <div className={childClass} /> });
+
+      expect(root.find(`.${childClass}`)).toHaveLength(1);
+    });
+
+    it('accepts an altSidePanelClass', () => {
+      const customClass = 'Example';
+
+      const root = render({ altSidePanelClass: customClass });
+
+      expect(root.find(`.${customClass}`)).toHaveLength(1);
+    });
+  });
 });

--- a/src/components/FullscreenGrid/index.tsx
+++ b/src/components/FullscreenGrid/index.tsx
@@ -3,38 +3,63 @@ import makeClassName from 'classnames';
 
 import styles from './styles.module.scss';
 
-type PanelProps = {
-  children: React.ReactNode | React.ReactNode[];
+type AnyReactNode = React.ReactNode | React.ReactNode[];
+
+export const Header = ({
+  children,
+  className,
+}: {
+  children?: AnyReactNode;
   className?: string;
-};
-
-export const Header = ({ children, className }: PanelProps) => {
+}) => {
   return (
-    <div className={makeClassName(styles.Header, className)}>{children}</div>
-  );
-};
-
-export const NavPanel = ({ children, className }: PanelProps) => {
-  return (
-    <div className={makeClassName(styles.NavPanel, className)}>{children}</div>
-  );
-};
-
-export const AltPanel = ({ children, className }: PanelProps) => {
-  return (
-    <div className={makeClassName(styles.AltPanel, className)}>{children}</div>
-  );
-};
-
-export const ContentPanel = ({ children, className }: PanelProps) => {
-  return (
-    <div className={makeClassName(styles.ContentPanel, className)}>
+    <header className={makeClassName(styles.Header, className)}>
       {children}
-    </div>
+    </header>
   );
 };
 
-const FullscreenGrid = ({ children, className }: PanelProps) => {
+type ContentShellProps = {
+  altSidePanel?: AnyReactNode;
+  altSidePanelClass?: string;
+  children?: AnyReactNode;
+  className?: string;
+  mainSidePanel?: AnyReactNode;
+  mainSidePanelClass?: string;
+};
+
+export const ContentShell = ({
+  altSidePanel,
+  altSidePanelClass,
+  children,
+  className,
+  mainSidePanel,
+  mainSidePanelClass,
+}: ContentShellProps) => {
+  return (
+    <React.Fragment>
+      <aside
+        className={makeClassName(styles.mainSidePanel, mainSidePanelClass)}
+      >
+        {mainSidePanel}
+      </aside>
+      <main className={makeClassName(styles.content, className)}>
+        {children}
+      </main>
+      <aside className={makeClassName(styles.altSidePanel, altSidePanelClass)}>
+        {altSidePanel}
+      </aside>
+    </React.Fragment>
+  );
+};
+
+const FullscreenGrid = ({
+  children,
+  className,
+}: {
+  children?: AnyReactNode;
+  className?: string;
+}) => {
   return (
     <div className={makeClassName(styles.FullscreenGrid, className)}>
       {children}

--- a/src/components/FullscreenGrid/styles.module.scss
+++ b/src/components/FullscreenGrid/styles.module.scss
@@ -1,15 +1,13 @@
 @import '../../scss/variables';
 
-$grid-gap: 10px;
-
 .FullscreenGrid {
   display: grid;
-  grid-gap: $grid-gap;
+  grid-gap: $default-padding;
   grid-template-areas:
     'FGHeader FGHeader FGHeader'
-    'FGNavPanel FGContentPanel FGAltPanel'
+    'FGMainSidePanel FGContent FGAltSidePanel'
     '. . .';
-  grid-template-columns: 1fr 4fr 1fr;
+  grid-template-columns: 2fr 5fr 1fr;
   grid-template-rows: min-content 1fr 0px;
   height: 100vh;
 }
@@ -18,23 +16,23 @@ $grid-gap: 10px;
   grid-area: FGHeader;
 }
 
-.NavPanel {
-  grid-area: FGNavPanel;
-  margin-left: $grid-gap;
+.mainSidePanel {
+  grid-area: FGMainSidePanel;
+  margin-left: $default-padding;
 }
 
-.AltPanel {
-  grid-area: FGAltPanel;
-  margin-right: $grid-gap;
+.altSidePanel {
+  grid-area: FGAltSidePanel;
+  margin-right: $default-padding;
 }
 
-.ContentPanel {
-  grid-area: FGContentPanel;
+.content {
+  grid-area: FGContent;
 }
 
-.NavPanel,
-.AltPanel,
-.ContentPanel {
+.mainSidePanel,
+.altSidePanel,
+.content {
   border-radius: $border-radius;
   border: 1px solid $light-gray;
   overflow-x: hidden;

--- a/src/components/LoginButton/index.tsx
+++ b/src/components/LoginButton/index.tsx
@@ -36,7 +36,7 @@ export class LoginButtonBase extends React.Component<Props> {
 
   render() {
     return (
-      <Button href={this.getFxaURL()} className={styles.link}>
+      <Button size="sm" href={this.getFxaURL()} className={styles.link}>
         {gettext('Log in')}
       </Button>
     );

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -39,10 +39,10 @@ export class NavbarBase extends React.Component<Props> {
         <Navbar.Brand className={styles.brand}>
           <Link to="/">addons-code-manager</Link>
         </Navbar.Brand>
-        <Navbar.Text>
+        <Navbar.Text className={styles.text}>
           {user ? <span className={styles.username}>{user.name}</span> : null}
           {user ? (
-            <Button className={styles.logOut} onClick={this.logOut}>
+            <Button size="sm" className={styles.logOut} onClick={this.logOut}>
               {gettext('Log out')}
             </Button>
           ) : (

--- a/src/components/Navbar/styles.module.scss
+++ b/src/components/Navbar/styles.module.scss
@@ -1,12 +1,31 @@
+@import '../../scss/variables';
+
 .Navbar {
   display: flex;
   justify-content: space-between;
+  padding: $default-padding;
+  width: 100%;
+}
+
+.brand,
+.text {
+  margin: 0;
+  padding: 0;
 }
 
 .brand a {
   color: #fff;
 }
 
+.brand a,
+.text,
+.Navbar {
+  align-items: center;
+  display: flex;
+  flex-align: center;
+  font-size: 0.9rem;
+}
+
 .username {
-  margin-right: 10px;
+  margin-right: $default-padding;
 }

--- a/src/components/VersionChooser/styles.module.scss
+++ b/src/components/VersionChooser/styles.module.scss
@@ -1,8 +1,7 @@
 @import '../../scss/variables';
 
 .VersionChooser {
-  border-radius: $border-radius;
-  border: 1px solid $light-gray;
+  background-color: #fff;
   margin-bottom: $default-padding;
   padding: $default-padding;
   width: 100%;

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -10,6 +10,7 @@ import {
   fakeVersion,
   fakeVersionEntry,
   fakeVersionFile,
+  getContentShellPanel,
   shallowUntilTarget,
   spyOn,
 } from '../../test-helpers';
@@ -187,8 +188,9 @@ describe(__filename, () => {
 
     const root = render({ store, versionId: String(version.id) });
 
-    expect(root.find(FileTree)).toHaveLength(1);
-    expect(root.find(FileTree)).toHaveProp('versionId', version.id);
+    const tree = getContentShellPanel(root, 'mainSidePanel').find(FileTree);
+    expect(tree).toHaveLength(1);
+    expect(tree).toHaveProp('versionId', version.id);
   });
 
   it('renders a FileMetadata component when a version file has loaded', () => {
@@ -199,8 +201,11 @@ describe(__filename, () => {
 
     const root = render({ store, versionId: String(version.id) });
 
-    expect(root.find(FileMetadata)).toHaveLength(1);
-    expect(root.find(FileMetadata)).toHaveProp(
+    const metadata = getContentShellPanel(root, 'mainSidePanel').find(
+      FileMetadata,
+    );
+    expect(metadata).toHaveLength(1);
+    expect(metadata).toHaveProp(
       'file',
       getVersionFile(
         store.getState().versions,
@@ -235,7 +240,9 @@ describe(__filename, () => {
       expect.objectContaining({ id: version.id }),
     );
 
-    const overview = root.find(CodeOverview);
+    const overview = getContentShellPanel(root, 'altSidePanel').find(
+      CodeOverview,
+    );
     expect(overview).toHaveLength(1);
     expect(overview).toHaveProp('content', content);
     expect(overview).toHaveProp(
@@ -285,7 +292,7 @@ describe(__filename, () => {
       versionId: String(version.id),
     });
 
-    const fileTree = root.find(FileTree);
+    const fileTree = getContentShellPanel(root, 'mainSidePanel').find(FileTree);
     expect(fileTree).toHaveProp('onSelect');
 
     const onSelectFile = fileTree.prop('onSelect');

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -8,6 +8,7 @@ import { ApplicationState } from '../../reducers';
 import { ConnectedReduxProps } from '../../configureStore';
 import { ApiState } from '../../reducers/api';
 import CodeOverview from '../../components/CodeOverview';
+import { ContentShell } from '../../components/FullscreenGrid';
 import FileTree from '../../components/FileTree';
 import {
   Version,
@@ -131,50 +132,42 @@ export class BrowseBase extends React.Component<Props> {
 
     if (!version) {
       return (
-        <Col>
+        <ContentShell>
           <Loading message={gettext('Loading version...')} />
-        </Col>
+        </ContentShell>
       );
     }
 
     return (
-      <React.Fragment>
-        <Col md="3">
-          <Row>
-            <Col>
-              <FileTree
-                onSelect={this.viewVersionFile}
-                versionId={version.id}
-              />
-            </Col>
-          </Row>
-          {file && (
-            <Row>
-              <Col className={styles.metadata}>
-                <FileMetadata file={file} />
-              </Col>
-            </Row>
-          )}
-        </Col>
-        {file ? (
+      <ContentShell
+        mainSidePanel={
           <React.Fragment>
-            <Col md="8">
-              <CodeView
-                mimeType={file.mimeType}
-                content={file.content}
-                version={version}
-              />
-            </Col>
-            <Col md="1">
-              <CodeOverview content={file.content} version={version} />
-            </Col>
+            <FileTree onSelect={this.viewVersionFile} versionId={version.id} />
+            {file && (
+              <Row>
+                <Col className={styles.metadata}>
+                  <FileMetadata file={file} />
+                </Col>
+              </Row>
+            )}
           </React.Fragment>
+        }
+        altSidePanel={
+          file ? (
+            <CodeOverview content={file.content} version={version} />
+          ) : null
+        }
+      >
+        {file ? (
+          <CodeView
+            mimeType={file.mimeType}
+            content={file.content}
+            version={version}
+          />
         ) : (
-          <Col md="9">
-            <Loading message={gettext('Loading content...')} />
-          </Col>
+          <Loading message={gettext('Loading content...')} />
         )}
-      </React.Fragment>
+      </ContentShell>
     );
   }
 }

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -8,6 +8,7 @@ import {
   createFakeLocation,
   createFakeThunk,
   fakeVersionWithDiff,
+  getContentShellPanel,
   shallowUntilTarget,
   spyOn,
 } from '../../test-helpers';
@@ -173,12 +174,11 @@ describe(__filename, () => {
     const addonId = 123;
     const root = render({ addonId: String(addonId) });
 
-    expect(root.find(Loading)).toHaveLength(2);
-    expect(root.find(Loading).at(0)).toHaveProp(
-      'message',
-      'Loading file tree...',
-    );
-    expect(root.find(Loading).at(1)).toHaveProp('message', 'Loading diff...');
+    expect(
+      getContentShellPanel(root, 'mainSidePanel').find(Loading),
+    ).toHaveProp('message', 'Loading file tree...');
+    expect(root.find(Loading)).toHaveProp('message', 'Loading diff...');
+
     // This component is always displayed.
     expect(root.find(VersionChooser)).toHaveLength(1);
     expect(root.find(VersionChooser)).toHaveProp('addonId', addonId);
@@ -198,8 +198,9 @@ describe(__filename, () => {
   it('renders a FileTree component when a diff has been loaded', () => {
     const { root, version } = loadDiffAndRender();
 
-    expect(root.find(FileTree)).toHaveLength(1);
-    expect(root.find(FileTree)).toHaveProp('versionId', version.id);
+    const tree = getContentShellPanel(root, 'mainSidePanel').find(FileTree);
+    expect(tree).toHaveLength(1);
+    expect(tree).toHaveProp('versionId', version.id);
   });
 
   it('renders a DiffView', () => {
@@ -260,7 +261,10 @@ describe(__filename, () => {
 
     const root = render({ store });
 
-    expect(root.find(`.${styles.error}`)).toHaveLength(2);
+    expect(
+      getContentShellPanel(root, 'mainSidePanel').find(`.${styles.error}`),
+    ).toHaveLength(1);
+    expect(root.find(`.${styles.error}`)).toHaveLength(1);
   });
 
   it('dispatches fetchDiff() on mount', () => {
@@ -438,7 +442,9 @@ describe(__filename, () => {
 
     dispatch.mockClear();
 
-    const onSelectFile = root.find(FileTree).prop('onSelect');
+    const onSelectFile = getContentShellPanel(root, 'mainSidePanel')
+      .find(FileTree)
+      .prop('onSelect');
     onSelectFile(path);
 
     expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { Col, Row } from 'react-bootstrap';
 import { RouteComponentProps } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 import { ApplicationState } from '../../reducers';
 import { ConnectedReduxProps } from '../../configureStore';
+import { ContentShell } from '../../components/FullscreenGrid';
 import FileTree from '../../components/FileTree';
 import DiffView from '../../components/DiffView';
 import Loading from '../../components/Loading';
@@ -147,35 +147,26 @@ export class CompareBase extends React.Component<Props> {
     const { addonId, compareInfo, version } = this.props;
 
     return (
-      <React.Fragment>
-        <Col md="3">
-          {version ? (
+      <ContentShell
+        mainSidePanel={
+          version ? (
             <FileTree onSelect={this.viewVersionFile} versionId={version.id} />
           ) : (
             this.renderLoadingMessageOrError(gettext('Loading file tree...'))
-          )}
-        </Col>
-        <Col md="9">
-          <Row>
-            <Col>
-              <VersionChooser addonId={addonId} />
-            </Col>
-          </Row>
-          <Row>
-            <Col>
-              {version && compareInfo ? (
-                <DiffView
-                  diffs={compareInfo.diffs}
-                  mimeType={compareInfo.mimeType}
-                  version={version}
-                />
-              ) : (
-                this.renderLoadingMessageOrError(gettext('Loading diff...'))
-              )}
-            </Col>
-          </Row>
-        </Col>
-      </React.Fragment>
+          )
+        }
+      >
+        <VersionChooser addonId={addonId} />
+        {version && compareInfo ? (
+          <DiffView
+            diffs={compareInfo.diffs}
+            mimeType={compareInfo.mimeType}
+            version={version}
+          />
+        ) : (
+          this.renderLoadingMessageOrError(gettext('Loading diff...'))
+        )}
+      </ContentShell>
     );
   }
 }

--- a/src/pages/Index/index.tsx
+++ b/src/pages/Index/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { Col } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 
+import { ContentShell } from '../../components/FullscreenGrid';
 import { gettext } from '../../utils';
 
 type Props = {
@@ -20,7 +20,7 @@ export class IndexBase extends React.Component<Props> {
     const repoUrl = 'https://github.com/mozilla/addons-code-manager';
 
     return (
-      <Col>
+      <ContentShell>
         <p>
           {gettext(
             'This is a tool for managing add-on source code that is used with the',
@@ -67,7 +67,7 @@ export class IndexBase extends React.Component<Props> {
             </ul>
           </React.Fragment>
         )}
-      </Col>
+      </ContentShell>
     );
   }
 }

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import { History, Location } from 'history';
 import { ShallowWrapper, shallow } from 'enzyme';
@@ -29,6 +30,7 @@ import {
 import LinterProvider, {
   LinterProviderInfo,
 } from './components/LinterProvider';
+import { ContentShell } from './components/FullscreenGrid';
 
 /* eslint-disable @typescript-eslint/camelcase */
 
@@ -589,4 +591,16 @@ export const simulateLinterProvider = (
     messagesAreLoading,
     selectedMessageMap,
   });
+};
+
+/*
+ * Given a ShallowWrapper for a component that renders ContentShell,
+ * return a wrapper around one of its panel attributes.
+ */
+export const getContentShellPanel = (
+  root: ShallowWrapper,
+  panelAttr: 'mainSidePanel' | 'altSidePanel',
+) => {
+  const panel = root.find(ContentShell).prop(panelAttr);
+  return shallow(<div>{panel}</div>);
 };

--- a/stories/CodeView.stories.tsx
+++ b/stories/CodeView.stories.tsx
@@ -56,7 +56,12 @@ const render = ({
     version: createInternalVersion(fakeVersion),
     ...moreProps,
   };
-  return renderWithStoreAndRouter(<CodeView {...props} />, store);
+  return renderWithStoreAndRouter(
+    <div className="CodeView-panel">
+      <CodeView {...props} />
+    </div>,
+    store,
+  );
 };
 
 const renderJSWithMessages = (

--- a/stories/FullscreenGrid.stories.tsx
+++ b/stories/FullscreenGrid.stories.tsx
@@ -3,9 +3,7 @@ import { storiesOf } from '@storybook/react';
 
 import FullscreenGrid, {
   Header,
-  NavPanel,
-  AltPanel,
-  ContentPanel,
+  ContentShell,
 } from '../src/components/FullscreenGrid';
 import { rootAttributeParams } from './utils';
 
@@ -27,11 +25,15 @@ storiesOf('FullscreenGrid', module)
       return (
         <FullscreenGrid>
           <Header className="FullscreenGridStory-Header">Header</Header>
-          <NavPanel className="FullscreenGridStory-NavPanel">NavPanel</NavPanel>
-          <ContentPanel className="FullscreenGridStory-ContentPanel">
-            ContentPanel
-          </ContentPanel>
-          <AltPanel className="FullscreenGridStory-AltPanel">AltPanel</AltPanel>
+          <ContentShell
+            altSidePanel="altSidePanel"
+            altSidePanelClass="FullscreenGridStory-altSidePanel"
+            className="FullscreenGridStory-content"
+            mainSidePanel="mainSidePanel"
+            mainSidePanelClass="FullscreenGridStory-mainSidePanel"
+          >
+            Content
+          </ContentShell>
         </FullscreenGrid>
       );
     },
@@ -48,9 +50,9 @@ storiesOf('FullscreenGrid', module)
       return (
         <FullscreenGrid>
           <Header className="FullscreenGridStory-Header">Header</Header>
-          <NavPanel>{someText}</NavPanel>
-          <ContentPanel>{someText}</ContentPanel>
-          <AltPanel>{someText}</AltPanel>
+          <ContentShell altSidePanel={someText} mainSidePanel={someText}>
+            {someText}
+          </ContentShell>
         </FullscreenGrid>
       );
     },

--- a/stories/setup/styles.scss
+++ b/stories/setup/styles.scss
@@ -1,3 +1,5 @@
+@import '../../src/scss/variables';
+
 body {
   padding: 24px;
 }
@@ -46,10 +48,16 @@ body.fullscreen {
   }
 }
 
+.CodeView-panel {
+  border-radius: $border-radius;
+  border: 1px solid $light-gray;
+  padding: $default-padding;
+}
+
 .FullscreenGridStory-Header,
-.FullscreenGridStory-NavPanel,
-.FullscreenGridStory-ContentPanel,
-.FullscreenGridStory-AltPanel {
+.FullscreenGridStory-mainSidePanel,
+.FullscreenGridStory-content,
+.FullscreenGridStory-altSidePanel {
   align-items: center;
   display: flex;
   justify-content: center;
@@ -60,15 +68,15 @@ body.fullscreen {
   padding: 20px;
 }
 
-.FullscreenGridStory-NavPanel {
+.FullscreenGridStory-mainSidePanel {
   background-color: lighten(orange, 44);
 }
 
-.FullscreenGridStory-ContentPanel {
+.FullscreenGridStory-content {
   background-color: lighten(yellow, 47);
 }
 
-.FullscreenGridStory-AltPanel {
+.FullscreenGridStory-altSidePanel {
   background-color: lighten(green, 68);
 }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/652

**TODO**: the file tree area is an improvement over master but I'd like to improve it more in https://github.com/mozilla/addons-code-manager/issues/653

Notes:
- I made the Navbar a bit smaller since the header is always present
- I removed borders from some things since the grid panels have borders now
- Everything else looks more or less the same except all screens are in the grid
- I adapted `FullscreenGrid` to make it easier to work with for our specific app

<details>
<summary>Screencast</summary>

![2019-04-26 14 40 42](https://user-images.githubusercontent.com/55398/56834317-b7a3d180-6836-11e9-805b-d24fd5293919.gif)

</details>


<details>
<summary>Screenshots</summary>

<img width="1449" alt="acm_panels_initial" src="https://user-images.githubusercontent.com/55398/56834533-43b5f900-6837-11e9-86b4-93187de4cead.png">
<img width="1449" alt="acm_panels_logging_in" src="https://user-images.githubusercontent.com/55398/56834540-47498000-6837-11e9-936c-67f63c0ff1c4.png">
<img width="1449" alt="acm_panels_loading" src="https://user-images.githubusercontent.com/55398/56834546-49abda00-6837-11e9-881d-4ec76fe9dc22.png">
<img width="1449" alt="acm_panels_browse" src="https://user-images.githubusercontent.com/55398/56834550-4b759d80-6837-11e9-892a-2136a04259a9.png">
<img width="1449" alt="acm_panels_compare" src="https://user-images.githubusercontent.com/55398/56834556-4e708e00-6837-11e9-9f99-1b10c4537ebb.png">
<img width="1449" alt="acm_panels_errors" src="https://user-images.githubusercontent.com/55398/56834561-503a5180-6837-11e9-8093-1fb91f02aff5.png">


</details>