### PR TITLE
Do not use a static React ref in CodeOverview

### DIFF
--- a/src/components/CodeOverview/index.spec.tsx
+++ b/src/components/CodeOverview/index.spec.tsx
@@ -14,6 +14,7 @@ import {
   createContextWithFakeRouter,
   createFakeExternalLinterResult,
   createFakeLocation,
+  createFakeRef,
   fakeVersion,
   shallowUntilTarget,
   simulateLinterProvider,
@@ -96,15 +97,6 @@ describe(__filename, () => {
       .map((i) => `// This is line ${i + 1} of the code`);
   };
 
-  const createFakeRef = (overrides = {}) => {
-    return {
-      current: {
-        ...document.createElement('div'),
-        ...overrides,
-      },
-    };
-  };
-
   const renderWithMessages = ({
     contentLines = generateFileLines({ count: 10 }),
     messages,
@@ -177,7 +169,7 @@ describe(__filename, () => {
 
   it('sets the overview height on mount', () => {
     const fakeRef = createFakeRef({ clientHeight: 100 });
-    const root = render({ initialOverviewRef: fakeRef });
+    const root = render({ createOverviewRef: () => fakeRef });
 
     expect(root.state('overviewHeight')).toEqual(fakeRef.current.clientHeight);
   });
@@ -185,7 +177,7 @@ describe(__filename, () => {
   it('sets the overview height in waitAndSetNewOverviewHeight', () => {
     const fakeRef = createFakeRef({ clientHeight: 100 });
     const { root, instance } = renderWithInstance({
-      initialOverviewRef: fakeRef,
+      createOverviewRef: () => fakeRef,
     });
 
     // Reset the overviewHeight so it will be calculated again.
@@ -199,7 +191,7 @@ describe(__filename, () => {
   it('can set the overview height explicitly', () => {
     const fakeRef = createFakeRef({ clientHeight: 400 });
     const { root, instance } = renderWithInstance({
-      initialOverviewRef: fakeRef,
+      createOverviewRef: () => fakeRef,
     });
 
     // Set a height that will be overwritten.
@@ -210,7 +202,9 @@ describe(__filename, () => {
   });
 
   it('only sets the overview height for defined refs', () => {
-    const { root, instance } = renderWithInstance({ initialOverviewRef: null });
+    const { root, instance } = renderWithInstance({
+      createOverviewRef: () => null,
+    });
 
     const overviewHeight = 200;
     root.setState({ overviewHeight });
@@ -224,7 +218,7 @@ describe(__filename, () => {
   it('only sets the overview height for active refs', () => {
     const { root, instance } = renderWithInstance({
       // Set an inactive ref.
-      initialOverviewRef: React.createRef(),
+      createOverviewRef: () => React.createRef(),
     });
 
     const overviewHeight = 200;

--- a/src/components/CodeOverview/index.tsx
+++ b/src/components/CodeOverview/index.tsx
@@ -31,7 +31,7 @@ export type DefaultProps = {
     addEventListener: typeof window.addEventListener;
     removeEventListener: typeof window.removeEventListener;
   };
-  initialOverviewRef: React.RefObject<HTMLDivElement>;
+  createOverviewRef: () => React.RefObject<HTMLDivElement> | null;
   overviewPadding: number;
   rowTopPadding: number;
   rowHeight: number;
@@ -48,7 +48,7 @@ export class CodeOverviewBase extends React.Component<Props, State> {
   static defaultProps = {
     _debounce: debounce,
     _window: window,
-    initialOverviewRef: React.createRef<HTMLDivElement>(),
+    createOverviewRef: () => React.createRef<HTMLDivElement>(),
     // This is the padding of the overview container.
     overviewPadding: 10,
     rowTopPadding: 2,
@@ -58,7 +58,7 @@ export class CodeOverviewBase extends React.Component<Props, State> {
 
   public state = { overviewHeight: null };
 
-  private overviewRef = this.props.initialOverviewRef;
+  private overviewRef = this.props.createOverviewRef();
 
   componentDidMount() {
     const { _window } = this.props;

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -604,3 +604,24 @@ export const getContentShellPanel = (
   const panel = root.find(ContentShell).prop(panelAttr);
   return shallow(<div>{panel}</div>);
 };
+
+/*
+ * Returns a fake React ref that can be passed into a component instance.
+ *
+ * The `currentOverrides` parameters are applied to ref.current. By
+ * default, ref.current will be a real DOM node so you'll need to
+ * override any properties that the component may touch.
+ */
+export const createFakeRef = (
+  /* istanbul ignore next */
+  currentOverrides = {},
+  { currentElement = document.createElement('div') } = {},
+) => {
+  return {
+    ...React.createRef(),
+    current: {
+      ...currentElement,
+      ...currentOverrides,
+    },
+  };
+};


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/673

I also moved `createFakeRef()` to the helpers file because this will be useful to other components.