### PR TITLE
Use AccordionMenu for files, info, key shortcuts

### DIFF
--- a/src/components/FileMetadata/index.tsx
+++ b/src/components/FileMetadata/index.tsx
@@ -12,8 +12,6 @@ type PublicProps = {
 const FileMetadataBase = ({ file }: PublicProps) => {
   return (
     <div className={styles.FileMetadata}>
-      <h4>{gettext('Information about this file')}</h4>
-
       <dl>
         <dt>{gettext('Version')}</dt>
         <dd className={styles.version}>{file.version}</dd>

--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -1,7 +1,6 @@
 /* eslint @typescript-eslint/camelcase: 0 */
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { ListGroup } from 'react-bootstrap';
 import Treefold from 'react-treefold';
 import { Store } from 'redux';
 
@@ -23,7 +22,6 @@ import {
 } from '../../test-helpers';
 import { getTreefoldRenderProps } from '../FileTreeNode/index.spec';
 import FileTreeNode from '../FileTreeNode';
-import KeyboardShortcuts from '../KeyboardShortcuts';
 import Loading from '../Loading';
 
 import FileTree, { DefaultProps, FileTreeBase, PublicProps } from '.';
@@ -125,45 +123,17 @@ describe(__filename, () => {
       expect(dispatch).not.toHaveBeenCalled();
     });
 
-    it('renders a ListGroup component with a Treefold', () => {
+    it('renders a Treefold component', () => {
       const store = configureStore();
       const version = getVersion({ store });
       _buildTree(store, version);
 
       const root = render({ store, versionId: version.id });
 
-      expect(root.find(ListGroup)).toHaveLength(1);
       expect(root.find(Treefold)).toHaveLength(1);
       expect(root.find(Treefold)).toHaveProp('nodes', [
         buildFileTree(version).nodes,
       ]);
-    });
-
-    it('renders a KeyboardShortcuts component', () => {
-      const store = configureStore();
-      const version = getVersion({ store });
-      _buildTree(store, version);
-
-      const root = render({ store, versionId: version.id });
-
-      const keyboardShortcuts = root.find(KeyboardShortcuts);
-
-      expect(keyboardShortcuts).toHaveLength(1);
-      expect(keyboardShortcuts).toHaveProp('currentPath', version.selectedPath);
-      expect(keyboardShortcuts).toHaveProp(
-        'pathList',
-        buildFileTree(version).pathList,
-      );
-      expect(keyboardShortcuts).toHaveProp('versionId', version.id);
-    });
-
-    it('does not render a KeyboardShortcuts component without a tree', () => {
-      const store = configureStore();
-      const version = getVersion({ store });
-
-      const root = render({ store, versionId: version.id });
-
-      expect(root.find(KeyboardShortcuts)).toHaveLength(0);
     });
 
     it('passes the onSelect prop to FileTreeNode', () => {

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -1,6 +1,6 @@
 import log from 'loglevel';
 import * as React from 'react';
-import { Button, ListGroup } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import Treefold, { TreefoldRenderProps } from 'react-treefold';
 
@@ -8,7 +8,6 @@ import styles from './styles.module.scss';
 import FileTreeNode, {
   PublicProps as FileTreeNodeProps,
 } from '../FileTreeNode';
-import KeyboardShortcuts from '../KeyboardShortcuts';
 import Loading from '../Loading';
 import { ApplicationState } from '../../reducers';
 import { ConnectedReduxProps } from '../../configureStore';
@@ -141,7 +140,7 @@ export class FileTreeBase extends React.Component<Props> {
     }
 
     return (
-      <ListGroup>
+      <div className={styles.shell}>
         <div className={styles.controlButtons}>
           <Button
             className={styles.button}
@@ -164,18 +163,15 @@ export class FileTreeBase extends React.Component<Props> {
             {gettext('Close all folders')}
           </Button>
         </div>
-        <Treefold
-          nodes={[tree.nodes]}
-          render={this.renderNode}
-          isNodeExpanded={this.isNodeExpanded}
-          onToggleExpand={this.onToggleExpand}
-        />
-        <KeyboardShortcuts
-          currentPath={version.selectedPath}
-          pathList={tree.pathList}
-          versionId={version.id}
-        />
-      </ListGroup>
+        <div className={styles.treeShell}>
+          <Treefold
+            nodes={[tree.nodes]}
+            render={this.renderNode}
+            isNodeExpanded={this.isNodeExpanded}
+            onToggleExpand={this.onToggleExpand}
+          />
+        </div>
+      </div>
     );
   }
 }

--- a/src/components/FileTree/styles.module.scss
+++ b/src/components/FileTree/styles.module.scss
@@ -1,3 +1,17 @@
+@import '../../scss/variables';
+
+.shell {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.treeShell {
+  border-radius: $border-radius;
+  border: 1px solid $light-gray;
+  overflow: auto;
+}
+
 .controlButtons {
   display: grid;
   grid-column-gap: 10px;

--- a/src/components/FileTreeNode/styles.module.scss
+++ b/src/components/FileTreeNode/styles.module.scss
@@ -1,12 +1,24 @@
 @import '../../scss/variables';
 
 .node {
+  border-left: none;
+  border-right: none;
   cursor: pointer;
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
   justify-content: space-between;
   padding: 0.5rem 1.25rem;
+
+  &:first-child {
+    border-radius: 0;
+    border-top: none;
+  }
+
+  &:last-child {
+    border-bottom: none;
+    border-radius: 0;
+  }
 }
 
 .nodeItem {

--- a/src/components/FullscreenGrid/index.tsx
+++ b/src/components/FullscreenGrid/index.tsx
@@ -18,6 +18,8 @@ export const Header = ({
   );
 };
 
+export type PanelAttribs = 'altSidePanel' | 'mainSidePanel';
+
 type ContentShellProps = {
   altSidePanel?: AnyReactNode;
   altSidePanelClass?: string;

--- a/src/components/KeyboardShortcuts/styles.module.scss
+++ b/src/components/KeyboardShortcuts/styles.module.scss
@@ -3,7 +3,6 @@
 .KeyboardShortcuts {
   border-radius: $border-radius;
   border: 1px solid $light-gray;
-  margin-top: $default-padding;
   padding: $default-padding;
 }
 

--- a/src/components/VersionFileViewer/index.spec.tsx
+++ b/src/components/VersionFileViewer/index.spec.tsx
@@ -1,0 +1,212 @@
+import * as React from 'react';
+import { Store } from 'redux';
+import { ShallowWrapper, shallow } from 'enzyme';
+
+import configureStore from '../../configureStore';
+import { AccordionItem } from '../AccordionMenu';
+import CodeOverview from '../CodeOverview';
+import FileMetadata from '../FileMetadata';
+import FileTree from '../FileTree';
+import { PanelAttribs } from '../FullscreenGrid';
+import KeyboardShortcuts from '../KeyboardShortcuts';
+import Loading from '../Loading';
+import {
+  ExternalVersionEntry,
+  actions as versionsActions,
+  getVersionFile,
+  getVersionInfo,
+} from '../../reducers/versions';
+import {
+  createFakeEntry,
+  getContentShellPanel,
+  fakeVersion,
+  fakeVersionEntry,
+} from '../../test-helpers';
+
+import VersionFileViewer, { ItemTitles, PublicProps } from '.';
+
+describe(__filename, () => {
+  const getInternalVersionAndFile = ({
+    store = configureStore(),
+    path = 'background.js',
+    entry,
+    fileContent = 'example file content',
+  }: {
+    store?: Store;
+    path?: string;
+    entry?: ExternalVersionEntry;
+    fileContent?: string;
+  } = {}) => {
+    // TODO: add a real createInternalVersionFile().
+    // See https://github.com/mozilla/addons-code-manager/issues/685
+    //
+    // After that this could simply be:
+    // return {
+    //   version: createInternalVersion(...),
+    //   file: createInternalVersionFile(...),
+    // };
+    const version = {
+      ...fakeVersion,
+      file: {
+        ...fakeVersion.file,
+        content: fileContent,
+        entries: {
+          ...fakeVersion.file.entries,
+          [path]: entry || { ...fakeVersionEntry, filename: path, path },
+        },
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        selected_file: path,
+      },
+    };
+    store.dispatch(versionsActions.loadVersionInfo({ version }));
+    store.dispatch(versionsActions.loadVersionFile({ path, version }));
+
+    const versionsState = store.getState().versions;
+
+    const internalVersion = getVersionInfo(versionsState, version.id);
+    if (!internalVersion) {
+      throw new Error(
+        `Unexpectedly could not retrieve version from state for id=${
+          version.id
+        }`,
+      );
+    }
+
+    const file = getVersionFile(versionsState, version.id, path);
+    if (!file) {
+      throw new Error(
+        `Unexpectedly could not retrieve version file from state for id=${
+          version.id
+        }, path=${path}`,
+      );
+    }
+
+    return { version: internalVersion, file };
+  };
+
+  type RenderParams = Partial<PublicProps>;
+
+  const render = (moreProps: RenderParams) => {
+    const { file, version } = getInternalVersionAndFile();
+    const props = {
+      children: <div />,
+      file,
+      onSelectFile: jest.fn(),
+      showFileInfo: true,
+      version,
+      ...moreProps,
+    };
+
+    return shallow(<VersionFileViewer {...props} />);
+  };
+
+  const renderPanel = (params: RenderParams, panel: PanelAttribs) => {
+    const root = render(params);
+    return getContentShellPanel(root, panel);
+  };
+
+  const getItem = (root: ShallowWrapper, title: ItemTitles) => {
+    return root
+      .find(AccordionItem)
+      .filterWhere((c) => c.prop('title') === title);
+  };
+
+  it('renders children', () => {
+    const childClass = 'ExampleClass';
+    const root = render({ children: <div className={childClass} /> });
+
+    expect(root.find(`.${childClass}`)).toHaveLength(1);
+  });
+
+  it('renders a placeholder without a version', () => {
+    const childClass = 'ExampleClass';
+    const root = render({
+      children: <div className={childClass} />,
+      version: null,
+    });
+
+    expect(root.find(Loading)).toHaveLength(1);
+    expect(root.find(`.${childClass}`)).toHaveLength(0);
+  });
+
+  it('renders a FileTree component', () => {
+    const onSelectFile = jest.fn();
+    const { version } = getInternalVersionAndFile();
+
+    const root = renderPanel({ onSelectFile, version }, 'mainSidePanel');
+
+    const tree = root.find(FileTree);
+    expect(tree).toHaveLength(1);
+    expect(tree).toHaveProp('onSelect', onSelectFile);
+    expect(tree).toHaveProp('versionId', version.id);
+  });
+
+  it('shows an information panel by default', () => {
+    const { file } = getInternalVersionAndFile();
+    const root = renderPanel({ file }, 'mainSidePanel');
+    const item = getItem(root, ItemTitles.Information);
+
+    const meta = item.find(FileMetadata);
+    expect(meta).toHaveProp('file', file);
+  });
+
+  it('can hide the information panel', () => {
+    const root = renderPanel({ showFileInfo: false }, 'mainSidePanel');
+
+    expect(getItem(root, ItemTitles.Information)).toHaveLength(0);
+  });
+
+  it('renders a placeholder in the information panel without a file', () => {
+    const root = renderPanel(
+      { file: null, showFileInfo: true },
+      'mainSidePanel',
+    );
+    const item = getItem(root, ItemTitles.Information);
+
+    expect(item.find(FileMetadata)).toHaveLength(0);
+    expect(item.find(Loading)).toHaveLength(1);
+  });
+
+  it('renders a KeyboardShortcuts panel', () => {
+    const { version } = getInternalVersionAndFile();
+    const root = renderPanel({ version }, 'mainSidePanel');
+    const item = getItem(root, ItemTitles.Shortcuts);
+
+    const shortcuts = item.find(KeyboardShortcuts);
+    expect(shortcuts).toHaveLength(1);
+    expect(shortcuts).toHaveProp('currentPath', version.selectedPath);
+    expect(shortcuts).toHaveProp('versionId', version.id);
+  });
+
+  it('renders CodeOverview', () => {
+    const { file, version } = getInternalVersionAndFile();
+    const root = renderPanel({ file, version }, 'altSidePanel');
+
+    const overview = root.find(CodeOverview);
+    expect(overview).toHaveLength(1);
+    expect(overview).toHaveProp('content', file.content);
+    expect(overview).toHaveProp('version', version);
+  });
+
+  it('does not render CodeOverview without a file', () => {
+    const root = renderPanel({ file: null }, 'altSidePanel');
+
+    expect(root.find(CodeOverview)).toHaveLength(0);
+  });
+
+  it('does not render CodeOverview content for images', () => {
+    const path = 'image.png';
+    const entry = createFakeEntry('image', path, 'image/png');
+    const fileContent = 'some image data';
+
+    const { file, version } = getInternalVersionAndFile({
+      fileContent,
+      path,
+      entry,
+    });
+    const root = renderPanel({ file, version }, 'altSidePanel');
+
+    const overview = root.find(CodeOverview);
+    expect(overview).toHaveProp('content', '');
+  });
+});

--- a/src/components/VersionFileViewer/index.tsx
+++ b/src/components/VersionFileViewer/index.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+
+import AccordionMenu, { AccordionItem } from '../AccordionMenu';
+import CodeOverview from '../CodeOverview';
+import FileMetadata from '../FileMetadata';
+import FileTree, { PublicProps as FileTreeProps } from '../FileTree';
+import { ContentShell } from '../FullscreenGrid';
+import KeyboardShortcuts from '../KeyboardShortcuts';
+import Loading from '../Loading';
+import { Version, VersionFile } from '../../reducers/versions';
+import { AnyReactNode } from '../../typeUtils';
+import { gettext } from '../../utils';
+import styles from './styles.module.scss';
+
+export enum ItemTitles {
+  Files = 'Files',
+  Information = 'Information',
+  Shortcuts = 'Keyboard Shortcuts',
+}
+
+export type PublicProps = {
+  children: AnyReactNode;
+  file: VersionFile | null | void;
+  onSelectFile: FileTreeProps['onSelect'];
+  showFileInfo: boolean;
+  version: Version | void | null;
+};
+
+const VersionFileViewer = ({
+  children,
+  file,
+  onSelectFile,
+  showFileInfo,
+  version,
+}: PublicProps) => {
+  if (!version) {
+    return (
+      <ContentShell>
+        <Loading message={gettext('Loading version...')} />
+      </ContentShell>
+    );
+  }
+
+  return (
+    <ContentShell
+      mainSidePanel={
+        <AccordionMenu>
+          <AccordionItem expandedByDefault title={ItemTitles.Files}>
+            <FileTree onSelect={onSelectFile} versionId={version.id} />
+          </AccordionItem>
+          {showFileInfo ? (
+            <AccordionItem title={ItemTitles.Information}>
+              {file ? (
+                <FileMetadata file={file} />
+              ) : (
+                <Loading message={gettext('Loading file...')} />
+              )}
+            </AccordionItem>
+          ) : null}
+          <AccordionItem title={ItemTitles.Shortcuts}>
+            <KeyboardShortcuts
+              currentPath={version.selectedPath}
+              versionId={version.id}
+            />
+          </AccordionItem>
+        </AccordionMenu>
+      }
+      mainSidePanelClass={styles.mainSidePanel}
+      altSidePanel={
+        file ? (
+          <CodeOverview
+            content={file.type === 'image' ? '' : file.content}
+            version={version}
+          />
+        ) : null
+      }
+    >
+      {children}
+    </ContentShell>
+  );
+};
+
+export default VersionFileViewer;

--- a/src/components/VersionFileViewer/styles.module.scss
+++ b/src/components/VersionFileViewer/styles.module.scss
@@ -1,0 +1,4 @@
+.mainSidePanel {
+  border: none;
+  padding: 0;
+}

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { Col, Row } from 'react-bootstrap';
 import log from 'loglevel';
 
 import { ApplicationState } from '../../reducers';
 import { ConnectedReduxProps } from '../../configureStore';
 import { ApiState } from '../../reducers/api';
-import CodeOverview from '../../components/CodeOverview';
-import { ContentShell } from '../../components/FullscreenGrid';
-import FileTree from '../../components/FileTree';
+import VersionFileViewer from '../../components/VersionFileViewer';
 import {
   Version,
   VersionFile,
@@ -23,9 +20,7 @@ import {
 import { gettext, getPathFromQueryString } from '../../utils';
 import Loading from '../../components/Loading';
 import CodeView from '../../components/CodeView';
-import FileMetadata from '../../components/FileMetadata';
 import ImageView from '../../components/ImageView';
-import styles from './styles.module.scss';
 
 export type PublicProps = {};
 
@@ -148,39 +143,15 @@ export class BrowseBase extends React.Component<Props> {
   render() {
     const { file, version } = this.props;
 
-    if (!version) {
-      return (
-        <ContentShell>
-          <Loading message={gettext('Loading version...')} />
-        </ContentShell>
-      );
-    }
-
     return (
-      <ContentShell
-        mainSidePanel={
-          <React.Fragment>
-            <FileTree onSelect={this.viewVersionFile} versionId={version.id} />
-            {file && (
-              <Row>
-                <Col className={styles.metadata}>
-                  <FileMetadata file={file} />
-                </Col>
-              </Row>
-            )}
-          </React.Fragment>
-        }
-        altSidePanel={
-          file ? (
-            <CodeOverview
-              content={file.type === 'image' ? '' : file.content}
-              version={version}
-            />
-          ) : null
-        }
+      <VersionFileViewer
+        file={file}
+        onSelectFile={this.viewVersionFile}
+        showFileInfo
+        version={version}
       >
         {this.getContent()}
-      </ContentShell>
+      </VersionFileViewer>
     );
   }
 }

--- a/src/pages/Browse/styles.module.scss
+++ b/src/pages/Browse/styles.module.scss
@@ -1,6 +1,0 @@
-@import '../../scss/variables';
-
-.metadata {
-  margin-bottom: $default-padding;
-  margin-top: $default-padding;
-}

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -8,7 +8,6 @@ import {
   createFakeLocation,
   createFakeThunk,
   fakeVersionWithDiff,
-  getContentShellPanel,
   shallowUntilTarget,
   spyOn,
 } from '../../test-helpers';
@@ -18,10 +17,9 @@ import {
   createInternalDiffs,
   createInternalVersion,
 } from '../../reducers/versions';
-import FileTree from '../../components/FileTree';
 import DiffView from '../../components/DiffView';
 import Loading from '../../components/Loading';
-import VersionChooser from '../../components/VersionChooser';
+import VersionFileViewer from '../../components/VersionFileViewer';
 import styles from './styles.module.scss';
 
 import Compare, { CompareBase, PublicProps, mapStateToProps } from '.';
@@ -170,20 +168,6 @@ describe(__filename, () => {
     };
   };
 
-  it('renders loading messages when no version has been loaded', () => {
-    const addonId = 123;
-    const root = render({ addonId: String(addonId) });
-
-    expect(
-      getContentShellPanel(root, 'mainSidePanel').find(Loading),
-    ).toHaveProp('message', 'Loading file tree...');
-    expect(root.find(Loading)).toHaveProp('message', 'Loading diff...');
-
-    // This component is always displayed.
-    expect(root.find(VersionChooser)).toHaveLength(1);
-    expect(root.find(VersionChooser)).toHaveProp('addonId', addonId);
-  });
-
   it('renders a loading message when no diff has been loaded', () => {
     const version = fakeVersionWithDiff;
     const store = configureStore();
@@ -195,12 +179,12 @@ describe(__filename, () => {
     expect(root.find(Loading)).toHaveProp('message', 'Loading diff...');
   });
 
-  it('renders a FileTree component when a diff has been loaded', () => {
+  it('renders a VersionFileViewer', () => {
     const { root, version } = loadDiffAndRender();
 
-    const tree = getContentShellPanel(root, 'mainSidePanel').find(FileTree);
-    expect(tree).toHaveLength(1);
-    expect(tree).toHaveProp('versionId', version.id);
+    const viewer = root.find(VersionFileViewer);
+    expect(viewer).toHaveLength(1);
+    expect(viewer).toHaveProp('version', createInternalVersion(version));
   });
 
   it('renders a DiffView', () => {
@@ -285,9 +269,6 @@ describe(__filename, () => {
       store,
     });
 
-    expect(
-      getContentShellPanel(root, 'mainSidePanel').find(`.${styles.error}`),
-    ).toHaveLength(1);
     expect(root.find(`.${styles.error}`)).toHaveLength(1);
   });
 
@@ -522,9 +503,7 @@ describe(__filename, () => {
 
     dispatch.mockClear();
 
-    const onSelectFile = getContentShellPanel(root, 'mainSidePanel')
-      .find(FileTree)
-      .prop('onSelect');
+    const onSelectFile = root.find(VersionFileViewer).prop('onSelectFile');
     onSelectFile(path);
 
     expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -4,11 +4,10 @@ import { connect } from 'react-redux';
 
 import { ApplicationState } from '../../reducers';
 import { ConnectedReduxProps } from '../../configureStore';
-import { ContentShell } from '../../components/FullscreenGrid';
-import FileTree from '../../components/FileTree';
 import DiffView from '../../components/DiffView';
 import Loading from '../../components/Loading';
 import VersionChooser from '../../components/VersionChooser';
+import VersionFileViewer from '../../components/VersionFileViewer';
 import {
   CompareInfo,
   Version,
@@ -135,15 +134,14 @@ export class CompareBase extends React.Component<Props> {
   render() {
     const { addonId, compareInfo, path, version } = this.props;
 
+    // TODO: set showFileInfo=true when we can:
+    // https://github.com/mozilla/addons-code-manager/issues/647
     return (
-      <ContentShell
-        mainSidePanel={
-          version ? (
-            <FileTree onSelect={this.viewVersionFile} versionId={version.id} />
-          ) : (
-            this.renderLoadingMessageOrError(gettext('Loading file tree...'))
-          )
-        }
+      <VersionFileViewer
+        file={null}
+        onSelectFile={this.viewVersionFile}
+        showFileInfo={false}
+        version={version}
       >
         <div className={styles.diffShell}>
           <VersionChooser addonId={addonId} />
@@ -160,7 +158,7 @@ export class CompareBase extends React.Component<Props> {
             this.renderLoadingMessageOrError(gettext('Loading diff...'))
           )}
         </div>
-      </ContentShell>
+      </VersionFileViewer>
     );
   }
 }

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -30,7 +30,7 @@ import {
 import LinterProvider, {
   LinterProviderInfo,
 } from './components/LinterProvider';
-import { ContentShell } from './components/FullscreenGrid';
+import { ContentShell, PanelAttribs } from './components/FullscreenGrid';
 
 /* eslint-disable @typescript-eslint/camelcase */
 
@@ -601,7 +601,7 @@ export const simulateLinterProvider = (
  */
 export const getContentShellPanel = (
   root: ShallowWrapper,
-  panelAttr: 'mainSidePanel' | 'altSidePanel',
+  panelAttr: PanelAttribs,
 ) => {
   const panel = root.find(ContentShell).prop(panelAttr);
   return shallow(<div>{panel}</div>);

--- a/stories/FileTreeNode.stories.tsx
+++ b/stories/FileTreeNode.stories.tsx
@@ -48,7 +48,12 @@ const render = ({
   store = configureStore(),
   ...props
 }: { store?: Store } & GetPropsParams = {}) => {
-  return renderWithStoreAndRouter(<FileTreeNode {...getProps(props)} />, store);
+  return renderWithStoreAndRouter(
+    <div className="FileTreeNodeStory-shell">
+      <FileTreeNode {...getProps(props)} />
+    </div>,
+    store,
+  );
 };
 
 storiesOf('FileTreeNode', module).addWithChapters('all variants', {

--- a/stories/setup/styles.scss
+++ b/stories/setup/styles.scss
@@ -48,6 +48,11 @@ body.fullscreen {
   }
 }
 
+.FileTreeNodeStory-shell {
+  border-radius: $border-radius;
+  border: 1px solid $light-gray;
+}
+
 .DiffViewStory-panel {
   border-radius: $border-radius;
   border: 1px solid $light-gray;


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/653

**NOTE**: in attempt to keep the patch small (ha), I deferred these tasks: 
- Decouple KeyboardShortcuts: https://github.com/mozilla/addons-code-manager/issues/678
- Fix hidden file menu issues: https://github.com/mozilla/addons-code-manager/issues/680

<details>
<summary>Screencast</summary>

![2019-05-03 09 13 00](https://user-images.githubusercontent.com/55398/57144197-2d072900-6d86-11e9-91ac-56a40ad2b29f.gif)


</details>

The compare page works, too, but I think it needs this tweak: https://github.com/mozilla/addons-code-manager/issues/679