### PR TITLE
Condense version compare dropdowns, make sticky

### DIFF
--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -154,6 +154,12 @@ export class DiffViewBase extends React.Component<Props> {
       // Remove the `#` if `location.hash` is defined
       location.hash.length > 2 ? [location.hash.substring(1)] : [];
 
+    const globalLinterMessages = selectedMessageMap
+      ? selectedMessageMap.global.map((message) => {
+          return <LinterMessage key={message.uid} message={message} />;
+        })
+      : [];
+
     return (
       <div className={styles.DiffView}>
         {diffs.length === 0 && (
@@ -165,10 +171,11 @@ export class DiffViewBase extends React.Component<Props> {
           </React.Fragment>
         )}
 
-        {selectedMessageMap &&
-          selectedMessageMap.global.map((message) => {
-            return <LinterMessage key={message.uid} message={message} />;
-          })}
+        {globalLinterMessages.length ? (
+          <div className={styles.globalLinterMessages}>
+            {globalLinterMessages}
+          </div>
+        ) : null}
 
         {diffs.map((diff) => {
           const { oldRevision, newRevision, hunks, type } = diff;

--- a/src/components/DiffView/styles.module.scss
+++ b/src/components/DiffView/styles.module.scss
@@ -1,22 +1,7 @@
 @import '../../scss/variables';
 
-// We add `.diff` to override the react-diff-view default style.
-.diff.diff {
-  border-bottom-left-radius: $border-radius;
-  border-bottom-right-radius: $border-radius;
-  border-collapse: separate;
-  border-color: $light-gray;
-  border-spacing: 0;
-  border-style: solid;
-  border-width: 0 1px 1px 1px;
-  margin-bottom: $default-padding;
-}
-
 .header {
   background-color: lighten($light-gray, 2);
-  border-top-left-radius: $border-radius;
-  border-top-right-radius: $border-radius;
-  border: 1px solid $light-gray;
   padding: $default-padding;
 }
 
@@ -59,6 +44,10 @@
   .diff-line .diff-code-selected {
     background-color: $light-gray;
   }
+}
+
+.globalLinterMessages {
+  padding: $default-padding $default-padding 0 $default-padding;
 }
 
 .inlineLinterMessages {

--- a/src/components/VersionChooser/index.spec.tsx
+++ b/src/components/VersionChooser/index.spec.tsx
@@ -115,14 +115,8 @@ describe(__filename, () => {
     const root = render({ addonId, store });
 
     expect(root.find(VersionSelect)).toHaveLength(2);
-    expect(root.find(VersionSelect).at(0)).toHaveProp(
-      'label',
-      'Choose an old version',
-    );
-    expect(root.find(VersionSelect).at(1)).toHaveProp(
-      'label',
-      'Choose a new version',
-    );
+    expect(root.find(VersionSelect).at(0)).toHaveProp('label', 'Old version');
+    expect(root.find(VersionSelect).at(1)).toHaveProp('label', 'New version');
     expect(root.find(VersionSelect).at(1)).toHaveProp('withLeftArrow', true);
   });
 

--- a/src/components/VersionChooser/index.tsx
+++ b/src/components/VersionChooser/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Col, Form, Row } from 'react-bootstrap';
+import { Form } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 
@@ -104,37 +104,31 @@ export class VersionChooserBase extends React.Component<Props> {
 
     return (
       <div className={styles.VersionChooser}>
-        <Form>
-          <Row className={styles.heading}>
-            <Col>
-              <h3>{gettext('Compare changes')}</h3>
-            </Col>
-          </Row>
+        <Form className={styles.form}>
+          <VersionSelect
+            className={styles.baseVersionSelect}
+            id="VersionSelect-oldVersion"
+            isLoading={!versionsMap}
+            isSelectable={_lowerVersionsThan(headVersionId)}
+            label={gettext('Old version')}
+            listedVersions={listedVersions}
+            onChange={this.onOldVersionChange}
+            unlistedVersions={unlistedVersions}
+            value={baseVersionId}
+          />
 
-          <Form.Row>
-            <VersionSelect
-              className={styles.baseVersionSelect}
-              isLoading={!versionsMap}
-              isSelectable={_lowerVersionsThan(headVersionId)}
-              label={gettext('Choose an old version')}
-              listedVersions={listedVersions}
-              onChange={this.onOldVersionChange}
-              unlistedVersions={unlistedVersions}
-              value={baseVersionId}
-            />
-
-            <VersionSelect
-              className={styles.headVersionSelect}
-              isLoading={!versionsMap}
-              isSelectable={_higherVersionsThan(baseVersionId)}
-              label={gettext('Choose a new version')}
-              listedVersions={listedVersions}
-              onChange={this.onNewVersionChange}
-              unlistedVersions={unlistedVersions}
-              value={headVersionId}
-              withLeftArrow
-            />
-          </Form.Row>
+          <VersionSelect
+            className={styles.headVersionSelect}
+            id="VersionSelect-newVersion"
+            isLoading={!versionsMap}
+            isSelectable={_higherVersionsThan(baseVersionId)}
+            label={gettext('New version')}
+            listedVersions={listedVersions}
+            onChange={this.onNewVersionChange}
+            unlistedVersions={unlistedVersions}
+            value={headVersionId}
+            withLeftArrow
+          />
         </Form>
       </div>
     );

--- a/src/components/VersionChooser/index.tsx
+++ b/src/components/VersionChooser/index.tsx
@@ -107,7 +107,7 @@ export class VersionChooserBase extends React.Component<Props> {
         <Form className={styles.form}>
           <VersionSelect
             className={styles.baseVersionSelect}
-            id="VersionSelect-oldVersion"
+            controlId="VersionSelect-oldVersion"
             isLoading={!versionsMap}
             isSelectable={_lowerVersionsThan(headVersionId)}
             label={gettext('Old version')}
@@ -119,7 +119,7 @@ export class VersionChooserBase extends React.Component<Props> {
 
           <VersionSelect
             className={styles.headVersionSelect}
-            id="VersionSelect-newVersion"
+            controlId="VersionSelect-newVersion"
             isLoading={!versionsMap}
             isSelectable={_higherVersionsThan(baseVersionId)}
             label={gettext('New version')}

--- a/src/components/VersionChooser/styles.module.scss
+++ b/src/components/VersionChooser/styles.module.scss
@@ -2,11 +2,9 @@
 
 .VersionChooser {
   background-color: #fff;
-  margin-bottom: $default-padding;
-  padding: $default-padding;
   width: 100%;
 }
 
-.heading {
-  margin-bottom: $default-padding;
+.form {
+  display: flex;
 }

--- a/src/components/VersionSelect/index.spec.tsx
+++ b/src/components/VersionSelect/index.spec.tsx
@@ -31,7 +31,7 @@ describe(__filename, () => {
     const versionsMap = createVersionsMap(versions);
 
     const allProps = {
-      id: 'anyIdString',
+      controlId: 'anyIdString',
       isLoading: false,
       isSelectable: jest.fn().mockReturnValue(true),
       label: 'select a version',
@@ -55,12 +55,11 @@ describe(__filename, () => {
     expect(root.find(Form.Label)).toIncludeText(label);
   });
 
-  it('associates a label with its control', () => {
-    const id = 'SomeIdString';
-    const root = render({ id });
+  it('assigns a controlId', () => {
+    const controlId = 'SomeIdString';
+    const root = render({ controlId });
 
-    expect(root.find(Form.Label)).toHaveProp('htmlFor', id);
-    expect(root.find(Form.Control)).toHaveProp('id', id);
+    expect(root.find(Form.Group)).toHaveProp('controlId', controlId);
   });
 
   it('does not render an arrow icon by default', () => {

--- a/src/components/VersionSelect/index.spec.tsx
+++ b/src/components/VersionSelect/index.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import { Form } from 'react-bootstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import Skeleton from '../Skeleton';
 import {
@@ -24,27 +25,23 @@ describe(__filename, () => {
   >;
 
   const render = ({
-    className = undefined,
-    isLoading = false,
-    isSelectable = jest.fn().mockReturnValue(true),
-    label = 'select a version',
-    onChange = jest.fn(),
-    value = undefined,
     versions = fakeVersionsList,
-    withLeftArrow = false,
+    ...props
   }: RenderParams = {}) => {
     const versionsMap = createVersionsMap(versions);
 
     const allProps = {
-      className,
-      isLoading,
-      isSelectable,
-      label,
+      id: 'anyIdString',
+      isLoading: false,
+      isSelectable: jest.fn().mockReturnValue(true),
+      label: 'select a version',
       listedVersions: versionsMap.listed,
-      onChange,
+      onChange: jest.fn(),
       unlistedVersions: versionsMap.unlisted,
-      value,
-      withLeftArrow,
+      value: undefined,
+      versions,
+      withLeftArrow: false,
+      ...props,
     };
 
     return shallow(<VersionSelect {...allProps} />);
@@ -58,16 +55,26 @@ describe(__filename, () => {
     expect(root.find(Form.Label)).toIncludeText(label);
   });
 
-  it('does not render an arrow by default', () => {
-    const root = render();
+  it('associates a label with its control', () => {
+    const id = 'SomeIdString';
+    const root = render({ id });
 
-    expect(root.find(`.${styles.arrow}`)).toHaveLength(0);
+    expect(root.find(Form.Label)).toHaveProp('htmlFor', id);
+    expect(root.find(Form.Control)).toHaveProp('id', id);
   });
 
-  it('renders an arrow when withLeftArrow is true', () => {
+  it('does not render an arrow icon by default', () => {
+    const root = render();
+
+    expect(root.find(FontAwesomeIcon)).toHaveLength(0);
+  });
+
+  it('renders an arrow icon when withLeftArrow is true', () => {
     const root = render({ withLeftArrow: true });
 
-    expect(root.find(`.${styles.arrow}`)).toHaveLength(1);
+    const icon = root.find(FontAwesomeIcon);
+    expect(icon).toHaveLength(1);
+    expect(icon).toHaveProp('icon', 'long-arrow-alt-left');
   });
 
   it('renders two lists of versions', () => {

--- a/src/components/VersionSelect/index.tsx
+++ b/src/components/VersionSelect/index.tsx
@@ -12,7 +12,7 @@ import styles from './styles.module.scss';
 
 export type PublicProps = {
   className?: string;
-  id: string;
+  controlId: string;
   isLoading: boolean;
   isSelectable: (version: VersionsListItem) => boolean;
   label: string;
@@ -52,7 +52,7 @@ class VersionSelectBase extends React.Component<PublicProps> {
   render() {
     const {
       className,
-      id,
+      controlId,
       isLoading,
       label,
       listedVersions,
@@ -66,11 +66,10 @@ class VersionSelectBase extends React.Component<PublicProps> {
         <Form.Group
           as={Col}
           className={makeClassName(className, styles.formGroup)}
+          controlId={controlId}
         >
           {withLeftArrow && <FontAwesomeIcon icon="long-arrow-alt-left" />}
-          <Form.Label className={styles.label} htmlFor={id}>
-            {label}
-          </Form.Label>
+          <Form.Label className={styles.label}>{label}</Form.Label>
           {isLoading ? (
             <div
               className={makeClassName(
@@ -83,12 +82,7 @@ class VersionSelectBase extends React.Component<PublicProps> {
               <Skeleton className={styles.simulatedFormControlSkeleton} />
             </div>
           ) : (
-            <Form.Control
-              id={id}
-              as="select"
-              value={value}
-              onChange={this.onChange}
-            >
+            <Form.Control as="select" value={value} onChange={this.onChange}>
               {listedVersions.length && (
                 <optgroup
                   className={styles.listedGroup}

--- a/src/components/VersionSelect/index.tsx
+++ b/src/components/VersionSelect/index.tsx
@@ -12,6 +12,7 @@ import styles from './styles.module.scss';
 
 export type PublicProps = {
   className?: string;
+  id: string;
   isLoading: boolean;
   isSelectable: (version: VersionsListItem) => boolean;
   label: string;
@@ -51,6 +52,7 @@ class VersionSelectBase extends React.Component<PublicProps> {
   render() {
     const {
       className,
+      id,
       isLoading,
       label,
       listedVersions,
@@ -61,14 +63,14 @@ class VersionSelectBase extends React.Component<PublicProps> {
 
     return (
       <React.Fragment>
-        {withLeftArrow && (
-          <div className={styles.arrow}>
-            <FontAwesomeIcon icon="long-arrow-alt-left" />
-          </div>
-        )}
-
-        <Form.Group as={Col} className={className}>
-          <Form.Label>{label}</Form.Label>
+        <Form.Group
+          as={Col}
+          className={makeClassName(className, styles.formGroup)}
+        >
+          {withLeftArrow && <FontAwesomeIcon icon="long-arrow-alt-left" />}
+          <Form.Label className={styles.label} htmlFor={id}>
+            {label}
+          </Form.Label>
           {isLoading ? (
             <div
               className={makeClassName(
@@ -81,7 +83,12 @@ class VersionSelectBase extends React.Component<PublicProps> {
               <Skeleton className={styles.simulatedFormControlSkeleton} />
             </div>
           ) : (
-            <Form.Control as="select" value={value} onChange={this.onChange}>
+            <Form.Control
+              id={id}
+              as="select"
+              value={value}
+              onChange={this.onChange}
+            >
               {listedVersions.length && (
                 <optgroup
                   className={styles.listedGroup}

--- a/src/components/VersionSelect/styles.module.scss
+++ b/src/components/VersionSelect/styles.module.scss
@@ -1,7 +1,4 @@
-.arrow {
-  margin: auto;
-  padding-top: 14px;
-}
+@import '../../scss/variables';
 
 .option {
   font-weight: 600;
@@ -17,5 +14,19 @@
 
   .simulatedFormControlSkeleton {
     width: 60px;
+  }
+}
+
+.formGroup {
+  align-items: center;
+  display: flex;
+}
+
+.label {
+  margin: 0 $default-padding;
+  white-space: nowrap;
+
+  &:first-child {
+    margin-left: 0;
   }
 }

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -7,8 +7,6 @@ import {
   createFakeHistory,
   createFakeLocation,
   createFakeThunk,
-  fakeExternalDiff,
-  fakeVersionEntry,
   fakeVersionWithDiff,
   getContentShellPanel,
   shallowUntilTarget,
@@ -17,10 +15,8 @@ import {
 import configureStore from '../../configureStore';
 import {
   actions as versionsActions,
-  createInternalCompareInfo,
   createInternalDiffs,
   createInternalVersion,
-  createInternalVersionEntry,
 } from '../../reducers/versions';
 import FileTree from '../../components/FileTree';
 import DiffView from '../../components/DiffView';
@@ -28,12 +24,7 @@ import Loading from '../../components/Loading';
 import VersionChooser from '../../components/VersionChooser';
 import styles from './styles.module.scss';
 
-import Compare, {
-  CompareBase,
-  PublicProps,
-  makeCompareInfoKey,
-  mapStateToProps,
-} from '.';
+import Compare, { CompareBase, PublicProps, mapStateToProps } from '.';
 
 describe(__filename, () => {
   type GetRouteParamsParams = {
@@ -634,72 +625,5 @@ describe(__filename, () => {
     });
 
     expect(dispatch).not.toHaveBeenCalled();
-  });
-
-  describe('makeCompareInfoKey', () => {
-    const fakeDiffWithContent = (path: string, allContent: string[]) => {
-      return {
-        ...fakeExternalDiff,
-        path,
-        hunks: [
-          {
-            ...fakeExternalDiff.hunks[0],
-            changes: allContent.map((content) => {
-              return {
-                ...fakeExternalDiff.hunks[0].changes[0],
-                content,
-              };
-            }),
-          },
-        ],
-      };
-    };
-
-    it('makes a key out of CompareInfo content', () => {
-      const baseVersionId = 1;
-      const headVersionId = 2;
-
-      const manifestContent1 = '[manifest content 1]';
-      const manifestContent2 = '[manifest content 2]';
-
-      const backgroundContent1 = '[background content 1]';
-      const backgroundContent2 = '[background content 2]';
-
-      const version = {
-        ...fakeVersionWithDiff,
-        id: headVersionId,
-        file: {
-          ...fakeVersionWithDiff.file,
-          diff: [
-            fakeDiffWithContent('manifest.json', [
-              manifestContent1,
-              manifestContent2,
-            ]),
-            fakeDiffWithContent('background.js', [
-              backgroundContent1,
-              backgroundContent2,
-            ]),
-          ],
-        },
-      };
-
-      expect(
-        makeCompareInfoKey(
-          createInternalCompareInfo({
-            baseVersionId,
-            headVersionId,
-            entry: createInternalVersionEntry(fakeVersionEntry),
-            version,
-          }),
-        ),
-      ).toEqual(
-        [
-          manifestContent1,
-          manifestContent2,
-          backgroundContent1,
-          backgroundContent2,
-        ].join(':'),
-      );
-    });
   });
 });

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -7,6 +7,8 @@ import {
   createFakeHistory,
   createFakeLocation,
   createFakeThunk,
+  fakeExternalDiff,
+  fakeVersionEntry,
   fakeVersionWithDiff,
   getContentShellPanel,
   shallowUntilTarget,
@@ -15,8 +17,10 @@ import {
 import configureStore from '../../configureStore';
 import {
   actions as versionsActions,
+  createInternalCompareInfo,
   createInternalDiffs,
   createInternalVersion,
+  createInternalVersionEntry,
 } from '../../reducers/versions';
 import FileTree from '../../components/FileTree';
 import DiffView from '../../components/DiffView';
@@ -24,7 +28,12 @@ import Loading from '../../components/Loading';
 import VersionChooser from '../../components/VersionChooser';
 import styles from './styles.module.scss';
 
-import Compare, { CompareBase, PublicProps, mapStateToProps } from '.';
+import Compare, {
+  CompareBase,
+  PublicProps,
+  makeCompareInfoKey,
+  mapStateToProps,
+} from '.';
 
 describe(__filename, () => {
   type GetRouteParamsParams = {
@@ -625,5 +634,72 @@ describe(__filename, () => {
     });
 
     expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  describe('makeCompareInfoKey', () => {
+    const fakeDiffWithContent = (path: string, allContent: string[]) => {
+      return {
+        ...fakeExternalDiff,
+        path,
+        hunks: [
+          {
+            ...fakeExternalDiff.hunks[0],
+            changes: allContent.map((content) => {
+              return {
+                ...fakeExternalDiff.hunks[0].changes[0],
+                content,
+              };
+            }),
+          },
+        ],
+      };
+    };
+
+    it('makes a key out of CompareInfo content', () => {
+      const baseVersionId = 1;
+      const headVersionId = 2;
+
+      const manifestContent1 = '[manifest content 1]';
+      const manifestContent2 = '[manifest content 2]';
+
+      const backgroundContent1 = '[background content 1]';
+      const backgroundContent2 = '[background content 2]';
+
+      const version = {
+        ...fakeVersionWithDiff,
+        id: headVersionId,
+        file: {
+          ...fakeVersionWithDiff.file,
+          diff: [
+            fakeDiffWithContent('manifest.json', [
+              manifestContent1,
+              manifestContent2,
+            ]),
+            fakeDiffWithContent('background.js', [
+              backgroundContent1,
+              backgroundContent2,
+            ]),
+          ],
+        },
+      };
+
+      expect(
+        makeCompareInfoKey(
+          createInternalCompareInfo({
+            baseVersionId,
+            headVersionId,
+            entry: createInternalVersionEntry(fakeVersionEntry),
+            version,
+          }),
+        ),
+      ).toEqual(
+        [
+          manifestContent1,
+          manifestContent2,
+          backgroundContent1,
+          backgroundContent2,
+        ].join(':'),
+      );
+    });
   });
 });

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -20,18 +20,6 @@ import {
 import { gettext, getPathFromQueryString } from '../../utils';
 import styles from './styles.module.scss';
 
-export const makeCompareInfoKey = (info: CompareInfo) => {
-  const changes = [];
-  for (const diff of info.diffs) {
-    for (const hunk of diff.hunks) {
-      for (const change of hunk.changes) {
-        changes.push(change.content);
-      }
-    }
-  }
-  return changes.join(':');
-};
-
 export type PublicProps = {
   _fetchDiff: typeof fetchDiff;
   _viewVersionFile: typeof viewVersionFile;
@@ -145,7 +133,7 @@ export class CompareBase extends React.Component<Props> {
   }
 
   render() {
-    const { addonId, compareInfo, version } = this.props;
+    const { addonId, compareInfo, path, version } = this.props;
 
     return (
       <ContentShell
@@ -160,10 +148,7 @@ export class CompareBase extends React.Component<Props> {
         <div className={styles.diffShell}>
           <VersionChooser addonId={addonId} />
           {version && compareInfo ? (
-            <div
-              key={makeCompareInfoKey(compareInfo)}
-              className={styles.diffContent}
-            >
+            <div key={`${version.id}:${path}`} className={styles.diffContent}>
               {/* The key in this ^ resets scrollbars between files */}
               <DiffView
                 diffs={compareInfo.diffs}

--- a/src/pages/Compare/styles.module.scss
+++ b/src/pages/Compare/styles.module.scss
@@ -1,0 +1,14 @@
+@import '../../scss/variables';
+
+.diffShell {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.diffContent {
+  border-radius: $border-radius;
+  border: 1px solid $light-gray;
+  overflow: auto;
+}

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -699,6 +699,27 @@ export const getCompareInfoKey = ({
   return [addonId, baseVersionId, headVersionId, path].join('/');
 };
 
+export const createInternalCompareInfo = ({
+  baseVersionId,
+  headVersionId,
+  entry,
+  version,
+}: {
+  baseVersionId: number;
+  headVersionId: number;
+  entry: VersionEntry;
+  version: ExternalVersionWithDiff;
+}): CompareInfo => {
+  return {
+    diffs: createInternalDiffs({
+      baseVersionId,
+      headVersionId,
+      version,
+    }),
+    mimeType: entry.mimeType,
+  };
+};
+
 export const getCompareInfo = (
   versions: VersionsState,
   addonId: number,
@@ -1086,14 +1107,12 @@ const reducer: Reducer<VersionsState, ActionType<typeof actions>> = (
         ...state,
         compareInfo: {
           ...state.compareInfo,
-          [compareInfoKey]: {
-            diffs: createInternalDiffs({
-              baseVersionId,
-              headVersionId,
-              version,
-            }),
-            mimeType: entry.mimeType,
-          },
+          [compareInfoKey]: createInternalCompareInfo({
+            baseVersionId,
+            headVersionId,
+            entry,
+            version,
+          }),
         },
         compareInfoIsLoading: {
           ...state.compareInfoIsLoading,

--- a/stories/DiffView.stories.tsx
+++ b/stories/DiffView.stories.tsx
@@ -29,7 +29,12 @@ const render = (
     ...moreProps,
   };
 
-  return renderWithStoreAndRouter(<DiffView {...props} />, store);
+  return renderWithStoreAndRouter(
+    <div className="DiffViewStory-panel">
+      <DiffView {...props} />
+    </div>,
+    store,
+  );
 };
 
 const renderWithMessages = (

--- a/stories/setup/styles.scss
+++ b/stories/setup/styles.scss
@@ -48,6 +48,11 @@ body.fullscreen {
   }
 }
 
+.DiffViewStory-panel {
+  border-radius: $border-radius;
+  border: 1px solid $light-gray;
+}
+
 .CodeView-panel {
   border-radius: $border-radius;
   border: 1px solid $light-gray;


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/679

Additionally, I associated labels and dropdowns for accessibility.

<details>
<summary>Before</summary>

![2019-05-03 08 48 27](https://user-images.githubusercontent.com/55398/57141727-89674a00-6d80-11e9-8327-e246cf6df6a1.gif)

</details>


<details>
<summary>After</summary>

![2019-05-03 13 20 02](https://user-images.githubusercontent.com/55398/57157421-461fd200-6da6-11e9-9ac6-a6210e7099b3.gif)


</details>
