### PR TITLE
Format query params sent to the API

### DIFF
--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -16,6 +16,7 @@ import {
   isErrorResponse,
   logOutFromServer,
   makeApiURL,
+  makeQueryString,
 } from '.';
 
 describe(__filename, () => {
@@ -188,6 +189,22 @@ describe(__filename, () => {
         expect.urlWithTheseParams(query),
         expect.any(Object),
       );
+    });
+
+    it('calls makeQueryString to construct the query string', async () => {
+      const _makeQueryString = jest.fn();
+      const query = { foo: '1', bar: 'abc' };
+
+      await callApiWithDefaultApiState({
+        _makeQueryString,
+        endpoint: '/url',
+        // Here, we disable the lang so that only `query` is passed to
+        // `makeQueryString()`.
+        lang: null,
+        query,
+      });
+
+      expect(_makeQueryString).toHaveBeenCalledWith(query);
     });
 
     it('can include credentials', async () => {
@@ -487,6 +504,49 @@ describe(__filename, () => {
       expect(() => {
         makeApiURL({});
       }).toThrow(/Either `path` or `url` must be defined/);
+    });
+  });
+
+  describe('makeQueryString', () => {
+    it('transforms an object to a query string', () => {
+      const query = makeQueryString({ user: 123, addon: 321 });
+      expect(query).toContain('user=123');
+      expect(query).toContain('addon=321');
+    });
+
+    it('ignores undefined query string values', () => {
+      const query = makeQueryString({ user: undefined, addon: 321 });
+      expect(query).toEqual('?addon=321');
+    });
+
+    it('ignores null query string values', () => {
+      const query = makeQueryString({ user: null, addon: 321 });
+      expect(query).toEqual('?addon=321');
+    });
+
+    it('ignores empty string query string values', () => {
+      const query = makeQueryString({ user: '', addon: 321 });
+      expect(query).toEqual('?addon=321');
+    });
+
+    it('handles falsey integers', () => {
+      const query = makeQueryString({ flag: 0 });
+      expect(query).toEqual('?flag=0');
+    });
+
+    it('handles truthy integers', () => {
+      const query = makeQueryString({ flag: 1 });
+      expect(query).toEqual('?flag=1');
+    });
+
+    it('handles false values', () => {
+      const query = makeQueryString({ flag: false });
+      expect(query).toEqual('?flag=false');
+    });
+
+    it('handles true values', () => {
+      const query = makeQueryString({ flag: true });
+      expect(query).toEqual('?flag=true');
     });
   });
 });

--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -510,7 +510,9 @@ describe(__filename, () => {
   describe('makeQueryString', () => {
     it('transforms an object to a query string', () => {
       const query = makeQueryString({ user: 123, addon: 321 });
-      expect(query).toEqual(expect.urlWithTheseParams({ addon: '321' }));
+      expect(query).toEqual(
+        expect.urlWithTheseParams({ user: '123', addon: '321' }),
+      );
     });
 
     it('ignores undefined query string values', () => {

--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -510,8 +510,7 @@ describe(__filename, () => {
   describe('makeQueryString', () => {
     it('transforms an object to a query string', () => {
       const query = makeQueryString({ user: 123, addon: 321 });
-      expect(query).toContain('user=123');
-      expect(query).toContain('addon=321');
+      expect(query).toEqual(expect.urlWithTheseParams({ addon: '321' }));
     });
 
     it('ignores undefined query string values', () => {
@@ -531,22 +530,22 @@ describe(__filename, () => {
 
     it('handles falsey integers', () => {
       const query = makeQueryString({ flag: 0 });
-      expect(query).toEqual('?flag=0');
+      expect(query).toEqual(expect.urlWithTheseParams({ flag: '0' }));
     });
 
     it('handles truthy integers', () => {
       const query = makeQueryString({ flag: 1 });
-      expect(query).toEqual('?flag=1');
+      expect(query).toEqual(expect.urlWithTheseParams({ flag: '1' }));
     });
 
     it('handles false values', () => {
       const query = makeQueryString({ flag: false });
-      expect(query).toEqual('?flag=false');
+      expect(query).toEqual(expect.urlWithTheseParams({ flag: 'false' }));
     });
 
     it('handles true values', () => {
       const query = makeQueryString({ flag: true });
-      expect(query).toEqual('?flag=true');
+      expect(query).toEqual(expect.urlWithTheseParams({ flag: 'true' }));
     });
   });
 });

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -80,7 +80,9 @@ export const makeApiURL = ({
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const makeQueryString = (query: { [key: string]: any }) => {
+export const makeQueryString = (query: {
+  [key: string]: string | number | null | void | boolean;
+}) => {
   const resolvedQuery = { ...query };
   Object.keys(resolvedQuery).forEach((key) => {
     const value = resolvedQuery[key];

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -79,7 +79,6 @@ export const makeApiURL = ({
   return parts.join('');
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const makeQueryString = (query: {
   [key: string]: string | number | null | void | boolean;
 }) => {


### PR DESCRIPTION
Fixes #164
Fixes #666 😈 

---

You can try this patch by browsing: http://localhost:3000/en-US/browse/616714/versions/1688036/?path=%3Cscript%3Ealert%281%29%3B