### PR TITLE
Add an env to use code-manager with a local olympia instance

### DIFF
--- a/.env.olympia
+++ b/.env.olympia
@@ -1,0 +1,12 @@
+# This is a special configuration file for running code-manager locally using a
+# local addons-server instance.
+
+REACT_APP_API_HOST=http://olympia.test
+
+# The default port (`3000`) is taken by addons-frontend when we run the whole
+# addons-server stack.
+PORT=4000
+
+REACT_APP_USE_INSECURE_PROXY=true
+REACT_APP_CRA_PORT=3100
+REACT_APP_IS_LOCAL_DEV=true

--- a/.env.olympia
+++ b/.env.olympia
@@ -5,7 +5,7 @@ REACT_APP_API_HOST=http://olympia.test
 
 # The default port (`3000`) is taken by addons-frontend when we run the whole
 # addons-server stack.
-PORT=4000
+PORT=5000
 
 REACT_APP_USE_INSECURE_PROXY=true
 REACT_APP_CRA_PORT=3100

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ This runs [ESLint][] to discover problems within our codebase without executing 
 
 This runs all the _lint_ commands at once.
 
+### `yarn olympia`
+
+A prerequisite to run this command is to [install addons-server locally](https://addons-server.readthedocs.io/en/latest/topics/install/index.html).
+
+This runs all development processes in a single column using [stmux][]. Open [http://olympia.dev:4000](http://olympia.dev:4000) to view the development site. **Press CTRL-a-? for help**. The application is configured to use a [local AMO API](https://addons-server.readthedocs.io/).
+
+Known issue: it is possible to login/logout but the login process will redirect you to the AMO frontend (http://olympia.dev) instead of http://olympia.dev:4000. You will have to manually go to code-manager, after that there should be no other authentication problem.
+
 ### `yarn prettier`
 
 This runs [Prettier][] to automatically format the entire codebase.

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ This runs all the _lint_ commands at once.
 
 A prerequisite to run this command is to [install addons-server locally](https://addons-server.readthedocs.io/en/latest/topics/install/index.html).
 
-This runs all development processes in a single column using [stmux][]. Open [http://olympia.dev:4000](http://olympia.dev:4000) to view the development site. **Press CTRL-a-? for help**. The application is configured to use a [local AMO API](https://addons-server.readthedocs.io/).
+This runs all development processes in a single column using [stmux][]. Open [http://olympia.test:5000](http://olympia.test:5000) to view the development site. **Press CTRL-a-? for help**. The application is configured to use a [local AMO API](https://addons-server.readthedocs.io/).
 
-Known issue: it is possible to login/logout but the login process will redirect you to the AMO frontend (http://olympia.dev) instead of http://olympia.dev:4000. You will have to manually go to code-manager, after that there should be no other authentication problem.
+Known issue: it is possible to login/logout but the login process will redirect you to the AMO frontend (http://olympia.test) instead of http://olympia.test:5000. You will have to manually go to code-manager, after that there should be no other authentication problem.
 
 ### `yarn prettier`
 

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
   "scripts": {
     "build": "react-scripts build",
     "build-local-dev-config": "cat .env.dev .env.common-local > .env.local",
+    "build-local-olympia-config": "cat .env.olympia > .env.local",
     "build-local-stage-config": "cat .env.stage .env.common-local > .env.local",
     "dev": "yarn build-local-dev-config && yarn stmux-dev",
     "dev-2col": "yarn build-local-dev-config && yarn stmux [ 'yarn test' .. [ 'tsc -w' : 'yarn react-scripts-start' : 'yarn serve-dev' ] ]",
@@ -108,6 +109,7 @@
     "eject": "react-scripts eject",
     "eslint": "eslint --ext ts --ext js --ext tsx src/",
     "lint": "yarn eslint",
+    "olympia": "yarn build-local-olympia-config && yarn stmux-dev",
     "prettier": "prettier --write '**'",
     "prettier-ci": "prettier --list-different '**' || (echo '\n\nThis failure means you did not run `yarn prettier-dev` before committing\n\n' && exit 1)",
     "prettier-dev": "pretty-quick --branch master",

--- a/src/components/LoginButton/index.spec.tsx
+++ b/src/components/LoginButton/index.spec.tsx
@@ -7,8 +7,18 @@ import { makeApiURL } from '../../api';
 import LoginButton from '.';
 
 describe(__filename, () => {
-  const render = ({ fxaConfig = 'fxa', _window = window } = {}) => {
-    return shallow(<LoginButton fxaConfig={fxaConfig} _window={_window} />);
+  const render = ({
+    _window = window,
+    fxaConfig = 'fxa',
+    isLocalDev = false,
+  } = {}) => {
+    return shallow(
+      <LoginButton
+        _window={_window}
+        fxaConfig={fxaConfig}
+        isLocalDev={isLocalDev}
+      />,
+    );
   };
 
   it('renders a login button', () => {
@@ -33,7 +43,7 @@ describe(__filename, () => {
     );
   });
 
-  it('passes a relative URL to addons-server when FxA config is `local`', () => {
+  it('passes a relative URL to addons-server in local dev', () => {
     const fxaConfig = 'local';
     const origin = 'https://example.org';
     const path = '/en-US/browse/4913/versions/1527/';
@@ -47,7 +57,7 @@ describe(__filename, () => {
       },
     };
 
-    const root = render({ fxaConfig, _window });
+    const root = render({ fxaConfig, _window, isLocalDev: true });
 
     expect(root.find(Button)).toHaveLength(1);
     expect(root.find(Button)).toHaveProp(

--- a/src/components/LoginButton/index.tsx
+++ b/src/components/LoginButton/index.tsx
@@ -10,6 +10,7 @@ type PublicProps = {};
 type DefaultProps = {
   _window: typeof window;
   fxaConfig: string;
+  isLocalDev: boolean;
 };
 
 type Props = PublicProps & DefaultProps;
@@ -18,14 +19,15 @@ export class LoginButtonBase extends React.Component<Props> {
   static defaultProps: DefaultProps = {
     _window: window,
     fxaConfig: process.env.REACT_APP_FXA_CONFIG as string,
+    isLocalDev: process.env.REACT_APP_IS_LOCAL_DEV === 'true',
   };
 
   getFxaURL() {
-    const { _window, fxaConfig } = this.props;
+    const { _window, fxaConfig, isLocalDev } = this.props;
     let { href } = _window.location;
 
-    // We use a relative URL for `local` FxA config.
-    if (fxaConfig === 'local') {
+    // We use a relative URL when we run the app locally.
+    if (isLocalDev) {
       href = href.replace(_window.location.origin, '');
     }
 


### PR DESCRIPTION
Fixes #710

---

This is a proposal to add a new env to code-manager that we can use with addons-server. I have been using this env for a while, then it broke because of the API version change (fixed in https://github.com/mozilla/addons-nginx/pull/11) today, so I fixed it and I am proposing it here now.

You can test it by installing addons-server and running `yarn olympia` in code-manager after that. Hopefully the added instructions are clear enough :)