### PR TITLE
[WIP] Toggle the main side panel

### DIFF
--- a/src/components/FullscreenGrid/ContentShell.spec.tsx
+++ b/src/components/FullscreenGrid/ContentShell.spec.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+
+import configureStore from '../../configureStore';
+import { shallowUntilTarget } from '../../test-helpers';
+import ContentShell, { ContentShellBase } from './ContentShell';
+
+describe(__filename, () => {
+  const render = (props = {}) => {
+    return shallowUntilTarget(<ContentShell {...props} />, ContentShellBase, {
+      shallowOptions: {
+        context: { store: configureStore() },
+      },
+    });
+  };
+
+  it('accepts a custom className', () => {
+    const className = 'MyContent';
+    const root = render({ className });
+
+    expect(root.find(`.${className}`)).toHaveLength(1);
+  });
+
+  it('renders children', () => {
+    const childClass = 'ChildExample';
+
+    const root = render({ children: <div className={childClass} /> });
+
+    expect(root.find(`.${childClass}`)).toHaveLength(1);
+  });
+
+  it('renders a mainSidePanel', () => {
+    const childClass = 'ChildExample';
+
+    const root = render({ mainSidePanel: <div className={childClass} /> });
+
+    expect(root.find(`.${childClass}`)).toHaveLength(1);
+  });
+
+  it('accepts a mainSidePanelClass', () => {
+    const customClass = 'Example';
+
+    const root = render({ mainSidePanelClass: customClass });
+
+    expect(root.find(`.${customClass}`)).toHaveLength(1);
+  });
+
+  it('renders an altSidePanel', () => {
+    const childClass = 'ChildExample';
+
+    const root = render({ altSidePanel: <div className={childClass} /> });
+
+    expect(root.find(`.${childClass}`)).toHaveLength(1);
+  });
+
+  it('accepts an altSidePanelClass', () => {
+    const customClass = 'Example';
+
+    const root = render({ altSidePanelClass: customClass });
+
+    expect(root.find(`.${customClass}`)).toHaveLength(1);
+  });
+});

--- a/src/components/FullscreenGrid/ContentShell.tsx
+++ b/src/components/FullscreenGrid/ContentShell.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react';
+import makeClassName from 'classnames';
+import { connect } from 'react-redux';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { ThunkDispatch } from '../../configureStore';
+import { ApplicationState } from '../../reducers';
+import { actions } from '../../reducers/fullscreenGrid';
+import { AnyReactNode } from '../../typeUtils';
+import { gettext } from '../../utils';
+import styles from './styles.module.scss';
+
+type ToggleButtonProps = {
+  label?: string;
+  onClick: () => void;
+  toggleLeft?: boolean;
+};
+
+const ToggleButton = ({
+  label,
+  onClick,
+  toggleLeft = false,
+}: ToggleButtonProps) => {
+  return (
+    <button
+      className={styles.ToggleButton}
+      onClick={onClick}
+      title={gettext('Toggle this panel')}
+      type="button"
+    >
+      <FontAwesomeIcon
+        icon={toggleLeft ? 'angle-double-left' : 'angle-double-right'}
+      />
+      {label ? ` ${label}` : null}
+    </button>
+  );
+};
+
+type PublicProps = {
+  altSidePanel?: AnyReactNode;
+  altSidePanelClass?: string;
+  children?: AnyReactNode;
+  className?: string;
+  mainSidePanel?: AnyReactNode;
+  mainSidePanelClass?: string;
+};
+
+type PropsFromState = {
+  mainSidePanelIsExpanded: boolean;
+};
+
+type DispatchProps = {
+  toggleMainSidePanel: () => void;
+};
+
+type Props = PublicProps & PropsFromState & DispatchProps;
+
+export const ContentShellBase = ({
+  altSidePanel,
+  altSidePanelClass,
+  children,
+  className,
+  mainSidePanel,
+  mainSidePanelClass,
+  mainSidePanelIsExpanded,
+  toggleMainSidePanel,
+}: Props) => {
+  return (
+    <React.Fragment>
+      <aside
+        aria-expanded={mainSidePanelIsExpanded ? 'true' : 'false'}
+        className={makeClassName(
+          styles.mainSidePanel,
+          {
+            [styles.isCollapsed]: !mainSidePanelIsExpanded,
+          },
+          mainSidePanelClass,
+        )}
+      >
+        {mainSidePanelIsExpanded ? (
+          <React.Fragment>
+            <div className={styles.mainSidePanelContent}>{mainSidePanel}</div>
+            <div className={styles.mainSidePanelCollapseButton}>
+              <ToggleButton
+                label={gettext('Collapse this panel')}
+                onClick={toggleMainSidePanel}
+                toggleLeft
+              />
+            </div>
+          </React.Fragment>
+        ) : (
+          <ToggleButton onClick={toggleMainSidePanel} />
+        )}
+      </aside>
+      <main className={makeClassName(styles.content, className)}>
+        {children}
+      </main>
+      <aside className={makeClassName(styles.altSidePanel, altSidePanelClass)}>
+        {altSidePanel}
+      </aside>
+    </React.Fragment>
+  );
+};
+
+const mapStateToProps = (state: ApplicationState): PropsFromState => {
+  return {
+    mainSidePanelIsExpanded: state.fullscreenGrid.mainSidePanelIsExpanded,
+  };
+};
+
+const mapDispatchToProps = (dispatch: ThunkDispatch): DispatchProps => {
+  return {
+    toggleMainSidePanel: () => dispatch(actions.toggleMainSidePanel()),
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ContentShellBase);

--- a/src/components/FullscreenGrid/index.spec.tsx
+++ b/src/components/FullscreenGrid/index.spec.tsx
@@ -1,13 +1,28 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 
-import FullscreenGrid, { Header, ContentShell } from '.';
+import configureStore from '../../configureStore';
+import { shallowUntilTarget } from '../../test-helpers';
+
+import FullscreenGrid, { Header, ContentShell, FullscreenGridBase } from '.';
 
 describe(__filename, () => {
+  it('exposes ContentShell to ensure backward compatibility', () => {
+    expect(ContentShell).toBeDefined();
+  });
+
   describe('FullscreenGrid', () => {
+    const render = (element: JSX.Element) => {
+      return shallowUntilTarget(element, FullscreenGridBase, {
+        shallowOptions: {
+          context: { store: configureStore() },
+        },
+      });
+    };
+
     it('accepts a custom className', () => {
       const className = 'MyGrid';
-      const root = shallow(
+      const root = render(
         <FullscreenGrid className={className}>
           <Header />
           <ContentShell />
@@ -20,7 +35,7 @@ describe(__filename, () => {
     it('renders children', () => {
       const childClass = 'ChildExample';
 
-      const root = shallow(
+      const root = render(
         <FullscreenGrid>
           <Header />
           <ContentShell>
@@ -51,59 +66,6 @@ describe(__filename, () => {
       );
 
       expect(root.find(`.${childClass}`)).toHaveLength(1);
-    });
-  });
-
-  describe('ContentShell', () => {
-    const render = (props = {}) => {
-      return shallow(<ContentShell {...props} />);
-    };
-
-    it('accepts a custom className', () => {
-      const className = 'MyContent';
-      const root = render({ className });
-
-      expect(root.find(`.${className}`)).toHaveLength(1);
-    });
-
-    it('renders children', () => {
-      const childClass = 'ChildExample';
-
-      const root = render({ children: <div className={childClass} /> });
-
-      expect(root.find(`.${childClass}`)).toHaveLength(1);
-    });
-
-    it('renders a mainSidePanel', () => {
-      const childClass = 'ChildExample';
-
-      const root = render({ mainSidePanel: <div className={childClass} /> });
-
-      expect(root.find(`.${childClass}`)).toHaveLength(1);
-    });
-
-    it('accepts a mainSidePanelClass', () => {
-      const customClass = 'Example';
-
-      const root = render({ mainSidePanelClass: customClass });
-
-      expect(root.find(`.${customClass}`)).toHaveLength(1);
-    });
-
-    it('renders an altSidePanel', () => {
-      const childClass = 'ChildExample';
-
-      const root = render({ altSidePanel: <div className={childClass} /> });
-
-      expect(root.find(`.${childClass}`)).toHaveLength(1);
-    });
-
-    it('accepts an altSidePanelClass', () => {
-      const customClass = 'Example';
-
-      const root = render({ altSidePanelClass: customClass });
-
-      expect(root.find(`.${customClass}`)).toHaveLength(1);
     });
   });
 });

--- a/src/components/FullscreenGrid/index.tsx
+++ b/src/components/FullscreenGrid/index.tsx
@@ -1,8 +1,24 @@
 import * as React from 'react';
 import makeClassName from 'classnames';
+import { connect } from 'react-redux';
 
+import { ApplicationState } from '../../reducers';
 import { AnyReactNode } from '../../typeUtils';
+import ContentShellComponent from './ContentShell';
 import styles from './styles.module.scss';
+
+type PropsFromState = {
+  mainSidePanelIsExpanded: boolean;
+};
+
+type PublicProps = {
+  children?: AnyReactNode;
+  className?: string;
+};
+
+type Props = PublicProps & PropsFromState;
+
+export type PanelAttribs = 'altSidePanel' | 'mainSidePanel';
 
 export const Header = ({
   children,
@@ -18,54 +34,32 @@ export const Header = ({
   );
 };
 
-export type PanelAttribs = 'altSidePanel' | 'mainSidePanel';
+export const ContentShell = ContentShellComponent;
 
-type ContentShellProps = {
-  altSidePanel?: AnyReactNode;
-  altSidePanelClass?: string;
-  children?: AnyReactNode;
-  className?: string;
-  mainSidePanel?: AnyReactNode;
-  mainSidePanelClass?: string;
-};
-
-export const ContentShell = ({
-  altSidePanel,
-  altSidePanelClass,
+export const FullscreenGridBase = ({
   children,
   className,
-  mainSidePanel,
-  mainSidePanelClass,
-}: ContentShellProps) => {
+  mainSidePanelIsExpanded,
+}: Props) => {
   return (
-    <React.Fragment>
-      <aside
-        className={makeClassName(styles.mainSidePanel, mainSidePanelClass)}
-      >
-        {mainSidePanel}
-      </aside>
-      <main className={makeClassName(styles.content, className)}>
-        {children}
-      </main>
-      <aside className={makeClassName(styles.altSidePanel, altSidePanelClass)}>
-        {altSidePanel}
-      </aside>
-    </React.Fragment>
-  );
-};
-
-const FullscreenGrid = ({
-  children,
-  className,
-}: {
-  children?: AnyReactNode;
-  className?: string;
-}) => {
-  return (
-    <div className={makeClassName(styles.FullscreenGrid, className)}>
+    <div
+      className={makeClassName(
+        styles.FullscreenGrid,
+        {
+          [styles.mainSidePanelIsCollapsed]: !mainSidePanelIsExpanded,
+        },
+        className,
+      )}
+    >
       {children}
     </div>
   );
 };
 
-export default FullscreenGrid;
+const mapStateToProps = (state: ApplicationState): PropsFromState => {
+  return {
+    mainSidePanelIsExpanded: state.fullscreenGrid.mainSidePanelIsExpanded,
+  };
+};
+
+export default connect(mapStateToProps)(FullscreenGridBase);

--- a/src/components/FullscreenGrid/styles.module.scss
+++ b/src/components/FullscreenGrid/styles.module.scss
@@ -10,6 +10,10 @@
   grid-template-columns: 2fr 5fr 1fr;
   grid-template-rows: min-content 1fr 0px;
   height: 100vh;
+
+  &.mainSidePanelIsCollapsed {
+    grid-template-columns: 40px 7fr 1fr;
+  }
 }
 
 .Header {
@@ -17,8 +21,17 @@
 }
 
 .mainSidePanel {
+  display: flex;
+  flex-direction: column;
   grid-area: FGMainSidePanel;
+  height: 100%;
+  justify-content: space-between;
   margin-left: $default-padding;
+
+  &.isCollapsed {
+    background-color: $light-gray;
+    padding: 0;
+  }
 }
 
 .altSidePanel {
@@ -38,4 +51,21 @@
   overflow-x: hidden;
   overflow-y: auto;
   padding: $default-padding;
+}
+
+.mainSidePanelContent {
+  height: calc(100% - 50px);
+}
+
+.mainSidePanelCollapseButton {
+  height: 40px;
+}
+
+.ToggleButton {
+  background-color: $light-gray;
+  border-radius: $border-radius;
+  border: 0;
+  height: 100%;
+  text-align: center;
+  width: 100%;
 }

--- a/src/reducers/fullscreenGrid.tsx
+++ b/src/reducers/fullscreenGrid.tsx
@@ -1,0 +1,31 @@
+import { Reducer } from 'redux';
+import { ActionType, createAction, getType } from 'typesafe-actions';
+
+export const actions = {
+  toggleMainSidePanel: createAction('TOGGLE_MAIN_SIDE_PANEL'),
+};
+
+export type FullscreenGridState = {
+  mainSidePanelIsExpanded: boolean;
+};
+
+export const initialState: FullscreenGridState = {
+  mainSidePanelIsExpanded: true,
+};
+
+const reducer: Reducer<FullscreenGridState, ActionType<typeof actions>> = (
+  state = initialState,
+  action,
+): FullscreenGridState => {
+  switch (action.type) {
+    case getType(actions.toggleMainSidePanel):
+      return {
+        ...state,
+        mainSidePanelIsExpanded: !state.mainSidePanelIsExpanded,
+      };
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/src/reducers/index.tsx
+++ b/src/reducers/index.tsx
@@ -6,6 +6,7 @@ import accordionMenu, { AccordionMenuState } from './accordionMenu';
 import api, { ApiState } from './api';
 import errors, { ErrorsState } from './errors';
 import fileTree, { FileTreeState } from './fileTree';
+import fullscreenGrid, { FullscreenGridState } from './fullscreenGrid';
 import linter, { LinterState } from './linter';
 import users, { UsersState } from './users';
 import versions, { VersionsState } from './versions';
@@ -15,6 +16,7 @@ export type ApplicationState = {
   api: ApiState;
   errors: ErrorsState;
   fileTree: FileTreeState;
+  fullscreenGrid: FullscreenGridState;
   linter: LinterState;
   router: RouterState;
   users: UsersState;
@@ -27,6 +29,7 @@ const createRootReducer = (history: History) => {
     api,
     errors,
     fileTree,
+    fullscreenGrid,
     linter,
     router: connectRouter(history),
     users,


### PR DESCRIPTION
This is a POC for #588. Once we have something like this, adding a keyboard shortcut will be trivial. You can't see it but there is a tooltip on the button that says "toggle this panel". In addtion, the "collapse ..." button is added by the `ContentShell`, so we can still put any content in the main side panel, without having to worry about positioning the button (we can see that in the screenshots below).

I'll split this patch if we agree to have such a feature.

## Gif

![2019-05-09 15 58 32](https://user-images.githubusercontent.com/217628/57459542-bda4a400-7273-11e9-907c-87ffa3a58a90.gif)

## Screenshots

![Screen Shot 2019-05-09 at 16 15 25](https://user-images.githubusercontent.com/217628/57460621-bc747680-7275-11e9-9276-70cc2b121fc8.png)
![Screen Shot 2019-05-09 at 16 15 19](https://user-images.githubusercontent.com/217628/57460623-bc747680-7275-11e9-940d-5afb6e38fac0.png)

---

What do you think?