### PR TITLE
Indicate file diff status in FileTreeNode

### DIFF
--- a/src/components/FileTreeNode/index.tsx
+++ b/src/components/FileTreeNode/index.tsx
@@ -233,14 +233,27 @@ export class FileTreeNodeBase<TreeNodeType> extends React.Component<Props> {
       return <div ref={this.nodeRef} {...props} />;
     };
 
+    const entryWasDeleted = entryStatus && entryStatus === 'D';
+    const entryWasModified = entryStatus && entryStatus === 'M';
+    const entryWasAdded = entryStatus && entryStatus === 'A';
+
+    let nodeTitle = gettext(`View ${node.name}`);
+    if (entryWasDeleted) {
+      nodeTitle = gettext(`${nodeTitle} (deleted)`);
+    } else if (entryWasModified) {
+      nodeTitle = gettext(`${nodeTitle} (modified)`);
+    } else if (entryWasAdded) {
+      nodeTitle = gettext(`${nodeTitle} (added)`);
+    }
+
     return (
       <React.Fragment>
         <ListGroup.Item as={ItemElement} {...listGroupItemProps}>
           <span
             className={makeClassName(styles.nodeItem, {
-              [styles.wasDeleted]: entryStatus && entryStatus === 'D',
-              [styles.wasModified]: entryStatus && entryStatus === 'M',
-              [styles.wasAdded]: entryStatus && entryStatus === 'A',
+              [styles.wasDeleted]: entryWasDeleted,
+              [styles.wasModified]: entryWasModified,
+              [styles.wasAdded]: entryWasAdded,
             })}
             style={{ paddingLeft: `${adjustedLevel * 10}px` }}
           >
@@ -249,7 +262,9 @@ export class FileTreeNodeBase<TreeNodeType> extends React.Component<Props> {
             ) : (
               <FontAwesomeIcon icon="file" />
             )}
-            <span className={styles.nodeName}>{node.name}</span>
+            <span title={nodeTitle} className={styles.nodeName}>
+              {node.name}
+            </span>
             {nodeIcons}
           </span>
         </ListGroup.Item>

--- a/src/components/FileTreeNode/index.tsx
+++ b/src/components/FileTreeNode/index.tsx
@@ -13,6 +13,7 @@ import LinterProvider, { LinterProviderInfo } from '../LinterProvider';
 import {
   Version,
   actions as versionsActions,
+  getMostRelevantEntryStatus,
   getVersionInfo,
 } from '../../reducers/versions';
 import {
@@ -180,6 +181,7 @@ export class FileTreeNodeBase<TreeNodeType> extends React.Component<Props> {
       node,
       onSelect,
       renderChildNodes,
+      version,
     } = this.props;
 
     const hasLinterMessages =
@@ -224,6 +226,9 @@ export class FileTreeNodeBase<TreeNodeType> extends React.Component<Props> {
       };
     }
 
+    const adjustedLevel = level + 1;
+    const entryStatus = getMostRelevantEntryStatus(version, node.id);
+
     const ItemElement = (props = {}) => {
       return <div ref={this.nodeRef} {...props} />;
     };
@@ -232,8 +237,12 @@ export class FileTreeNodeBase<TreeNodeType> extends React.Component<Props> {
       <React.Fragment>
         <ListGroup.Item as={ItemElement} {...listGroupItemProps}>
           <span
-            className={styles.nodeItem}
-            style={{ paddingLeft: `${level * 12}px` }}
+            className={makeClassName(styles.nodeItem, {
+              [styles.wasDeleted]: entryStatus && entryStatus === 'D',
+              [styles.wasModified]: entryStatus && entryStatus === 'M',
+              [styles.wasAdded]: entryStatus && entryStatus === 'A',
+            })}
+            style={{ paddingLeft: `${adjustedLevel * 10}px` }}
           >
             {isFolder ? (
               <FontAwesomeIcon icon={isExpanded ? 'folder-open' : 'folder'} />
@@ -251,7 +260,7 @@ export class FileTreeNodeBase<TreeNodeType> extends React.Component<Props> {
           ) : (
             <ListGroup.Item
               className={makeClassName(styles.node, styles.emptyNodeDirectory)}
-              style={{ paddingLeft: `${(level + 2) * 20}px` }}
+              style={{ paddingLeft: `${(adjustedLevel + 2) * 20}px` }}
             >
               {gettext('This folder is empty')}
             </ListGroup.Item>

--- a/src/components/FileTreeNode/styles.module.scss
+++ b/src/components/FileTreeNode/styles.module.scss
@@ -8,7 +8,9 @@
   flex-direction: row;
   flex-wrap: nowrap;
   justify-content: space-between;
-  padding: 0.5rem 1.25rem;
+  margin-left: 0;
+  margin-right: 0;
+  padding: 0;
 
   &:first-child {
     border-radius: 0;
@@ -23,8 +25,12 @@
 
 .nodeItem {
   align-items: flex-start;
+  // Set up a common border that can be colored in different ways
+  // according to the file status.
+  border-left: 10px solid transparent;
   display: flex;
   line-height: 1;
+  padding: 0.6rem 1.25rem 0.4rem 1.25rem;
   width: 100%;
 }
 
@@ -36,6 +42,8 @@
 
 .nodeName {
   overflow: hidden;
+  // This accounts for low hanging glyphs such as `g` in a way that
+  // does not disrupt the icon alignment (as opposed to using line-height)
   padding-bottom: 0.2rem;
   text-overflow: ellipsis;
   white-space: wrap;
@@ -64,4 +72,16 @@
 
 .isKnownLibrary {
   color: lighten($black, 50);
+}
+
+.wasDeleted {
+  border-left-color: $red;
+}
+
+.wasModified {
+  border-left-color: $orange;
+}
+
+.wasAdded {
+  border-left-color: $green;
 }

--- a/src/components/FileTreeNode/styles.module.scss
+++ b/src/components/FileTreeNode/styles.module.scss
@@ -75,10 +75,10 @@
 }
 
 .wasDeleted {
-  border-left-color: $diff-gutter-delete-color;
+  border-left-color: darken($diff-gutter-delete-color, 10);
 }
 
 .wasModified,
 .wasAdded {
-  border-left-color: $diff-gutter-insert-color;
+  border-left-color: darken($diff-gutter-insert-color, 10);
 }

--- a/src/components/FileTreeNode/styles.module.scss
+++ b/src/components/FileTreeNode/styles.module.scss
@@ -75,13 +75,10 @@
 }
 
 .wasDeleted {
-  border-left-color: $red;
+  border-left-color: $diff-gutter-delete-color;
 }
 
-.wasModified {
-  border-left-color: $orange;
-}
-
+.wasModified,
 .wasAdded {
-  border-left-color: $green;
+  border-left-color: $diff-gutter-insert-color;
 }

--- a/src/reducers/fileTree.spec.tsx
+++ b/src/reducers/fileTree.spec.tsx
@@ -20,7 +20,7 @@ import { getMessageMap } from './linter';
 import {
   createFakeExternalLinterResult,
   createFakeThunk,
-  createVersionWithEntries,
+  createVersionWithInternalEntries,
   fakeVersion,
   fakeVersionEntry,
   getFakeVersionAndPathList,
@@ -71,7 +71,7 @@ describe(__filename, () => {
 
   describe('buildFileTree', () => {
     it('creates a root node', () => {
-      const version = createVersionWithEntries([]);
+      const version = createVersionWithInternalEntries([]);
       const addonName = getLocalizedString(version.addon.name);
 
       const tree = buildFileTreeNodes(version);
@@ -92,7 +92,7 @@ describe(__filename, () => {
           filename,
         }),
       ];
-      const version = createVersionWithEntries(entries);
+      const version = createVersionWithInternalEntries(entries);
 
       const tree = buildFileTreeNodes(version);
 
@@ -113,7 +113,7 @@ describe(__filename, () => {
           filename,
         }),
       ];
-      const version = createVersionWithEntries(entries);
+      const version = createVersionWithInternalEntries(entries);
 
       const tree = buildFileTreeNodes(version);
 
@@ -144,7 +144,7 @@ describe(__filename, () => {
           path: `${directory}/${file}`,
         }),
       ];
-      const version = createVersionWithEntries(entries);
+      const version = createVersionWithInternalEntries(entries);
 
       const tree = buildFileTreeNodes(version);
 
@@ -181,7 +181,7 @@ describe(__filename, () => {
           path: `${badDirectoryName}/${file}`,
         }),
       ];
-      const version = createVersionWithEntries(entries);
+      const version = createVersionWithInternalEntries(entries);
 
       expect(() => {
         buildFileTreeNodes(version);
@@ -213,7 +213,7 @@ describe(__filename, () => {
           path: `${directoryName}/${directoryName}/${fileName}`,
         }),
       ];
-      const version = createVersionWithEntries(entries);
+      const version = createVersionWithInternalEntries(entries);
 
       const data = buildFileTreeNodes(version);
 
@@ -255,7 +255,7 @@ describe(__filename, () => {
           mime_category: 'directory',
         }),
       ];
-      const version = createVersionWithEntries(entries);
+      const version = createVersionWithInternalEntries(entries);
 
       const tree = buildFileTreeNodes(version);
 
@@ -292,7 +292,7 @@ describe(__filename, () => {
           filename: 'A',
         }),
       ];
-      const version = createVersionWithEntries(entries);
+      const version = createVersionWithInternalEntries(entries);
 
       const tree = buildFileTreeNodes(version);
 
@@ -325,7 +325,7 @@ describe(__filename, () => {
           mime_category: 'directory',
         }),
       ];
-      const version = createVersionWithEntries(entries);
+      const version = createVersionWithInternalEntries(entries);
 
       const tree = buildFileTreeNodes(version);
 
@@ -364,7 +364,7 @@ describe(__filename, () => {
           path: 'parent/A',
         }),
       ];
-      const version = createVersionWithEntries(entries);
+      const version = createVersionWithInternalEntries(entries);
 
       const tree = buildFileTreeNodes(version);
       const firstNode = tree.children[0] as DirectoryNode;
@@ -403,7 +403,7 @@ describe(__filename, () => {
           path: 'parent/A',
         }),
       ];
-      const version = createVersionWithEntries(entries);
+      const version = createVersionWithInternalEntries(entries);
 
       const tree = buildFileTreeNodes(version);
       const firstNode = tree.children[0] as DirectoryNode;

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -406,6 +406,25 @@ export const getVersionInfo = (versions: VersionsState, versionId: number) => {
   return versions.versionInfo[versionId];
 };
 
+export const getMostRelevantEntryStatus = (
+  version: Version,
+  path: string,
+): VersionEntryStatus | void => {
+  const statuses = version.entries
+    .filter((e) => e.path.startsWith(path))
+    .map((e) => e.status);
+
+  const priorities: VersionEntryStatus[] = ['A', 'M', 'D'];
+
+  for (const p of priorities) {
+    if (statuses.includes(p)) {
+      return p;
+    }
+  }
+
+  return statuses.length ? statuses[0] : undefined;
+};
+
 export const getVersionFile = (
   versions: VersionsState,
   versionId: number,

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -14,3 +14,10 @@ $alert-secondary-bg-color: #e2e3e5;
 $code-font-family: Consolas, Courier, monospace;
 $code-font-size: 16px;
 $code-line-height: 1.5;
+
+// These colors were copied from react-diff-view:
+// https://github.com/otakustay/react-diff-view/blob/0f0bbc77b7a3039d5a49303969c04f01122059c6/src/Hunk/Change.css
+// If they ever go out of sync, we'll have to define all of our
+// own colors explicitly and override the react-diff-view styles.
+$diff-gutter-delete-color: #fadde0;
+$diff-gutter-insert-color: #d6fedb;

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -1,3 +1,5 @@
+import pathLib from 'path';
+
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { History, Location } from 'history';
@@ -122,13 +124,45 @@ export const fakeVersion: ExternalVersionWithContent = Object.freeze({
   version: '1.0',
 });
 
-export const createVersionWithEntries = (
+export const createExternalVersionWithEntries = (
+  partialEntries: ({ path: string } & Partial<ExternalVersionEntry>)[],
+  versionProps: Partial<ExternalVersionWithContent> = {},
+) => {
+  return {
+    ...fakeVersion,
+    ...versionProps,
+    file: {
+      ...fakeVersion.file,
+      entries: partialEntries.reduce((entries, file) => {
+        return {
+          [file.path]: {
+            ...fakeVersionEntry,
+            filename: pathLib.basename(file.path),
+            path: file.path,
+            ...file,
+          },
+          ...entries,
+        };
+      }, {}),
+    },
+  };
+};
+
+// Try to use createVersionWithEntries instead, if possible, since that
+// one is composed of a realistic external object.
+export const createVersionWithInternalEntries = (
   entries: Version['entries'],
 ): Version => {
   return {
     ...createInternalVersion(fakeVersion),
     entries,
   };
+};
+
+export const createVersionWithEntries = (
+  ...args: Parameters<typeof createExternalVersionWithEntries>
+) => {
+  return createInternalVersion(createExternalVersionWithEntries(...args));
 };
 
 export const getFakeVersionAndPathList = (


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/413

I didn't have time to add a story but we could do that in https://github.com/mozilla/addons-code-manager/issues/431 💳 

Examples, mostly from http://localhost:3000/en-US/compare/616645/versions/1655530...1655531/?path=scripts/background.js

<img width="320" alt="Screenshot 2019-05-17 11 41 50" src="https://user-images.githubusercontent.com/55398/57943593-0672e300-789a-11e9-90bf-e647ccf6a1e0.png">
<img width="320" alt="Screenshot 2019-05-17 11 42 07" src="https://user-images.githubusercontent.com/55398/57943594-0672e300-789a-11e9-8519-7415332416bf.png">
<img width="320" alt="Screenshot 2019-05-17 11 42 30" src="https://user-images.githubusercontent.com/55398/57943595-070b7980-789a-11e9-8437-1d799f34b069.png">
<img width="320" alt="Screenshot 2019-05-17 11 42 51" src="https://user-images.githubusercontent.com/55398/57943596-070b7980-789a-11e9-8e61-aa6004ec5e45.png">
