### PR TITLE
Extract ContentShell component

### DIFF
--- a/src/components/App/index.spec.tsx
+++ b/src/components/App/index.spec.tsx
@@ -5,7 +5,7 @@ import { Route } from 'react-router-dom';
 
 import styles from './styles.module.scss';
 import configureStore from '../../configureStore';
-import { ContentShell } from '../FullscreenGrid';
+import ContentShell from '../FullscreenGrid/ContentShell';
 import { actions as apiActions } from '../../reducers/api';
 import { actions as errorsActions } from '../../reducers/errors';
 import { actions as userActions } from '../../reducers/users';

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -24,7 +24,8 @@ import {
   fetchCurrentUser,
   selectCurrentUser,
 } from '../../reducers/users';
-import FullscreenGrid, { ContentShell, Header } from '../FullscreenGrid';
+import ContentShell from '../FullscreenGrid/ContentShell';
+import FullscreenGrid, { Header } from '../FullscreenGrid';
 import Navbar from '../Navbar';
 import Browse from '../../pages/Browse';
 import Compare from '../../pages/Compare';

--- a/src/components/FullscreenGrid/ContentShell.spec.tsx
+++ b/src/components/FullscreenGrid/ContentShell.spec.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+
+import ContentShell from './ContentShell';
+
+describe(__filename, () => {
+  const render = (props = {}) => {
+    return shallow(<ContentShell {...props} />);
+  };
+
+  it('accepts a custom className', () => {
+    const className = 'MyContent';
+    const root = render({ className });
+
+    expect(root.find(`.${className}`)).toHaveLength(1);
+  });
+
+  it('renders children', () => {
+    const childClass = 'ChildExample';
+
+    const root = render({ children: <div className={childClass} /> });
+
+    expect(root.find(`.${childClass}`)).toHaveLength(1);
+  });
+
+  it('renders a mainSidePanel', () => {
+    const childClass = 'ChildExample';
+
+    const root = render({ mainSidePanel: <div className={childClass} /> });
+
+    expect(root.find(`.${childClass}`)).toHaveLength(1);
+  });
+
+  it('accepts a mainSidePanelClass', () => {
+    const customClass = 'Example';
+
+    const root = render({ mainSidePanelClass: customClass });
+
+    expect(root.find(`.${customClass}`)).toHaveLength(1);
+  });
+
+  it('renders an altSidePanel', () => {
+    const childClass = 'ChildExample';
+
+    const root = render({ altSidePanel: <div className={childClass} /> });
+
+    expect(root.find(`.${childClass}`)).toHaveLength(1);
+  });
+
+  it('accepts an altSidePanelClass', () => {
+    const customClass = 'Example';
+
+    const root = render({ altSidePanelClass: customClass });
+
+    expect(root.find(`.${customClass}`)).toHaveLength(1);
+  });
+});

--- a/src/components/FullscreenGrid/ContentShell.tsx
+++ b/src/components/FullscreenGrid/ContentShell.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import makeClassName from 'classnames';
+
+import { AnyReactNode } from '../../typeUtils';
+import styles from './styles.module.scss';
+
+type PublicProps = {
+  altSidePanel?: AnyReactNode;
+  altSidePanelClass?: string;
+  children?: AnyReactNode;
+  className?: string;
+  mainSidePanel?: AnyReactNode;
+  mainSidePanelClass?: string;
+};
+
+type Props = PublicProps;
+
+export const ContentShellBase = ({
+  altSidePanel,
+  altSidePanelClass,
+  children,
+  className,
+  mainSidePanel,
+  mainSidePanelClass,
+}: Props) => {
+  return (
+    <React.Fragment>
+      <aside
+        className={makeClassName(styles.mainSidePanel, mainSidePanelClass)}
+      >
+        {mainSidePanel}
+      </aside>
+      <main className={makeClassName(styles.content, className)}>
+        {children}
+      </main>
+      <aside className={makeClassName(styles.altSidePanel, altSidePanelClass)}>
+        {altSidePanel}
+      </aside>
+    </React.Fragment>
+  );
+};
+
+export default ContentShellBase;

--- a/src/components/FullscreenGrid/index.spec.tsx
+++ b/src/components/FullscreenGrid/index.spec.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 
-import FullscreenGrid, { Header, ContentShell } from '.';
+import ContentShell from './ContentShell';
+
+import FullscreenGrid, { Header } from '.';
 
 describe(__filename, () => {
-  it('exposes ContentShell', () => {
-    expect(ContentShell).toBeDefined();
-  });
-
   describe('FullscreenGrid', () => {
     it('accepts a custom className', () => {
       const className = 'MyGrid';

--- a/src/components/FullscreenGrid/index.spec.tsx
+++ b/src/components/FullscreenGrid/index.spec.tsx
@@ -4,6 +4,10 @@ import { shallow } from 'enzyme';
 import FullscreenGrid, { Header, ContentShell } from '.';
 
 describe(__filename, () => {
+  it('exposes ContentShell', () => {
+    expect(ContentShell).toBeDefined();
+  });
+
   describe('FullscreenGrid', () => {
     it('accepts a custom className', () => {
       const className = 'MyGrid';
@@ -51,59 +55,6 @@ describe(__filename, () => {
       );
 
       expect(root.find(`.${childClass}`)).toHaveLength(1);
-    });
-  });
-
-  describe('ContentShell', () => {
-    const render = (props = {}) => {
-      return shallow(<ContentShell {...props} />);
-    };
-
-    it('accepts a custom className', () => {
-      const className = 'MyContent';
-      const root = render({ className });
-
-      expect(root.find(`.${className}`)).toHaveLength(1);
-    });
-
-    it('renders children', () => {
-      const childClass = 'ChildExample';
-
-      const root = render({ children: <div className={childClass} /> });
-
-      expect(root.find(`.${childClass}`)).toHaveLength(1);
-    });
-
-    it('renders a mainSidePanel', () => {
-      const childClass = 'ChildExample';
-
-      const root = render({ mainSidePanel: <div className={childClass} /> });
-
-      expect(root.find(`.${childClass}`)).toHaveLength(1);
-    });
-
-    it('accepts a mainSidePanelClass', () => {
-      const customClass = 'Example';
-
-      const root = render({ mainSidePanelClass: customClass });
-
-      expect(root.find(`.${customClass}`)).toHaveLength(1);
-    });
-
-    it('renders an altSidePanel', () => {
-      const childClass = 'ChildExample';
-
-      const root = render({ altSidePanel: <div className={childClass} /> });
-
-      expect(root.find(`.${childClass}`)).toHaveLength(1);
-    });
-
-    it('accepts an altSidePanelClass', () => {
-      const customClass = 'Example';
-
-      const root = render({ altSidePanelClass: customClass });
-
-      expect(root.find(`.${customClass}`)).toHaveLength(1);
     });
   });
 });

--- a/src/components/FullscreenGrid/index.tsx
+++ b/src/components/FullscreenGrid/index.tsx
@@ -11,7 +11,10 @@ type PublicProps = {
 
 type Props = PublicProps;
 
-export type PanelAttribs = 'altSidePanel' | 'mainSidePanel';
+export enum PanelAttribs {
+  altSidePanel = 'altSidePanel',
+  mainSidePanel = 'mainSidePanel',
+}
 
 export const Header = ({
   children,

--- a/src/components/FullscreenGrid/index.tsx
+++ b/src/components/FullscreenGrid/index.tsx
@@ -2,7 +2,17 @@ import * as React from 'react';
 import makeClassName from 'classnames';
 
 import { AnyReactNode } from '../../typeUtils';
+import ContentShellComponent from './ContentShell';
 import styles from './styles.module.scss';
+
+type PublicProps = {
+  children?: AnyReactNode;
+  className?: string;
+};
+
+type Props = PublicProps;
+
+export type PanelAttribs = 'altSidePanel' | 'mainSidePanel';
 
 export const Header = ({
   children,
@@ -18,49 +28,9 @@ export const Header = ({
   );
 };
 
-export type PanelAttribs = 'altSidePanel' | 'mainSidePanel';
+export const ContentShell = ContentShellComponent;
 
-type ContentShellProps = {
-  altSidePanel?: AnyReactNode;
-  altSidePanelClass?: string;
-  children?: AnyReactNode;
-  className?: string;
-  mainSidePanel?: AnyReactNode;
-  mainSidePanelClass?: string;
-};
-
-export const ContentShell = ({
-  altSidePanel,
-  altSidePanelClass,
-  children,
-  className,
-  mainSidePanel,
-  mainSidePanelClass,
-}: ContentShellProps) => {
-  return (
-    <React.Fragment>
-      <aside
-        className={makeClassName(styles.mainSidePanel, mainSidePanelClass)}
-      >
-        {mainSidePanel}
-      </aside>
-      <main className={makeClassName(styles.content, className)}>
-        {children}
-      </main>
-      <aside className={makeClassName(styles.altSidePanel, altSidePanelClass)}>
-        {altSidePanel}
-      </aside>
-    </React.Fragment>
-  );
-};
-
-const FullscreenGrid = ({
-  children,
-  className,
-}: {
-  children?: AnyReactNode;
-  className?: string;
-}) => {
+export const FullscreenGridBase = ({ children, className }: Props) => {
   return (
     <div className={makeClassName(styles.FullscreenGrid, className)}>
       {children}
@@ -68,4 +38,4 @@ const FullscreenGrid = ({
   );
 };
 
-export default FullscreenGrid;
+export default FullscreenGridBase;

--- a/src/components/FullscreenGrid/index.tsx
+++ b/src/components/FullscreenGrid/index.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import makeClassName from 'classnames';
 
 import { AnyReactNode } from '../../typeUtils';
-import ContentShellComponent from './ContentShell';
 import styles from './styles.module.scss';
 
 type PublicProps = {
@@ -27,8 +26,6 @@ export const Header = ({
     </header>
   );
 };
-
-export const ContentShell = ContentShellComponent;
 
 export const FullscreenGridBase = ({ children, className }: Props) => {
   return (

--- a/src/components/VersionFileViewer/index.spec.tsx
+++ b/src/components/VersionFileViewer/index.spec.tsx
@@ -133,7 +133,10 @@ describe(__filename, () => {
     const onSelectFile = jest.fn();
     const { version } = getInternalVersionAndFile();
 
-    const root = renderPanel({ onSelectFile, version }, 'mainSidePanel');
+    const root = renderPanel(
+      { onSelectFile, version },
+      PanelAttribs.mainSidePanel,
+    );
 
     const tree = root.find(FileTree);
     expect(tree).toHaveLength(1);
@@ -143,7 +146,7 @@ describe(__filename, () => {
 
   it('shows an information panel by default', () => {
     const { file } = getInternalVersionAndFile();
-    const root = renderPanel({ file }, 'mainSidePanel');
+    const root = renderPanel({ file }, PanelAttribs.mainSidePanel);
     const item = getItem(root, ItemTitles.Information);
 
     const meta = item.find(FileMetadata);
@@ -151,7 +154,10 @@ describe(__filename, () => {
   });
 
   it('can hide the information panel', () => {
-    const root = renderPanel({ showFileInfo: false }, 'mainSidePanel');
+    const root = renderPanel(
+      { showFileInfo: false },
+      PanelAttribs.mainSidePanel,
+    );
 
     expect(getItem(root, ItemTitles.Information)).toHaveLength(0);
   });
@@ -159,7 +165,7 @@ describe(__filename, () => {
   it('renders a placeholder in the information panel without a file', () => {
     const root = renderPanel(
       { file: null, showFileInfo: true },
-      'mainSidePanel',
+      PanelAttribs.mainSidePanel,
     );
     const item = getItem(root, ItemTitles.Information);
 
@@ -169,7 +175,7 @@ describe(__filename, () => {
 
   it('renders a KeyboardShortcuts panel', () => {
     const { version } = getInternalVersionAndFile();
-    const root = renderPanel({ version }, 'mainSidePanel');
+    const root = renderPanel({ version }, PanelAttribs.mainSidePanel);
     const item = getItem(root, ItemTitles.Shortcuts);
 
     const shortcuts = item.find(KeyboardShortcuts);
@@ -180,7 +186,7 @@ describe(__filename, () => {
 
   it('renders CodeOverview', () => {
     const { file, version } = getInternalVersionAndFile();
-    const root = renderPanel({ file, version }, 'altSidePanel');
+    const root = renderPanel({ file, version }, PanelAttribs.altSidePanel);
 
     const overview = root.find(CodeOverview);
     expect(overview).toHaveLength(1);
@@ -189,7 +195,7 @@ describe(__filename, () => {
   });
 
   it('does not render CodeOverview without a file', () => {
-    const root = renderPanel({ file: null }, 'altSidePanel');
+    const root = renderPanel({ file: null }, PanelAttribs.altSidePanel);
 
     expect(root.find(CodeOverview)).toHaveLength(0);
   });
@@ -204,7 +210,7 @@ describe(__filename, () => {
       path,
       entry,
     });
-    const root = renderPanel({ file, version }, 'altSidePanel');
+    const root = renderPanel({ file, version }, PanelAttribs.altSidePanel);
 
     const overview = root.find(CodeOverview);
     expect(overview).toHaveProp('content', '');

--- a/src/components/VersionFileViewer/index.tsx
+++ b/src/components/VersionFileViewer/index.tsx
@@ -4,7 +4,7 @@ import AccordionMenu, { AccordionItem } from '../AccordionMenu';
 import CodeOverview from '../CodeOverview';
 import FileMetadata from '../FileMetadata';
 import FileTree, { PublicProps as FileTreeProps } from '../FileTree';
-import { ContentShell } from '../FullscreenGrid';
+import ContentShell from '../FullscreenGrid/ContentShell';
 import KeyboardShortcuts from '../KeyboardShortcuts';
 import Loading from '../Loading';
 import { Version, VersionFile } from '../../reducers/versions';

--- a/src/pages/Index/index.tsx
+++ b/src/pages/Index/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 
-import { ContentShell } from '../../components/FullscreenGrid';
+import ContentShell from '../../components/FullscreenGrid/ContentShell';
 import { gettext } from '../../utils';
 
 type Props = {

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -30,7 +30,8 @@ import {
 import LinterProvider, {
   LinterProviderInfo,
 } from './components/LinterProvider';
-import { ContentShell, PanelAttribs } from './components/FullscreenGrid';
+import ContentShell from './components/FullscreenGrid/ContentShell';
+import { PanelAttribs } from './components/FullscreenGrid';
 
 /* eslint-disable @typescript-eslint/camelcase */
 

--- a/stories/AccordionMenu.stories.tsx
+++ b/stories/AccordionMenu.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
-import FullscreenGrid, { ContentShell } from '../src/components/FullscreenGrid';
+import ContentShell from '../src/components/FullscreenGrid/ContentShell';
+import FullscreenGrid from '../src/components/FullscreenGrid';
 import AccordionMenu, { AccordionItem } from '../src/components/AccordionMenu';
 import {
   generateParagraphs,

--- a/stories/CodeView.stories.tsx
+++ b/stories/CodeView.stories.tsx
@@ -3,7 +3,8 @@ import { Store } from 'redux';
 import { storiesOf } from '@storybook/react';
 
 import configureStore from '../src/configureStore';
-import FullscreenGrid, { ContentShell } from '../src/components/FullscreenGrid';
+import ContentShell from '../src/components/FullscreenGrid/ContentShell';
+import FullscreenGrid from '../src/components/FullscreenGrid';
 import CodeView, {
   PublicProps as CodeViewProps,
 } from '../src/components/CodeView';

--- a/stories/FullscreenGrid.stories.tsx
+++ b/stories/FullscreenGrid.stories.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import ContentShell from '../src/components/FullscreenGrid/ContentShell';
-import FullscreenGrid, { Header } from '../src/components/FullscreenGrid';
+import FullscreenGrid, {
+  Header,
+  PanelAttribs,
+} from '../src/components/FullscreenGrid';
 import { generateParagraphs, rootAttributeParams } from './utils';
 
 const getParams = () => rootAttributeParams({ fullscreen: true });
@@ -15,10 +18,10 @@ storiesOf('FullscreenGrid', module)
         <FullscreenGrid>
           <Header className="FullscreenGridStory-Header">Header</Header>
           <ContentShell
-            altSidePanel="altSidePanel"
+            altSidePanel={PanelAttribs.altSidePanel}
             altSidePanelClass="FullscreenGridStory-altSidePanel"
             className="FullscreenGridStory-content"
-            mainSidePanel="mainSidePanel"
+            mainSidePanel={PanelAttribs.mainSidePanel}
             mainSidePanelClass="FullscreenGridStory-mainSidePanel"
           >
             Content

--- a/stories/FullscreenGrid.stories.tsx
+++ b/stories/FullscreenGrid.stories.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
-import FullscreenGrid, {
-  Header,
-  ContentShell,
-} from '../src/components/FullscreenGrid';
+import ContentShell from '../src/components/FullscreenGrid/ContentShell';
+import FullscreenGrid, { Header } from '../src/components/FullscreenGrid';
 import { generateParagraphs, rootAttributeParams } from './utils';
 
 const getParams = () => rootAttributeParams({ fullscreen: true });


### PR DESCRIPTION
Fixes #730

---

This patch supports what's described in #721. I kept the `ContentShell`
files in `FullscreenGrid/` because it is strongly coupled.