### PR TITLE
Toggle main side panel

### DIFF
--- a/src/components/FullscreenGrid/ContentShell.spec.tsx
+++ b/src/components/FullscreenGrid/ContentShell.spec.tsx
@@ -125,7 +125,7 @@ describe(__filename, () => {
     );
   });
 
-  it('dispatches toggleMainSidePanel on the toggle button is clicked', () => {
+  it('dispatches toggleMainSidePanel when the toggle button is clicked', () => {
     const store = configureStore();
     const dispatch = spyOn(store, 'dispatch');
 

--- a/src/components/FullscreenGrid/ContentShell.spec.tsx
+++ b/src/components/FullscreenGrid/ContentShell.spec.tsx
@@ -1,11 +1,22 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
+import { Store } from 'redux';
 
-import ContentShell from './ContentShell';
+import configureStore from '../../configureStore';
+import { actions as fullscreenGridActions } from '../../reducers/fullscreenGrid';
+import { spyOn, shallowUntilTarget } from '../../test-helpers';
+import ContentShell, { ContentShellBase, PublicProps } from './ContentShell';
+import styles from './styles.module.scss';
 
 describe(__filename, () => {
-  const render = (props = {}) => {
-    return shallow(<ContentShell {...props} />);
+  type RenderParams = PublicProps & { store?: Store };
+
+  const render = ({
+    store = configureStore(),
+    ...props
+  }: RenderParams = {}) => {
+    return shallowUntilTarget(<ContentShell {...props} />, ContentShellBase, {
+      shallowOptions: { context: { store } },
+    });
   };
 
   it('accepts a custom className', () => {
@@ -28,7 +39,11 @@ describe(__filename, () => {
 
     const root = render({ mainSidePanel: <div className={childClass} /> });
 
-    expect(root.find(`.${childClass}`)).toHaveLength(1);
+    const mainSidePanelContent = root.find(`.${styles.mainSidePanelContent}`);
+    expect(mainSidePanelContent).toHaveLength(1);
+    // The `mainSidePanel` is placed into a `<div />` as there is a button
+    // below to collapse it.
+    expect(mainSidePanelContent.find(`.${childClass}`)).toHaveLength(1);
   });
 
   it('accepts a mainSidePanelClass', () => {
@@ -53,5 +68,72 @@ describe(__filename, () => {
     const root = render({ altSidePanelClass: customClass });
 
     expect(root.find(`.${customClass}`)).toHaveLength(1);
+  });
+
+  it('renders the main side panel expanded by default', () => {
+    const root = render();
+
+    expect(root.find(`.${styles.mainSidePanel}`)).toHaveProp(
+      'aria-expanded',
+      'true',
+    );
+    expect(root.find(`${styles.mainSidePanelIsCollapsed}`)).toHaveLength(0);
+  });
+
+  it('renders a ToggleButton for the main side panel', () => {
+    const root = render();
+
+    expect(root.find(`.${styles.mainSidePanelToggleButton}`)).toHaveLength(1);
+    expect(root.find(`.${styles.mainSidePanelToggleButton}`)).toHaveProp(
+      'label',
+      'Collapse this panel',
+    );
+    expect(root.find(`.${styles.mainSidePanelToggleButton}`)).toHaveProp(
+      'title',
+      'Collapse this panel',
+    );
+    expect(root.find(`.${styles.mainSidePanelToggleButton}`)).toHaveProp(
+      'toggleLeft',
+      true,
+    );
+  });
+
+  it('renders a collapsed main side panel', () => {
+    const store = configureStore();
+    store.dispatch(fullscreenGridActions.toggleMainSidePanel());
+
+    const root = render({ store });
+
+    expect(root.find(`.${styles.mainSidePanel}`)).toHaveProp(
+      'aria-expanded',
+      'false',
+    );
+    expect(root.find(`.${styles.mainSidePanelIsCollapsed}`)).toHaveLength(1);
+
+    expect(root.find(`.${styles.mainSidePanelToggleButton}`)).toHaveLength(1);
+    expect(root.find(`.${styles.mainSidePanelToggleButton}`)).toHaveProp(
+      'label',
+      null,
+    );
+    expect(root.find(`.${styles.mainSidePanelToggleButton}`)).toHaveProp(
+      'title',
+      'Expand this panel',
+    );
+    expect(root.find(`.${styles.mainSidePanelToggleButton}`)).toHaveProp(
+      'toggleLeft',
+      false,
+    );
+  });
+
+  it('dispatches toggleMainSidePanel on the toggle button is clicked', () => {
+    const store = configureStore();
+    const dispatch = spyOn(store, 'dispatch');
+
+    const root = render({ store });
+    root.find(`.${styles.mainSidePanelToggleButton}`).simulate('click');
+
+    expect(dispatch).toHaveBeenCalledWith(
+      fullscreenGridActions.toggleMainSidePanel(),
+    );
   });
 });

--- a/src/components/FullscreenGrid/ContentShell.tsx
+++ b/src/components/FullscreenGrid/ContentShell.tsx
@@ -1,10 +1,16 @@
 import * as React from 'react';
 import makeClassName from 'classnames';
+import { connect } from 'react-redux';
 
+import { ThunkDispatch } from '../../configureStore';
+import { ApplicationState } from '../../reducers';
+import { actions } from '../../reducers/fullscreenGrid';
 import { AnyReactNode } from '../../typeUtils';
+import { gettext } from '../../utils';
+import ToggleButton from '../ToggleButton';
 import styles from './styles.module.scss';
 
-type PublicProps = {
+export type PublicProps = {
   altSidePanel?: AnyReactNode;
   altSidePanelClass?: string;
   children?: AnyReactNode;
@@ -13,7 +19,15 @@ type PublicProps = {
   mainSidePanelClass?: string;
 };
 
-type Props = PublicProps;
+type PropsFromState = {
+  mainSidePanelIsExpanded: boolean;
+};
+
+type DispatchProps = {
+  toggleMainSidePanel: () => void;
+};
+
+type Props = PublicProps & PropsFromState & DispatchProps;
 
 export const ContentShellBase = ({
   altSidePanel,
@@ -22,13 +36,35 @@ export const ContentShellBase = ({
   className,
   mainSidePanel,
   mainSidePanelClass,
+  mainSidePanelIsExpanded,
+  toggleMainSidePanel,
 }: Props) => {
   return (
     <React.Fragment>
       <aside
-        className={makeClassName(styles.mainSidePanel, mainSidePanelClass)}
+        aria-expanded={mainSidePanelIsExpanded ? 'true' : 'false'}
+        className={makeClassName(
+          styles.mainSidePanel,
+          {
+            [styles.mainSidePanelIsCollapsed]: !mainSidePanelIsExpanded,
+          },
+          mainSidePanelClass,
+        )}
       >
-        {mainSidePanel}
+        <div className={styles.mainSidePanelContent}>{mainSidePanel}</div>
+        <ToggleButton
+          className={styles.mainSidePanelToggleButton}
+          label={
+            mainSidePanelIsExpanded ? gettext('Collapse this panel') : null
+          }
+          onClick={toggleMainSidePanel}
+          title={
+            mainSidePanelIsExpanded
+              ? gettext('Collapse this panel')
+              : gettext('Expand this panel')
+          }
+          toggleLeft={mainSidePanelIsExpanded}
+        />
       </aside>
       <main className={makeClassName(styles.content, className)}>
         {children}
@@ -40,4 +76,19 @@ export const ContentShellBase = ({
   );
 };
 
-export default ContentShellBase;
+const mapStateToProps = (state: ApplicationState): PropsFromState => {
+  return {
+    mainSidePanelIsExpanded: state.fullscreenGrid.mainSidePanelIsExpanded,
+  };
+};
+
+const mapDispatchToProps = (dispatch: ThunkDispatch): DispatchProps => {
+  return {
+    toggleMainSidePanel: () => dispatch(actions.toggleMainSidePanel()),
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ContentShellBase);

--- a/src/components/FullscreenGrid/ContentShell.tsx
+++ b/src/components/FullscreenGrid/ContentShell.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import makeClassName from 'classnames';
 import { connect } from 'react-redux';
 
-import { ThunkDispatch } from '../../configureStore';
+import { ConnectedReduxProps } from '../../configureStore';
 import { ApplicationState } from '../../reducers';
 import { actions } from '../../reducers/fullscreenGrid';
 import { AnyReactNode } from '../../typeUtils';
@@ -23,21 +23,17 @@ type PropsFromState = {
   mainSidePanelIsExpanded: boolean;
 };
 
-type DispatchProps = {
-  toggleMainSidePanel: () => void;
-};
-
-type Props = PublicProps & PropsFromState & DispatchProps;
+type Props = PublicProps & PropsFromState & ConnectedReduxProps;
 
 export const ContentShellBase = ({
   altSidePanel,
   altSidePanelClass,
   children,
   className,
+  dispatch,
   mainSidePanel,
   mainSidePanelClass,
   mainSidePanelIsExpanded,
-  toggleMainSidePanel,
 }: Props) => {
   return (
     <React.Fragment>
@@ -57,7 +53,7 @@ export const ContentShellBase = ({
           label={
             mainSidePanelIsExpanded ? gettext('Collapse this panel') : null
           }
-          onClick={toggleMainSidePanel}
+          onClick={() => dispatch(actions.toggleMainSidePanel())}
           title={
             mainSidePanelIsExpanded
               ? gettext('Collapse this panel')
@@ -82,13 +78,4 @@ const mapStateToProps = (state: ApplicationState): PropsFromState => {
   };
 };
 
-const mapDispatchToProps = (dispatch: ThunkDispatch): DispatchProps => {
-  return {
-    toggleMainSidePanel: () => dispatch(actions.toggleMainSidePanel()),
-  };
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ContentShellBase);
+export default connect(mapStateToProps)(ContentShellBase);

--- a/src/components/FullscreenGrid/index.spec.tsx
+++ b/src/components/FullscreenGrid/index.spec.tsx
@@ -51,7 +51,7 @@ describe(__filename, () => {
       const root = render(<FullscreenGrid />);
 
       expect(root).toHaveClassName(`${styles.FullscreenGrid}`);
-      expect(root).not.toHaveClassName(`${styles.mainSidePanelIsCollapsed}`);
+      expect(root).not.toHaveClassName(`${styles.hasACollapsedMainSidePanel}`);
     });
 
     it('sets an extra CSS class when the main side panel is collapsed', () => {
@@ -60,7 +60,7 @@ describe(__filename, () => {
 
       const root = render(<FullscreenGrid />, { store });
 
-      expect(root).toHaveClassName(`${styles.mainSidePanelIsCollapsed}`);
+      expect(root).toHaveClassName(`${styles.hasACollapsedMainSidePanel}`);
     });
   });
 

--- a/src/components/FullscreenGrid/index.spec.tsx
+++ b/src/components/FullscreenGrid/index.spec.tsx
@@ -2,14 +2,27 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 
 import ContentShell from './ContentShell';
+import configureStore from '../../configureStore';
+import { actions as fullscreenGridActions } from '../../reducers/fullscreenGrid';
+import { shallowUntilTarget } from '../../test-helpers';
+import styles from './styles.module.scss';
 
-import FullscreenGrid, { Header } from '.';
+import FullscreenGrid, { Header, FullscreenGridBase } from '.';
 
 describe(__filename, () => {
   describe('FullscreenGrid', () => {
+    const render = (
+      element: JSX.Element,
+      { store = configureStore() } = {},
+    ) => {
+      return shallowUntilTarget(element, FullscreenGridBase, {
+        shallowOptions: { context: { store } },
+      });
+    };
+
     it('accepts a custom className', () => {
       const className = 'MyGrid';
-      const root = shallow(
+      const root = render(
         <FullscreenGrid className={className}>
           <Header />
           <ContentShell />
@@ -22,7 +35,7 @@ describe(__filename, () => {
     it('renders children', () => {
       const childClass = 'ChildExample';
 
-      const root = shallow(
+      const root = render(
         <FullscreenGrid>
           <Header />
           <ContentShell>
@@ -32,6 +45,22 @@ describe(__filename, () => {
       );
 
       expect(root.find(`.${childClass}`)).toHaveLength(1);
+    });
+
+    it('renders with a default CSS class', () => {
+      const root = render(<FullscreenGrid />);
+
+      expect(root).toHaveClassName(`${styles.FullscreenGrid}`);
+      expect(root).not.toHaveClassName(`${styles.mainSidePanelIsCollapsed}`);
+    });
+
+    it('sets an extra CSS class when the main side panel is collapsed', () => {
+      const store = configureStore();
+      store.dispatch(fullscreenGridActions.toggleMainSidePanel());
+
+      const root = render(<FullscreenGrid />, { store });
+
+      expect(root).toHaveClassName(`${styles.mainSidePanelIsCollapsed}`);
     });
   });
 

--- a/src/components/FullscreenGrid/index.spec.tsx
+++ b/src/components/FullscreenGrid/index.spec.tsx
@@ -50,8 +50,8 @@ describe(__filename, () => {
     it('renders with a default CSS class', () => {
       const root = render(<FullscreenGrid />);
 
-      expect(root).toHaveClassName(`${styles.FullscreenGrid}`);
-      expect(root).not.toHaveClassName(`${styles.hasACollapsedMainSidePanel}`);
+      expect(root).toHaveClassName(styles.FullscreenGrid);
+      expect(root).not.toHaveClassName(styles.hasACollapsedMainSidePanel);
     });
 
     it('sets an extra CSS class when the main side panel is collapsed', () => {
@@ -60,7 +60,7 @@ describe(__filename, () => {
 
       const root = render(<FullscreenGrid />, { store });
 
-      expect(root).toHaveClassName(`${styles.hasACollapsedMainSidePanel}`);
+      expect(root).toHaveClassName(styles.hasACollapsedMainSidePanel);
     });
   });
 

--- a/src/components/FullscreenGrid/index.tsx
+++ b/src/components/FullscreenGrid/index.tsx
@@ -46,7 +46,7 @@ export const FullscreenGridBase = ({
       className={makeClassName(
         styles.FullscreenGrid,
         {
-          [styles.mainSidePanelIsCollapsed]: !mainSidePanelIsExpanded,
+          [styles.hasACollapsedMainSidePanel]: !mainSidePanelIsExpanded,
         },
         className,
       )}

--- a/src/components/FullscreenGrid/index.tsx
+++ b/src/components/FullscreenGrid/index.tsx
@@ -1,15 +1,21 @@
 import * as React from 'react';
 import makeClassName from 'classnames';
+import { connect } from 'react-redux';
 
+import { ApplicationState } from '../../reducers';
 import { AnyReactNode } from '../../typeUtils';
 import styles from './styles.module.scss';
+
+type PropsFromState = {
+  mainSidePanelIsExpanded: boolean;
+};
 
 type PublicProps = {
   children?: AnyReactNode;
   className?: string;
 };
 
-type Props = PublicProps;
+type Props = PublicProps & PropsFromState;
 
 export enum PanelAttribs {
   altSidePanel = 'altSidePanel',
@@ -30,12 +36,30 @@ export const Header = ({
   );
 };
 
-export const FullscreenGridBase = ({ children, className }: Props) => {
+export const FullscreenGridBase = ({
+  children,
+  className,
+  mainSidePanelIsExpanded,
+}: Props) => {
   return (
-    <div className={makeClassName(styles.FullscreenGrid, className)}>
+    <div
+      className={makeClassName(
+        styles.FullscreenGrid,
+        {
+          [styles.mainSidePanelIsCollapsed]: !mainSidePanelIsExpanded,
+        },
+        className,
+      )}
+    >
       {children}
     </div>
   );
 };
 
-export default FullscreenGridBase;
+const mapStateToProps = (state: ApplicationState): PropsFromState => {
+  return {
+    mainSidePanelIsExpanded: state.fullscreenGrid.mainSidePanelIsExpanded,
+  };
+};
+
+export default connect(mapStateToProps)(FullscreenGridBase);

--- a/src/components/FullscreenGrid/styles.module.scss
+++ b/src/components/FullscreenGrid/styles.module.scss
@@ -1,5 +1,8 @@
 @import '../../scss/variables';
 
+$collapse-button-height: 40px;
+$expand-button-width: 40px;
+
 .FullscreenGrid {
   display: grid;
   grid-gap: $default-padding;
@@ -10,6 +13,10 @@
   grid-template-columns: 2fr 5fr 1fr;
   grid-template-rows: min-content 1fr 0px;
   height: 100vh;
+
+  &.mainSidePanelIsCollapsed {
+    grid-template-columns: $expand-button-width 7fr 1fr;
+  }
 }
 
 .Header {
@@ -17,8 +24,27 @@
 }
 
 .mainSidePanel {
+  display: flex;
+  flex-direction: column;
   grid-area: FGMainSidePanel;
+  height: 100%;
+  justify-content: space-between;
   margin-left: $default-padding;
+
+  .mainSidePanelToggleButton {
+    height: $collapse-button-height;
+    width: 100%;
+  }
+
+  &.mainSidePanelIsCollapsed {
+    background-color: $light-gray;
+    padding: 0;
+
+    .mainSidePanelToggleButton {
+      height: 100%;
+      padding: 0;
+    }
+  }
 }
 
 .altSidePanel {
@@ -38,4 +64,13 @@
   overflow-x: hidden;
   overflow-y: auto;
   padding: $default-padding;
+}
+
+.mainSidePanelContent {
+  height: calc(100% - #{$collapse-button-height + $default-padding});
+  overflow-x: auto;
+
+  .mainSidePanelIsCollapsed & {
+    display: none;
+  }
 }

--- a/src/components/FullscreenGrid/styles.module.scss
+++ b/src/components/FullscreenGrid/styles.module.scss
@@ -1,6 +1,5 @@
 @import '../../scss/variables';
 
-$collapse-button-height: 40px;
 $expand-button-width: 40px;
 
 .FullscreenGrid {
@@ -32,7 +31,9 @@ $expand-button-width: 40px;
   margin-left: $default-padding;
 
   .mainSidePanelToggleButton {
-    height: $collapse-button-height;
+    height: auto;
+    margin-top: $default-padding;
+    padding: $default-padding;
     width: 100%;
   }
 
@@ -66,8 +67,13 @@ $expand-button-width: 40px;
   padding: $default-padding;
 }
 
+.mainSidePanel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
 .mainSidePanelContent {
-  height: calc(100% - #{$collapse-button-height + $default-padding});
   overflow-x: auto;
 
   .mainSidePanelIsCollapsed & {

--- a/src/components/FullscreenGrid/styles.module.scss
+++ b/src/components/FullscreenGrid/styles.module.scss
@@ -13,7 +13,7 @@ $expand-button-width: 40px;
   grid-template-rows: min-content 1fr 0px;
   height: 100vh;
 
-  &.mainSidePanelIsCollapsed {
+  &.hasACollapsedMainSidePanel {
     grid-template-columns: $expand-button-width 7fr 1fr;
   }
 }
@@ -26,7 +26,7 @@ $expand-button-width: 40px;
   display: flex;
   flex-direction: column;
   grid-area: FGMainSidePanel;
-  height: 100%;
+  height: auto;
   justify-content: space-between;
   margin-left: $default-padding;
 
@@ -35,10 +35,15 @@ $expand-button-width: 40px;
     margin-top: $default-padding;
     padding: $default-padding;
     width: 100%;
+
+    &:not(:global(.focus-visible)) {
+      box-shadow: none;
+    }
   }
 
   &.mainSidePanelIsCollapsed {
     background-color: $light-gray;
+    margin-top: 0;
     padding: 0;
 
     .mainSidePanelToggleButton {
@@ -65,12 +70,6 @@ $expand-button-width: 40px;
   overflow-x: hidden;
   overflow-y: auto;
   padding: $default-padding;
-}
-
-.mainSidePanel {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
 }
 
 .mainSidePanelContent {

--- a/src/components/FullscreenGrid/styles.module.scss
+++ b/src/components/FullscreenGrid/styles.module.scss
@@ -23,16 +23,16 @@ $expand-button-width: 40px;
 }
 
 .mainSidePanel {
-  display: flex;
+  display: grid;
   flex-direction: column;
   grid-area: FGMainSidePanel;
+  grid-gap: $default-padding;
+  grid-template-rows: 1fr auto;
   height: auto;
-  justify-content: space-between;
   margin-left: $default-padding;
 
   .mainSidePanelToggleButton {
     height: auto;
-    margin-top: $default-padding;
     padding: $default-padding;
     width: 100%;
 
@@ -43,7 +43,7 @@ $expand-button-width: 40px;
 
   &.mainSidePanelIsCollapsed {
     background-color: $light-gray;
-    margin-top: 0;
+    grid-gap: 0;
     padding: 0;
 
     .mainSidePanelToggleButton {

--- a/src/components/ToggleButton/index.spec.tsx
+++ b/src/components/ToggleButton/index.spec.tsx
@@ -22,7 +22,6 @@ describe(__filename, () => {
 
     const button = root.find(Button);
     expect(button).toHaveLength(1);
-    expect(button).toHaveProp('title', 'Toggle this panel');
     expect(button).toHaveClassName(`${styles.ToggleButton}`);
   });
 
@@ -66,5 +65,12 @@ describe(__filename, () => {
     root.simulate('click');
 
     expect(onClick).toHaveBeenCalled();
+  });
+
+  it('accepts an HTML title', () => {
+    const title = 'Toggle this panel';
+    const root = render({ title });
+
+    expect(root).toHaveProp('title', title);
   });
 });

--- a/src/components/ToggleButton/index.tsx
+++ b/src/components/ToggleButton/index.tsx
@@ -3,13 +3,13 @@ import makeClassName from 'classnames';
 import { Button } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import { gettext } from '../../utils';
 import styles from './styles.module.scss';
 
 type Props = {
   className?: string;
-  label?: string;
+  label?: string | null;
   onClick: () => void;
+  title?: string;
   toggleLeft?: boolean;
 };
 
@@ -17,6 +17,7 @@ const ToggleButton = ({
   className,
   label,
   onClick,
+  title,
   toggleLeft = false,
 }: Props) => {
   const labelElement = label ? (
@@ -34,7 +35,7 @@ const ToggleButton = ({
         className,
       )}
       onClick={onClick}
-      title={gettext('Toggle this panel')}
+      title={title}
     >
       {!toggleLeft && labelElement}
       <FontAwesomeIcon icon={icon} />

--- a/stories/FullscreenGrid.stories.tsx
+++ b/stories/FullscreenGrid.stories.tsx
@@ -6,7 +6,12 @@ import FullscreenGrid, {
   Header,
   PanelAttribs,
 } from '../src/components/FullscreenGrid';
-import { generateParagraphs, rootAttributeParams } from './utils';
+import ToggleButton from '../src/components/ToggleButton';
+import {
+  generateParagraphs,
+  renderWithStoreAndRouter,
+  rootAttributeParams,
+} from './utils';
 
 const getParams = () => rootAttributeParams({ fullscreen: true });
 
@@ -14,7 +19,7 @@ storiesOf('FullscreenGrid', module)
   .add(
     'default',
     () => {
-      return (
+      return renderWithStoreAndRouter(
         <FullscreenGrid>
           <Header className="FullscreenGridStory-Header">Header</Header>
           <ContentShell
@@ -26,7 +31,7 @@ storiesOf('FullscreenGrid', module)
           >
             Content
           </ContentShell>
-        </FullscreenGrid>
+        </FullscreenGrid>,
       );
     },
     getParams(),
@@ -36,13 +41,13 @@ storiesOf('FullscreenGrid', module)
     () => {
       const someText = generateParagraphs(10);
 
-      return (
+      return renderWithStoreAndRouter(
         <FullscreenGrid>
           <Header className="FullscreenGridStory-Header">Header</Header>
           <ContentShell altSidePanel={someText} mainSidePanel={someText}>
             {someText}
           </ContentShell>
-        </FullscreenGrid>
+        </FullscreenGrid>,
       );
     },
     getParams(),


### PR DESCRIPTION
Fixes #736
~~:warning: Depends on #729, #732 and #734~~

---

This patch allows to expand/collapse the main side panel (left panel). We have everything to implement the same feature for the right panel if we want to.

I filed an issue for the style of the buttons already, because I am pretty sure we can do better: https://github.com/mozilla/addons-code-manager/issues/737.

## Gifs

App:

![2019-05-10 15 16 31](https://user-images.githubusercontent.com/217628/57530105-d32ed200-7336-11e9-8bc2-693400cb6755.gif)

Storybook 1:

![ezgif com-resize](https://user-images.githubusercontent.com/217628/57529692-d07fad00-7335-11e9-9b43-5dca98a6669b.gif)

Storybook 2:

![2019-05-10 15 06 14](https://user-images.githubusercontent.com/217628/57529517-66670800-7335-11e9-9a07-ea84eaa1db30.gif)

## Screenshots

Regular screens:

![Screen Shot 2019-05-10 at 15 07 15](https://user-images.githubusercontent.com/217628/57529543-7aab0500-7335-11e9-8892-093f0b6b648e.png)
![Screen Shot 2019-05-10 at 15 07 13](https://user-images.githubusercontent.com/217628/57529545-7b439b80-7335-11e9-850d-312f236a8ec6.png)
![Screen Shot 2019-05-10 at 15 07 08](https://user-images.githubusercontent.com/217628/57529546-7b439b80-7335-11e9-9f40-e062d1e893f0.png)
![Screen Shot 2019-05-10 at 15 07 05](https://user-images.githubusercontent.com/217628/57529547-7b439b80-7335-11e9-9ddc-62aa7b247fa9.png)

Smaller screens:

![Screen Shot 2019-05-10 at 15 07 51](https://user-images.githubusercontent.com/217628/57529558-81397c80-7335-11e9-89d4-e3d05acb9e36.png)
![Screen Shot 2019-05-10 at 15 07 49](https://user-images.githubusercontent.com/217628/57529559-81397c80-7335-11e9-9ecb-4ed792a56c7f.png)
![Screen Shot 2019-05-10 at 15 07 41](https://user-images.githubusercontent.com/217628/57529560-81397c80-7335-11e9-8fa2-e8a4f0d5d205.png)
![Screen Shot 2019-05-10 at 15 07 38](https://user-images.githubusercontent.com/217628/57529561-81397c80-7335-11e9-9ed8-f7767a7b6bf9.png)
