### PR TITLE
Only scroll/focus a FileTreeNode when necessary

### DIFF
--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -153,7 +153,7 @@ describe(__filename, () => {
       );
     });
 
-    it('passes the version prop to FileTreeNode', () => {
+    it('configures FileTreeNode', () => {
       const store = configureStore();
       const version = getVersion({ store });
 
@@ -164,8 +164,8 @@ describe(__filename, () => {
       );
 
       expect(shallow(<div>{node}</div>).find(FileTreeNode)).toHaveProp(
-        'version',
-        version,
+        'versionId',
+        version.id,
       );
     });
 

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -78,7 +78,9 @@ export class FileTreeBase extends React.Component<Props> {
     const { onSelect, version } = this.props;
 
     if (version) {
-      return <FileTreeNode {...props} onSelect={onSelect} version={version} />;
+      return (
+        <FileTreeNode {...props} onSelect={onSelect} versionId={version.id} />
+      );
     }
     return <Loading message={gettext('Loading version...')} />;
   };
@@ -184,7 +186,10 @@ const mapStateToProps = (
   const version = getVersionInfo(state.versions, versionId);
 
   if (!version) {
-    // This should never happen as we are fetching the version in all of the
+    // TODO: support loading version objects as needed.
+    // https://github.com/mozilla/addons-code-manager/issues/754
+    //
+    // An empty version should never happen as we are fetching the version in all of the
     // parents on this component and only rendering the FileTree if we have a
     // version, but let's log a warning in case we encounter a case where this
     // does happen.

--- a/src/components/FileTreeNode/index.spec.tsx
+++ b/src/components/FileTreeNode/index.spec.tsx
@@ -585,7 +585,7 @@ describe(__filename, () => {
     const fakeRef = createFakeRef({ scrollIntoView: jest.fn() });
     // Make sure the path is not in focus.
     store.dispatch(
-      versionsActions.setFocusedPath({
+      versionsActions.setVisibleSelectedPath({
         path: null,
         versionId: externalVersion.id,
       }),
@@ -603,7 +603,7 @@ describe(__filename, () => {
 
     expect(fakeRef.current.scrollIntoView).toHaveBeenCalled();
     expect(dispatch).toHaveBeenCalledWith(
-      versionsActions.setFocusedPath({
+      versionsActions.setVisibleSelectedPath({
         path: nodeId,
         versionId: externalVersion.id,
       }),
@@ -614,7 +614,9 @@ describe(__filename, () => {
     const versionId = 8765;
     const store = createStoreWithVersion({ ...fakeVersion, id: versionId });
     // Make sure the path is not in focus.
-    store.dispatch(versionsActions.setFocusedPath({ path: null, versionId }));
+    store.dispatch(
+      versionsActions.setVisibleSelectedPath({ path: null, versionId }),
+    );
     const fakeRef = createFakeRef({ scrollIntoView: jest.fn() });
     const dispatch = spyOn(store, 'dispatch');
 
@@ -636,7 +638,7 @@ describe(__filename, () => {
 
     // Focus the path.
     store.dispatch(
-      versionsActions.setFocusedPath({
+      versionsActions.setVisibleSelectedPath({
         path: nodeId,
         versionId: externalVersion.id,
       }),

--- a/src/components/FileTreeNode/index.tsx
+++ b/src/components/FileTreeNode/index.tsx
@@ -150,11 +150,11 @@ export class FileTreeNodeBase<TreeNodeType> extends React.Component<Props> {
   _scrollIntoViewIfNeeded = () => {
     const { dispatch, node, version } = this.props;
 
-    if (this.isSelected() && version.focusedPath !== node.id) {
+    if (this.isSelected() && version.visibleSelectedPath !== node.id) {
       if (this.nodeRef && this.nodeRef.current) {
         this.nodeRef.current.scrollIntoView();
         dispatch(
-          versionsActions.setFocusedPath({
+          versionsActions.setVisibleSelectedPath({
             path: node.id,
             versionId: version.id,
           }),

--- a/src/components/FileTreeNode/index.tsx
+++ b/src/components/FileTreeNode/index.tsx
@@ -1,13 +1,20 @@
 import log from 'loglevel';
 import * as React from 'react';
+import { connect } from 'react-redux';
 import { ListGroup } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import makeClassName from 'classnames';
 
+import { ApplicationState } from '../../reducers';
+import { ConnectedReduxProps } from '../../configureStore';
 import { gettext } from '../../utils';
 import { TreefoldRenderPropsForFileTree } from '../FileTree';
 import LinterProvider, { LinterProviderInfo } from '../LinterProvider';
-import { Version } from '../../reducers/versions';
+import {
+  Version,
+  actions as versionsActions,
+  getVersionInfo,
+} from '../../reducers/versions';
 import {
   LinterMessage,
   LinterMessageMap,
@@ -20,15 +27,16 @@ type ScrollIntoViewIfNeeded = () => void;
 
 export type PublicProps = TreefoldRenderPropsForFileTree & {
   _scrollIntoViewIfNeeded?: ScrollIntoViewIfNeeded;
+  createNodeRef?: () => React.RefObject<HTMLDivElement> | null;
   onSelect: (id: string) => void;
+  versionId: number;
+};
+
+type PropsFromState = {
   version: Version;
 };
 
-export type DefaultProps = {
-  createNodeRef: () => React.RefObject<HTMLDivElement> | null;
-};
-
-type Props = PublicProps & DefaultProps;
+type Props = PublicProps & PropsFromState & ConnectedReduxProps;
 
 type MessageType = LinterMessage['type'];
 
@@ -117,14 +125,13 @@ const getIconForType = (type: string | null) => {
   }
 };
 
-class FileTreeNodeBase<TreeNodeType> extends React.Component<Props> {
-  static defaultProps = {
-    createNodeRef: () => React.createRef(),
-  };
-
+export class FileTreeNodeBase<TreeNodeType> extends React.Component<Props> {
   private scrollIntoViewIfNeeded: ScrollIntoViewIfNeeded;
 
-  private nodeRef = this.props.createNodeRef();
+  private nodeRef: React.RefObject<HTMLDivElement> | null = this.props
+    .createNodeRef
+    ? this.props.createNodeRef()
+    : React.createRef();
 
   constructor(props: Props) {
     super(props);
@@ -141,9 +148,17 @@ class FileTreeNodeBase<TreeNodeType> extends React.Component<Props> {
   }
 
   _scrollIntoViewIfNeeded = () => {
-    if (this.isSelected()) {
+    const { dispatch, node, version } = this.props;
+
+    if (this.isSelected() && version.focusedPath !== node.id) {
       if (this.nodeRef && this.nodeRef.current) {
         this.nodeRef.current.scrollIntoView();
+        dispatch(
+          versionsActions.setFocusedPath({
+            path: node.id,
+            versionId: version.id,
+          }),
+        );
       } else {
         log.warn(`nodeRef.current was unexpectedly empty: ${this.nodeRef}`);
       }
@@ -261,4 +276,21 @@ class FileTreeNodeBase<TreeNodeType> extends React.Component<Props> {
   }
 }
 
-export default FileTreeNodeBase;
+const mapStateToProps = (
+  state: ApplicationState,
+  ownProps: PublicProps,
+): PropsFromState => {
+  const version = getVersionInfo(state.versions, ownProps.versionId);
+  if (!version) {
+    // TODO: support loading version objects as needed.
+    // https://github.com/mozilla/addons-code-manager/issues/754
+    throw new Error(
+      `No version exists in state for version ID ${ownProps.versionId}`,
+    );
+  }
+  return { version };
+};
+
+export default connect(mapStateToProps)(
+  FileTreeNodeBase,
+) as React.ComponentType<PublicProps>;

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -614,12 +614,12 @@ describe(__filename, () => {
         addon: createInternalVersionAddon(version.addon),
         entries: [createInternalVersionEntry(entry)],
         expandedPaths: getParentFolders(version.file.selected_file),
-        focusedPath: null,
         id: version.id,
         reviewed: version.reviewed,
         version: version.version,
         selectedPath: version.file.selected_file,
         validationURL: fakeVersion.validation_url_json,
+        visibleSelectedPath: null,
       });
     });
 
@@ -2318,8 +2318,8 @@ describe(__filename, () => {
     });
   });
 
-  describe('setFocusedPath', () => {
-    it('sets a focused path', () => {
+  describe('setVisibleSelectedPath', () => {
+    it('sets a visible selected path', () => {
       const versionId = 54376;
       const path = 'scripts/background.js';
 
@@ -2343,7 +2343,7 @@ describe(__filename, () => {
       );
       state = reducer(
         state,
-        actions.setFocusedPath({
+        actions.setVisibleSelectedPath({
           path,
           versionId,
         }),
@@ -2355,14 +2355,14 @@ describe(__filename, () => {
           `Unexpectedly found an empty version for ID ${versionId}`,
         );
       }
-      expect(version.focusedPath).toEqual(path);
+      expect(version.visibleSelectedPath).toEqual(path);
     });
 
     it('requires the version to exist in state', () => {
       expect(() =>
         reducer(
           undefined,
-          actions.setFocusedPath({
+          actions.setVisibleSelectedPath({
             path: 'any-path',
             versionId: fakeVersion.id + 1,
           }),
@@ -2393,7 +2393,7 @@ describe(__filename, () => {
       expect(() =>
         reducer(
           state,
-          actions.setFocusedPath({
+          actions.setVisibleSelectedPath({
             path: 'some-completely-unknown-path',
             versionId,
           }),

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -614,6 +614,7 @@ describe(__filename, () => {
         addon: createInternalVersionAddon(version.addon),
         entries: [createInternalVersionEntry(entry)],
         expandedPaths: getParentFolders(version.file.selected_file),
+        focusedPath: null,
         id: version.id,
         reviewed: version.reviewed,
         version: version.version,
@@ -2314,6 +2315,90 @@ describe(__filename, () => {
           version,
         }),
       ).toEqual({ anchor: 'I5', path: null });
+    });
+  });
+
+  describe('setFocusedPath', () => {
+    it('sets a focused path', () => {
+      const versionId = 54376;
+      const path = 'scripts/background.js';
+
+      let state;
+
+      state = reducer(
+        state,
+        actions.loadVersionInfo({
+          version: {
+            ...fakeVersion,
+            id: versionId,
+            file: {
+              ...fakeVersion.file,
+              entries: {
+                ...fakeVersion.file.entries,
+                [path]: { ...fakeVersionEntry, path },
+              },
+            },
+          },
+        }),
+      );
+      state = reducer(
+        state,
+        actions.setFocusedPath({
+          path,
+          versionId,
+        }),
+      );
+
+      const version = getVersionInfo(state, versionId);
+      if (!version) {
+        throw new Error(
+          `Unexpectedly found an empty version for ID ${versionId}`,
+        );
+      }
+      expect(version.focusedPath).toEqual(path);
+    });
+
+    it('requires the version to exist in state', () => {
+      expect(() =>
+        reducer(
+          undefined,
+          actions.setFocusedPath({
+            path: 'any-path',
+            versionId: fakeVersion.id + 1,
+          }),
+        ),
+      ).toThrow(/Version missing/);
+    });
+
+    it('requires a known path', () => {
+      const versionId = 54376;
+      const path = 'scripts/background.js';
+
+      const state = reducer(
+        undefined,
+        actions.loadVersionInfo({
+          version: {
+            ...fakeVersion,
+            id: versionId,
+            file: {
+              ...fakeVersion.file,
+              entries: {
+                [path]: { ...fakeVersionEntry, path },
+              },
+            },
+          },
+        }),
+      );
+
+      expect(() =>
+        reducer(
+          state,
+          actions.setFocusedPath({
+            path: 'some-completely-unknown-path',
+            versionId,
+          }),
+        ),
+      ).toThrow(/unknown path/);
     });
   });
 });

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -183,11 +183,11 @@ export type Version = {
   addon: VersionAddon;
   entries: VersionEntry[];
   expandedPaths: string[];
-  focusedPath: string | null;
   id: number;
   reviewed: string;
   selectedPath: string;
   validationURL: string;
+  visibleSelectedPath: string | null;
   version: string;
 };
 
@@ -227,10 +227,13 @@ export const actions = {
     return (payload: { selectedPath: string; versionId: number }) =>
       resolve(payload);
   }),
-  setFocusedPath: createAction('SET_FOCUSED_PATH', (resolve) => {
-    return (payload: { path: string | null; versionId: number }) =>
-      resolve(payload);
-  }),
+  setVisibleSelectedPath: createAction(
+    'SET_VISIBLE_SELECTED_PATH',
+    (resolve) => {
+      return (payload: { path: string | null; versionId: number }) =>
+        resolve(payload);
+    },
+  ),
   toggleExpandedPath: createAction('TOGGLE_EXPANDED_PATH', (resolve) => {
     return (payload: { path: string; versionId: number }) => resolve(payload);
   }),
@@ -386,12 +389,12 @@ export const createInternalVersion = (
       return createInternalVersionEntry(version.file.entries[nodeName]);
     }),
     expandedPaths: getParentFolders(version.file.selected_file),
-    focusedPath: null,
     id: version.id,
     reviewed: version.reviewed,
     selectedPath: version.file.selected_file,
     version: version.version,
     validationURL: version.validation_url_json,
+    visibleSelectedPath: null,
   };
 };
 
@@ -1015,7 +1018,7 @@ const reducer: Reducer<VersionsState, ActionType<typeof actions>> = (
         },
       };
     }
-    case getType(actions.setFocusedPath): {
+    case getType(actions.setVisibleSelectedPath): {
       const { path, versionId } = action.payload;
 
       const version = state.versionInfo[versionId];
@@ -1036,7 +1039,7 @@ const reducer: Reducer<VersionsState, ActionType<typeof actions>> = (
           ...state.versionInfo,
           [versionId]: {
             ...version,
-            focusedPath: path,
+            visibleSelectedPath: path,
           },
         },
       };

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -25,6 +25,7 @@ import {
   ExternalVersionsListItem,
   Version,
   VersionEntryType,
+  actions as versionsActions,
   createInternalVersion,
   createInternalVersionEntry,
 } from './reducers/versions';
@@ -649,4 +650,13 @@ export const createFakeRef = (
       ...currentOverrides,
     },
   };
+};
+
+export const createStoreWithVersion = (
+  /* istanbul ignore next */
+  version = fakeVersion,
+) => {
+  const store = configureStore();
+  store.dispatch(versionsActions.loadVersionInfo({ version }));
+  return store;
 };

--- a/stories/FileTreeNode.stories.tsx
+++ b/stories/FileTreeNode.stories.tsx
@@ -2,10 +2,8 @@ import React from 'react';
 import { Store } from 'redux';
 import { storiesOf } from '@storybook/react';
 
-import configureStore from '../src/configureStore';
 import FileTreeNode, { PublicProps } from '../src/components/FileTreeNode';
-import { createInternalVersion } from '../src/reducers/versions';
-import { fakeVersion } from '../src/test-helpers';
+import { createStoreWithVersion, fakeVersion } from '../src/test-helpers';
 import { renderWithStoreAndRouter } from './utils';
 
 type GetPropsParams = {
@@ -21,7 +19,7 @@ const getProps = ({
   nodeName = 'node name',
   nodeId = 'node-id',
   renderChildNodes = () => ({}),
-  version = createInternalVersion(fakeVersion),
+  versionId = fakeVersion.id,
 }: GetPropsParams = {}) => {
   return {
     getToggleProps: () => ({
@@ -40,17 +38,18 @@ const getProps = ({
     },
     renderChildNodes,
     onSelect: () => {},
-    version,
+    versionId,
   };
 };
 
 const render = ({
-  store = configureStore(),
+  versionId = 543219,
+  store = createStoreWithVersion({ ...fakeVersion, id: versionId }),
   ...props
 }: { store?: Store } & GetPropsParams = {}) => {
   return renderWithStoreAndRouter(
     <div className="FileTreeNodeStory-shell">
-      <FileTreeNode {...getProps(props)} />
+      <FileTreeNode {...getProps({ versionId, ...props })} />
     </div>,
     store,
   );
@@ -81,10 +80,14 @@ storiesOf('FileTreeNode', module).addWithChapters('all variants', {
         {
           title: 'directory, expanded, with a child',
           sectionFn: () => {
-            const version = createInternalVersion(fakeVersion);
+            const versionId = 921;
+            const store = createStoreWithVersion({
+              ...fakeVersion,
+              id: versionId,
+            });
 
             return render({
-              version,
+              versionId,
               hasChildNodes: true,
               isExpanded: true,
               isFolder: true,
@@ -92,20 +95,29 @@ storiesOf('FileTreeNode', module).addWithChapters('all variants', {
               renderChildNodes: () => {
                 return (
                   <FileTreeNode
-                    version={version}
-                    {...getProps({ level: 1, nodeName: 'background.js' })}
+                    {...getProps({
+                      versionId,
+                      level: 1,
+                      nodeName: 'background.js',
+                    })}
                   />
                 );
               },
+              store,
             });
           },
         },
         {
           title: 'selected node',
           sectionFn: () => {
-            const version = createInternalVersion(fakeVersion);
+            const externalVersion = fakeVersion;
+            const store = createStoreWithVersion(externalVersion);
 
-            return render({ version, nodeId: version.selectedPath });
+            return render({
+              store,
+              versionId: externalVersion.id,
+              nodeId: externalVersion.file.selected_file,
+            });
           },
         },
       ],


### PR DESCRIPTION
This fixes https://github.com/mozilla/addons-code-manager/issues/699 by keeping track of focused nodes and only scrolling when they first come into focus.