### PR TITLE
Adjust Browse / Compare page titles

### DIFF
--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -502,6 +502,6 @@ describe(__filename, () => {
 
     const root = render({ store, versionId: String(version.id) });
 
-    expect(root.find('title')).toHaveText(`Browse ${name}@${versionString}`);
+    expect(root.find('title')).toHaveText(`Browse ${name} @ ${versionString}`);
   });
 });

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -502,6 +502,6 @@ describe(__filename, () => {
 
     const root = render({ store, versionId: String(version.id) });
 
-    expect(root.find('title')).toHaveText(`Browse ${name} @ ${versionString}`);
+    expect(root.find('title')).toHaveText(`Browse ${name}: ${versionString}`);
   });
 });

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -154,7 +154,7 @@ export class BrowseBase extends React.Component<Props> {
           <title>
             {version
               ? gettext(
-                  `Browse ${getLocalizedString(version.addon.name)}@${
+                  `Browse ${getLocalizedString(version.addon.name)} @ ${
                     version.version
                   }`,
                 )

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -154,7 +154,7 @@ export class BrowseBase extends React.Component<Props> {
           <title>
             {version
               ? gettext(
-                  `Browse ${getLocalizedString(version.addon.name)} @ ${
+                  `Browse ${getLocalizedString(version.addon.name)}: ${
                     version.version
                   }`,
                 )

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -653,7 +653,7 @@ describe(__filename, () => {
     });
 
     expect(root.find('title')).toHaveText(
-      `Compare ${name}:${baseVersionId}...${headVersionId}`,
+      `Compare ${name}: ${baseVersionId}...${headVersionId}`,
     );
   });
 });

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -151,7 +151,7 @@ export class CompareBase extends React.Component<Props> {
               ? gettext(
                   `Compare ${getLocalizedString(
                     version.addon.name,
-                  )}:${baseVersionId}...${headVersionId}`,
+                  )}: ${baseVersionId}...${headVersionId}`,
                 )
               : gettext('Compare add-on versions')}
           </title>


### PR DESCRIPTION
Closes https://github.com/mozilla/addons-code-manager/issues/813

This makes some minor adjustments to the titles.

Browse example: `Browse DuckDuckGo Plus: 2019.1.31`

Compare example: `Compare Grammarly for Firefox: 123456...234567`