### PR TITLE
Load version objects amidst different comparisons

### DIFF
--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -542,7 +542,53 @@ describe(__filename, () => {
     });
   });
 
-  it('does not dispatch anything when diff is loaded on mount', () => {
+  it('dispatches fetchDiff() when switching between base versions', () => {
+    const addonId = 2;
+    const headVersionId = 10;
+    const firstBaseVersion = 9;
+    const secondBaseVersion = 8;
+    const version = { ...fakeVersionWithDiff, id: headVersionId };
+
+    const store = configureStore();
+
+    _loadDiff({
+      addonId,
+      baseVersionId: firstBaseVersion,
+      headVersionId,
+      store,
+      version,
+    });
+
+    // Load a comparison for the same head version but a different base
+    // version
+    _loadDiff({
+      addonId,
+      baseVersionId: secondBaseVersion,
+      headVersionId,
+      store,
+      version,
+    });
+
+    const dispatch = spyOn(store, 'dispatch');
+
+    const fakeThunk = createFakeThunk();
+    const _fetchDiff = fakeThunk.createThunk;
+
+    render({
+      _fetchDiff,
+      addonId: String(addonId),
+      // "Go back" to the first comparison view. This will cause the
+      // previously stored comparison to load but should force the
+      // version to get reloaded since it will be out of date.
+      baseVersionId: String(firstBaseVersion),
+      headVersionId: String(headVersionId),
+      store,
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
+  });
+
+  it('does not dispatch fetchDiff() when the diff is already loaded', () => {
     const { dispatchSpy } = loadDiffAndRender();
 
     expect(dispatchSpy).not.toHaveBeenCalled();

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -108,7 +108,12 @@ describe(__filename, () => {
     store = configureStore(),
     version = fakeVersionWithDiff,
   }) => {
-    store.dispatch(versionsActions.loadVersionInfo({ version }));
+    store.dispatch(
+      versionsActions.loadVersionInfo({
+        version,
+        comparedToVersionId: baseVersionId,
+      }),
+    );
     store.dispatch(
       versionsActions.loadDiff({
         addonId,
@@ -201,7 +206,10 @@ describe(__filename, () => {
     const viewer = root.find(VersionFileViewer);
     expect(viewer).toHaveLength(1);
     expect(viewer).toHaveProp('compareInfo', compareInfo);
-    expect(viewer).toHaveProp('version', createInternalVersion(version));
+    expect(viewer).toHaveProp(
+      'version',
+      createInternalVersion(version, { comparedToVersionId: baseVersionId }),
+    );
   });
 
   it('renders a DiffView', () => {
@@ -253,7 +261,10 @@ describe(__filename, () => {
       }),
     );
     expect(diffView).toHaveProp('mimeType', mimeType);
-    expect(diffView).toHaveProp('version', createInternalVersion(version));
+    expect(diffView).toHaveProp(
+      'version',
+      createInternalVersion(version, { comparedToVersionId: baseVersionId }),
+    );
   });
 
   it('renders an error when fetching a diff has failed', () => {

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -70,6 +70,7 @@ export class CompareBase extends React.Component<Props> {
       history,
       match,
       path,
+      version,
     } = this.props;
     const { addonId, baseVersionId, headVersionId, lang } = match.params;
 
@@ -90,7 +91,7 @@ export class CompareBase extends React.Component<Props> {
       return;
     }
 
-    if (compareInfo === undefined) {
+    if (compareInfo === undefined || version === undefined) {
       dispatch(
         _fetchDiff({
           addonId: parseInt(addonId, 10),
@@ -203,7 +204,9 @@ export const mapStateToProps = (
   );
 
   // The Compare API returns the version info of the head/newest version.
-  const version = getVersionInfo(state.versions, headVersionId);
+  const version = getVersionInfo(state.versions, headVersionId, {
+    comparedToVersionId: baseVersionId,
+  });
 
   return {
     addonId,

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -498,7 +498,10 @@ describe(__filename, () => {
 
       let versionsState = reducer(
         undefined,
-        actions.loadVersionInfo({ version }),
+        actions.loadVersionInfo({
+          version,
+          comparedToVersionId: baseVersionId,
+        }),
       );
       versionsState = reducer(
         versionsState,
@@ -547,7 +550,10 @@ describe(__filename, () => {
 
       const previousState = reducer(
         undefined,
-        actions.loadVersionInfo({ version }),
+        actions.loadVersionInfo({
+          version,
+          comparedToVersionId: baseVersionId,
+        }),
       );
 
       expect(() => {
@@ -836,6 +842,47 @@ describe(__filename, () => {
       const state = initialState;
 
       expect(getVersionInfo(state, 1)).toEqual(undefined);
+    });
+
+    it('returns null if there was an error fetching the version', () => {
+      const versionId = 1;
+      // Trigger an error with fetching the version.
+      const state = reducer(
+        undefined,
+        actions.abortFetchVersion({ versionId }),
+      );
+
+      expect(getVersionInfo(state, versionId)).toEqual(null);
+    });
+
+    it('returns undefined if the comparedToVersionId does not match', () => {
+      const comparedToVersionId = 10;
+      const version = { ...fakeVersion, id: comparedToVersionId + 1 };
+
+      const state = reducer(
+        undefined,
+        actions.loadVersionInfo({ version, comparedToVersionId }),
+      );
+
+      expect(
+        getVersionInfo(state, version.id, {
+          comparedToVersionId: comparedToVersionId - 1,
+        }),
+      ).toEqual(undefined);
+    });
+
+    it('returns a mismatched version when comparedToVersionId is undefined', () => {
+      const comparedToVersionId = 10;
+      const version = { ...fakeVersion, id: comparedToVersionId + 1 };
+
+      const state = reducer(
+        undefined,
+        actions.loadVersionInfo({ version, comparedToVersionId }),
+      );
+
+      expect(getVersionInfo(state, version.id)).toEqual(
+        createInternalVersion(version, { comparedToVersionId }),
+      );
     });
   });
 

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -855,6 +855,20 @@ describe(__filename, () => {
       expect(getVersionInfo(state, versionId)).toEqual(null);
     });
 
+    it('returns null if there was an error fetching a version with comparedToVersionId set', () => {
+      const comparedToVersionId = 1;
+      const versionId = 2;
+      // Trigger an error with fetching the version.
+      const state = reducer(
+        undefined,
+        actions.abortFetchVersion({ versionId }),
+      );
+
+      expect(getVersionInfo(state, versionId, { comparedToVersionId })).toEqual(
+        null,
+      );
+    });
+
     it('returns undefined if the comparedToVersionId does not match', () => {
       const comparedToVersionId = 10;
       const version = { ...fakeVersion, id: comparedToVersionId + 1 };

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -411,8 +411,25 @@ export const getVersionFiles = (versions: VersionsState, versionId: number) => {
   return versions.versionFiles[versionId];
 };
 
-export const getVersionInfo = (versions: VersionsState, versionId: number) => {
-  return versions.versionInfo[versionId];
+export const getVersionInfo = (
+  versions: VersionsState,
+  versionId: number,
+  { comparedToVersionId }: { comparedToVersionId?: number } = {},
+) => {
+  const version = versions.versionInfo[versionId];
+
+  if (version === undefined) {
+    return undefined;
+  }
+  if (
+    version &&
+    comparedToVersionId !== undefined &&
+    version.comparedToVersionId !== comparedToVersionId
+  ) {
+    return undefined;
+  }
+
+  return version;
 };
 
 export const getMostRelevantEntryStatus = (
@@ -874,8 +891,10 @@ export const fetchDiff = ({
       );
       dispatch(errorsActions.addError({ error: response.error }));
     } else {
-      const versionInfo = getVersionInfo(versionsState, response.id);
-      if (!versionInfo || versionInfo.comparedToVersionId !== baseVersionId) {
+      const version = getVersionInfo(versionsState, response.id, {
+        comparedToVersionId: baseVersionId,
+      });
+      if (!version) {
         dispatch(
           actions.loadVersionInfo({
             version: response,
@@ -1267,7 +1286,9 @@ const reducer: Reducer<VersionsState, ActionType<typeof actions>> = (
         path,
       });
 
-      const headVersion = getVersionInfo(state, headVersionId);
+      const headVersion = getVersionInfo(state, headVersionId, {
+        comparedToVersionId: baseVersionId,
+      });
       if (!headVersion) {
         throw new Error(`Version missing for headVersionId: ${headVersionId}`);
       }

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -891,10 +891,11 @@ export const fetchDiff = ({
       );
       dispatch(errorsActions.addError({ error: response.error }));
     } else {
-      const version = getVersionInfo(versionsState, response.id, {
-        comparedToVersionId: baseVersionId,
-      });
-      if (!version) {
+      if (
+        !getVersionInfo(versionsState, response.id, {
+          comparedToVersionId: baseVersionId,
+        })
+      ) {
         dispatch(
           actions.loadVersionInfo({
             version: response,


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/776 by always loading version objects when the comparison parameters change.

I also made sure I didn't regress the fix for https://github.com/mozilla/addons-code-manager/issues/592

The root cause of https://github.com/mozilla/addons-code-manager/issues/776 is that the [compare API](https://addons-server.readthedocs.io/en/latest/topics/api/reviewers.html#get--api-v4-reviewers-addon-(int-addon_id)-versions-(int-version_id)-compare_to-(int-version_id)-) returns a version *as compared to* the base version you give it. This is confusing because the returned object has the same ID but different data like different statuses for each file path.

I'm not totally happy with this solution (my patch) but it seemed like a quick-ish way to fix it.