### PR TITLE
Add a keyboard shortcut to toggle the main side panel

### DIFF
--- a/src/components/KeyboardShortcuts/index.spec.tsx
+++ b/src/components/KeyboardShortcuts/index.spec.tsx
@@ -12,6 +12,7 @@ import {
   actions as versionsActions,
   createInternalVersion,
 } from '../../reducers/versions';
+import { actions as fullscreenGridActions } from '../../reducers/fullscreenGrid';
 import {
   CreateKeydownEventParams,
   createContextWithFakeRouter,
@@ -127,6 +128,31 @@ describe(__filename, () => {
     const root = render();
 
     expect(root.find(`.${styles.KeyboardShortcuts}`)).toHaveLength(1);
+  });
+
+  it('does not render a description for alias keys', () => {
+    const root = render();
+
+    const aliasKeys = Object.keys(supportedKeys).filter(
+      (key) => supportedKeys[key] === null,
+    );
+
+    for (const key of aliasKeys) {
+      // The expression below tries to find all react components with $key as
+      // unique child, which is the case of the `kbd` components.
+      expect(root.find({ children: key })).toHaveLength(0);
+    }
+  });
+
+  it('adds a disabled style to the diff keys when there is no compare info', () => {
+    const root = render({ compareInfo: null });
+
+    expect(root.find(`dt.${styles.disabled}`)).toHaveLength(2);
+    expect(root.find(`dd.${styles.disabled}`)).toHaveLength(2);
+
+    // Make sure we added the disabled style to the diff keys.
+    expect(root.find(`dt.${styles.disabled}`).at(0)).toIncludeText('n');
+    expect(root.find(`dt.${styles.disabled}`).at(1)).toIncludeText('p');
   });
 
   it('binds and unbinds keydown to the listener', () => {
@@ -292,6 +318,22 @@ describe(__filename, () => {
     );
   });
 
+  it('dispatches the toggle side panels actions when "h" is pressed', () => {
+    const versionId = 723;
+
+    const store = configureStoreWithFileTree({ versionId });
+    const dispatch = spyOn(store, 'dispatch');
+
+    renderAndTriggerKeyEvent({ key: 'h' }, { store, versionId });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      fullscreenGridActions.toggleMainSidePanel(),
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      fullscreenGridActions.toggleAltSidePanel(),
+    );
+  });
+
   it('does not listen to keyboard events without a file tree', () => {
     // Configure an empty store, one without a file tree loaded.
     const store = configureStore();
@@ -318,7 +360,7 @@ describe(__filename, () => {
     },
   );
 
-  it.each(supportedKeys)(
+  it.each(Object.keys(supportedKeys))(
     'prevents the default event when pressing "%s"',
     (key) => {
       const event = createKeydownEvent({ key });
@@ -332,7 +374,7 @@ describe(__filename, () => {
 
   it('does not prevent the default event when pressing an unsupported key', () => {
     const key = '_';
-    expect(supportedKeys).not.toContain(key);
+    expect(Object.keys(supportedKeys)).not.toContain(key);
 
     const event = createKeydownEvent({ key });
     const preventDefault = spyOn(event, 'preventDefault');

--- a/src/components/KeyboardShortcuts/index.spec.tsx
+++ b/src/components/KeyboardShortcuts/index.spec.tsx
@@ -138,8 +138,8 @@ describe(__filename, () => {
     );
 
     for (const key of aliasKeys) {
-      // The expression below tries to find all react components with $key as
-      // unique child, which is the case of the `kbd` components.
+      // The expression below will look for any JSX rendered with an alias key,
+      // such as a <kbd> tag.
       expect(root.find({ children: key })).toHaveLength(0);
     }
   });
@@ -318,7 +318,7 @@ describe(__filename, () => {
     );
   });
 
-  it('dispatches the toggle side panels actions when "h" is pressed', () => {
+  it('dispatches toggleMainSidePanel() when "h" is pressed', () => {
     const versionId = 723;
 
     const store = configureStoreWithFileTree({ versionId });
@@ -328,9 +328,6 @@ describe(__filename, () => {
 
     expect(dispatch).toHaveBeenCalledWith(
       fullscreenGridActions.toggleMainSidePanel(),
-    );
-    expect(dispatch).toHaveBeenCalledWith(
-      fullscreenGridActions.toggleAltSidePanel(),
     );
   });
 

--- a/src/components/KeyboardShortcuts/index.tsx
+++ b/src/components/KeyboardShortcuts/index.tsx
@@ -28,7 +28,7 @@ export const supportedKeys: { [key: string]: string | null } = {
   c: gettext('Close all folders'),
   n: gettext('Next change'),
   p: gettext('Previous change'),
-  h: gettext('Toggle side panels'),
+  h: gettext('Hide file tree'),
 };
 
 export type PublicProps = {
@@ -157,7 +157,6 @@ export class KeyboardShortcutsBase extends React.Component<Props> {
           break;
         case 'h':
           dispatch(fullscreenGridActions.toggleMainSidePanel());
-          dispatch(fullscreenGridActions.toggleAltSidePanel());
           break;
         default:
       }
@@ -177,7 +176,7 @@ export class KeyboardShortcutsBase extends React.Component<Props> {
   }
 
   makeClassNameForKey(key: string) {
-    // diff keys
+    // `n` and `p` are the keys for navigating a diff.
     if (['n', 'p'].includes(key) && !this.props.compareInfo) {
       return styles.disabled;
     }

--- a/src/components/KeyboardShortcuts/index.tsx
+++ b/src/components/KeyboardShortcuts/index.tsx
@@ -28,7 +28,7 @@ export const supportedKeys: { [key: string]: string | null } = {
   c: gettext('Close all folders'),
   n: gettext('Next change'),
   p: gettext('Previous change'),
-  h: gettext('Hide file tree'),
+  h: gettext('Toggle main side panel'),
 };
 
 export type PublicProps = {

--- a/src/components/KeyboardShortcuts/index.tsx
+++ b/src/components/KeyboardShortcuts/index.tsx
@@ -16,10 +16,20 @@ import {
   actions as versionsActions,
   goToRelativeDiff,
 } from '../../reducers/versions';
+import { actions as fullscreenGridActions } from '../../reducers/fullscreenGrid';
 import styles from './styles.module.scss';
 import { gettext } from '../../utils';
 
-export const supportedKeys = ['k', 'j', 'e', 'o', 'c', 'n', 'p'];
+export const supportedKeys: { [key: string]: string | null } = {
+  k: gettext('Up file'),
+  j: gettext('Down file'),
+  o: gettext('Open all folders'),
+  e: null, // same as 'o'
+  c: gettext('Close all folders'),
+  n: gettext('Next change'),
+  p: gettext('Previous change'),
+  h: gettext('Toggle side panels'),
+};
 
 export type PublicProps = {
   compareInfo: CompareInfo | null | void;
@@ -73,7 +83,7 @@ export class KeyboardShortcutsBase extends React.Component<Props> {
       !event.ctrlKey &&
       !event.metaKey &&
       !event.shiftKey &&
-      supportedKeys.includes(event.key)
+      Object.keys(supportedKeys).includes(event.key)
     ) {
       event.preventDefault();
 
@@ -145,6 +155,10 @@ export class KeyboardShortcutsBase extends React.Component<Props> {
             log.warn('Cannot navigate to previous change without diff loaded');
           }
           break;
+        case 'h':
+          dispatch(fullscreenGridActions.toggleMainSidePanel());
+          dispatch(fullscreenGridActions.toggleAltSidePanel());
+          break;
         default:
       }
     }
@@ -162,37 +176,34 @@ export class KeyboardShortcutsBase extends React.Component<Props> {
     _document.removeEventListener('keydown', this.keydownListener);
   }
 
-  render() {
-    const { compareInfo } = this.props;
-    const diffKeysClassName = !compareInfo ? styles.disabled : '';
+  makeClassNameForKey(key: string) {
+    // diff keys
+    if (['n', 'p'].includes(key) && !this.props.compareInfo) {
+      return styles.disabled;
+    }
 
+    return '';
+  }
+
+  render() {
     return (
       <div className={styles.KeyboardShortcuts}>
         <dl className={styles.definitions}>
-          <dt>
-            <kbd>k</kbd>
-          </dt>
-          <dd>{gettext('Up file')}</dd>
-          <dt>
-            <kbd>j</kbd>
-          </dt>
-          <dd>{gettext('Down file')}</dd>
-          <dt className={diffKeysClassName}>
-            <kbd>p</kbd>
-          </dt>
-          <dd className={diffKeysClassName}>{gettext('Previous change')}</dd>
-          <dt className={diffKeysClassName}>
-            <kbd>n</kbd>
-          </dt>
-          <dd className={diffKeysClassName}>{gettext('Next change')}</dd>
-          <dt>
-            <kbd>o</kbd>
-          </dt>
-          <dd>{gettext('Open all folders')}</dd>
-          <dt>
-            <kbd>c</kbd>
-          </dt>
-          <dd>{gettext('Close all folders')}</dd>
+          {Object.keys(supportedKeys)
+            // exlude alias keys
+            .filter((key) => supportedKeys[key] !== null)
+            .map((key) => {
+              const className = this.makeClassNameForKey(key);
+
+              return (
+                <React.Fragment key={key}>
+                  <dt className={className}>
+                    <kbd>{key}</kbd>
+                  </dt>
+                  <dd className={className}>{supportedKeys[key]}</dd>
+                </React.Fragment>
+              );
+            })}
         </dl>
       </div>
     );


### PR DESCRIPTION
Fixes #588

---

I reworked the supported keys a bit so that it is easier to know which key does what and adding new keyboard shortcuts should be a matter of adding a new entry to the `supportedKeys` map + add a `case` block in the switch.

I added a bunch of missing test cases too.

![Screen Shot 2019-06-12 at 11 56 46](https://user-images.githubusercontent.com/217628/59342248-aee55d00-8d09-11e9-85a5-53f029746db8.png)

