### PR TITLE
Add a line-to-change map for the CodeOverview

### DIFF
--- a/src/pages/Compare/utils.spec.tsx
+++ b/src/pages/Compare/utils.spec.tsx
@@ -1,0 +1,197 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  ExternalChange,
+  ExternalHunk,
+  createInternalDiff,
+} from '../../reducers/versions';
+import { fakeExternalDiff, fakeVersionWithDiff } from '../../test-helpers';
+import { ForwardComparisonMap } from './utils';
+
+describe(__filename, () => {
+  const createFakeExternalChange = (
+    change: Partial<ExternalChange>,
+  ): ExternalChange => {
+    return {
+      ...fakeExternalDiff.hunks[0].changes[0],
+      ...change,
+    };
+  };
+
+  const newForwardComparisonMap = ({
+    changes = fakeExternalDiff.hunks[0].changes,
+    hunks = [
+      {
+        ...fakeExternalDiff.hunks[0],
+        changes,
+      },
+    ],
+  }: {
+    changes?: ExternalChange[];
+    hunks?: ExternalHunk[];
+  } = {}) => {
+    const fakeVersion = {
+      ...fakeVersionWithDiff,
+      file: {
+        ...fakeVersionWithDiff.file,
+        diff: {
+          ...fakeExternalDiff,
+          hunks,
+        },
+      },
+    };
+
+    const diffInfo = createInternalDiff({
+      baseVersionId: 1,
+      headVersionId: 2,
+      version: fakeVersion,
+    });
+    if (!diffInfo) {
+      throw new Error('diffInfo was unexpectedly empty');
+    }
+
+    return new ForwardComparisonMap(diffInfo);
+  };
+
+  describe('ForwardComparisonMap', () => {
+    it('maps normal changes', () => {
+      const change = createFakeExternalChange({
+        old_line_number: 1,
+        new_line_number: 1,
+        type: 'normal',
+      });
+
+      expect(
+        newForwardComparisonMap({ changes: [change] }).getCodeLineAnchor(1),
+      ).toEqual('#N1');
+    });
+
+    it('maps delete changes', () => {
+      const change = createFakeExternalChange({
+        old_line_number: 2,
+        new_line_number: -1,
+        type: 'delete',
+      });
+
+      expect(
+        newForwardComparisonMap({ changes: [change] }).getCodeLineAnchor(2),
+      ).toEqual('#D2');
+    });
+
+    it('maps insert changes', () => {
+      const change = createFakeExternalChange({
+        old_line_number: -1,
+        new_line_number: 2,
+        type: 'insert',
+      });
+
+      expect(
+        newForwardComparisonMap({ changes: [change] }).getCodeLineAnchor(2),
+      ).toEqual('#I2');
+    });
+
+    it('merges changes', () => {
+      const changes = [
+        createFakeExternalChange({
+          old_line_number: 1,
+          new_line_number: 1,
+          type: 'normal',
+        }),
+        createFakeExternalChange({
+          old_line_number: -1,
+          new_line_number: 2,
+          type: 'insert',
+        }),
+      ];
+
+      const map = newForwardComparisonMap({ changes });
+      expect(map.getCodeLineAnchor(1)).toEqual('#N1');
+      expect(map.getCodeLineAnchor(2)).toEqual('#I2');
+    });
+
+    it('merges changes for all hunks', () => {
+      const hunks = [
+        {
+          ...fakeExternalDiff.hunks[0],
+          changes: [
+            createFakeExternalChange({
+              old_line_number: 1,
+              new_line_number: 1,
+              type: 'normal',
+            }),
+          ],
+        },
+        {
+          ...fakeExternalDiff.hunks[0],
+          changes: [
+            createFakeExternalChange({
+              old_line_number: -1,
+              new_line_number: 2,
+              type: 'insert',
+            }),
+          ],
+        },
+      ];
+
+      const map = newForwardComparisonMap({ hunks });
+      expect(map.getCodeLineAnchor(1)).toEqual('#N1');
+      expect(map.getCodeLineAnchor(2)).toEqual('#I2');
+    });
+
+    it('favors inserts', () => {
+      const changes = [
+        createFakeExternalChange({
+          old_line_number: 2,
+          new_line_number: -1,
+          type: 'delete',
+        }),
+        createFakeExternalChange({
+          old_line_number: -1,
+          new_line_number: 2,
+          type: 'insert',
+        }),
+        createFakeExternalChange({
+          old_line_number: 2,
+          new_line_number: 2,
+          type: 'normal',
+        }),
+      ];
+
+      expect(newForwardComparisonMap({ changes }).getCodeLineAnchor(2)).toEqual(
+        '#I2',
+      );
+    });
+
+    it('favors normal lines over deletes', () => {
+      const changes = [
+        createFakeExternalChange({
+          old_line_number: 1,
+          new_line_number: 1,
+          type: 'normal',
+        }),
+        createFakeExternalChange({
+          old_line_number: 1,
+          new_line_number: -1,
+          type: 'delete',
+        }),
+      ];
+
+      expect(newForwardComparisonMap({ changes }).getCodeLineAnchor(1)).toEqual(
+        '#N1',
+      );
+    });
+
+    it('handles unknown lines', () => {
+      const changes = [
+        createFakeExternalChange({
+          old_line_number: 1,
+          new_line_number: 1,
+          type: 'normal',
+        }),
+      ];
+
+      expect(newForwardComparisonMap({ changes }).getCodeLineAnchor(2)).toEqual(
+        '',
+      );
+    });
+  });
+});

--- a/src/pages/Compare/utils.spec.tsx
+++ b/src/pages/Compare/utils.spec.tsx
@@ -193,5 +193,21 @@ describe(__filename, () => {
         '',
       );
     });
+
+    it('lets you create a bound getCodeLineAnchor callback', () => {
+      const line = 1;
+      const change = createFakeExternalChange({
+        old_line_number: line,
+        new_line_number: line,
+        type: 'normal',
+      });
+
+      const map = newForwardComparisonMap({ changes: [change] });
+      const getCodeLineAnchor = map.createCodeLineAnchorGetter();
+
+      expect(getCodeLineAnchor(line)).toEqual(
+        map.getCodeLineAnchor.bind(map)(line),
+      );
+    });
   });
 });

--- a/src/pages/Compare/utils.tsx
+++ b/src/pages/Compare/utils.tsx
@@ -1,0 +1,82 @@
+import log from 'loglevel';
+import {
+  ChangeInfo,
+  ChangeType,
+  DiffInfo,
+  getChangeKey,
+} from 'react-diff-view';
+
+import { getAllHunkChanges } from '../../components/DiffView';
+
+type ForwardChangeMap = {
+  [line: string]: ChangeInfo[];
+};
+
+const mergeChanges = (
+  changeMap: ForwardChangeMap,
+  line: string,
+  change: ChangeInfo,
+) => {
+  const lineChanges = changeMap[line] || [];
+  lineChanges.push(change);
+  return lineChanges;
+};
+
+// This is a map of an old vs. new file comparison, giving preference to the
+// "forward" file, i.e. the newer file.
+export class ForwardComparisonMap {
+  private changeMap: ForwardChangeMap;
+
+  constructor(diff: DiffInfo) {
+    this.changeMap = getAllHunkChanges(diff.hunks).reduce((all, change) => {
+      return {
+        ...all,
+        [String(change.oldLineNumber)]: mergeChanges(
+          all,
+          String(change.oldLineNumber),
+          change,
+        ),
+        [String(change.newLineNumber)]: mergeChanges(
+          all,
+          String(change.newLineNumber),
+          change,
+        ),
+      };
+    }, {});
+
+    const relevantTypes: ChangeType[] = ['insert', 'normal', 'delete'];
+
+    // Sort changes per line, ordered by relevantTypes.
+    Object.keys(this.changeMap).forEach((line) => {
+      this.changeMap[line].sort((firstChange, secondChange) => {
+        if (firstChange.type === secondChange.type) {
+          return 0;
+        }
+
+        for (const type of relevantTypes) {
+          if (firstChange.type === type) {
+            return -1;
+          }
+          if (secondChange.type === type) {
+            return 1;
+          }
+        }
+
+        // This isn't possible but it needs to return a value to satisfy the
+        // sort() interface
+        /* istanbul ignore next */
+        return 0;
+      });
+    });
+  }
+
+  getCodeLineAnchor(line: number) {
+    const lineChanges = this.changeMap[line];
+    if (!lineChanges || lineChanges.length === 0) {
+      log.warn(`No changes were mapped for line ${line}`);
+      return '';
+    }
+
+    return `#${getChangeKey(lineChanges[0])}`;
+  }
+}

--- a/src/pages/Compare/utils.tsx
+++ b/src/pages/Compare/utils.tsx
@@ -70,6 +70,10 @@ export class ForwardComparisonMap {
     });
   }
 
+  createCodeLineAnchorGetter() {
+    return this.getCodeLineAnchor.bind(this);
+  }
+
   getCodeLineAnchor(line: number) {
     const lineChanges = this.changeMap[line];
     if (!lineChanges || lineChanges.length === 0) {

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -100,7 +100,7 @@ export type ExternalChange = {
   type: 'normal' | 'delete' | 'insert';
 };
 
-type ExternalHunk = {
+export type ExternalHunk = {
   changes: ExternalChange[];
   header: string;
   new_lines: number;


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/859

This will ultimately be used like `getCodeLineAnchor(line)`:

https://github.com/mozilla/addons-code-manager/blob/0f6bb509136231ad035ea0c76c6c3706df6585de/src/components/CodeOverview/index.tsx#L219-L221

You can see the overview working in https://github.com/mozilla/addons-code-manager/pull/865