### PR TITLE
Add CodeOverview to the compare page

### DIFF
--- a/src/components/CodeOverview/index.spec.tsx
+++ b/src/components/CodeOverview/index.spec.tsx
@@ -298,9 +298,9 @@ describe(__filename, () => {
       }),
     );
 
-    expect(fakeGetCodeLineAnchor).toHaveBeenCalled();
-    expect(fakeGetCodeLineAnchor.mock.calls[lineIndex]).toEqual([line]);
-    expect(fakeGetCodeLineAnchor.mock.calls[lineIndex - 1]).toEqual([line - 1]);
+    // Make sure subsequent line numbers are passed in order.
+    expect(fakeGetCodeLineAnchor).toHaveBeenNthCalledWith(line, line);
+    expect(fakeGetCodeLineAnchor).toHaveBeenNthCalledWith(line - 1, line - 1);
   });
 
   it('scrolls a linter message into view when clicking its link', () => {

--- a/src/components/CodeOverview/index.spec.tsx
+++ b/src/components/CodeOverview/index.spec.tsx
@@ -276,6 +276,33 @@ describe(__filename, () => {
     expect(link).toHaveProp('title', `Jump to line ${line}`);
   });
 
+  it('renders links for a code line using a custom getCodeLineAnchor', () => {
+    const customAnchor = 'example-anchor';
+    const fakeGetCodeLineAnchor = jest.fn(() => customAnchor);
+
+    const location = createFakeLocation();
+    const root = renderWithFixedHeight({
+      getCodeLineAnchor: fakeGetCodeLineAnchor,
+      content: generateFileLines({ count: 3 }).join('\n'),
+      location,
+    });
+
+    const line = 3;
+    const lineIndex = line - 1;
+    const link = root.find(Link).at(lineIndex);
+
+    expect(link).toHaveProp(
+      'to',
+      expect.objectContaining({
+        hash: customAnchor,
+      }),
+    );
+
+    expect(fakeGetCodeLineAnchor).toHaveBeenCalled();
+    expect(fakeGetCodeLineAnchor.mock.calls[lineIndex]).toEqual([line]);
+    expect(fakeGetCodeLineAnchor.mock.calls[lineIndex - 1]).toEqual([line - 1]);
+  });
+
   it('scrolls a linter message into view when clicking its link', () => {
     const fakeDOMNode = { scrollIntoView: jest.fn() };
     const _document = {

--- a/src/components/CodeOverview/index.tsx
+++ b/src/components/CodeOverview/index.tsx
@@ -24,8 +24,6 @@ import {
   generateLineShapes,
 } from '../CodeLineShapes/utils';
 
-export type GetCodeLineAnchor = (line: number) => string;
-
 export type PublicProps = {
   content: string;
   version: Version;
@@ -39,7 +37,7 @@ export type DefaultProps = {
     removeEventListener: typeof window.removeEventListener;
   };
   createOverviewRef: () => React.RefObject<HTMLDivElement> | null;
-  getCodeLineAnchor: GetCodeLineAnchor;
+  getCodeLineAnchor: typeof _getCodeLineAnchor;
   overviewPadding: number;
   rowTopPadding: number;
   rowHeight: number;

--- a/src/components/CodeOverview/index.tsx
+++ b/src/components/CodeOverview/index.tsx
@@ -5,7 +5,10 @@ import makeClassName from 'classnames';
 import chunk from 'lodash.chunk';
 import debounce from 'lodash.debounce';
 
-import { getCodeLineAnchor, getLines } from '../CodeView/utils';
+import {
+  getCodeLineAnchor as _getCodeLineAnchor,
+  getLines,
+} from '../CodeView/utils';
 import {
   LinterMessage as LinterMessageType,
   findMostSevereType,
@@ -21,6 +24,8 @@ import {
   generateLineShapes,
 } from '../CodeLineShapes/utils';
 
+export type GetCodeLineAnchor = (line: number) => string;
+
 export type PublicProps = {
   content: string;
   version: Version;
@@ -34,6 +39,7 @@ export type DefaultProps = {
     removeEventListener: typeof window.removeEventListener;
   };
   createOverviewRef: () => React.RefObject<HTMLDivElement> | null;
+  getCodeLineAnchor: GetCodeLineAnchor;
   overviewPadding: number;
   rowTopPadding: number;
   rowHeight: number;
@@ -53,6 +59,7 @@ export class CodeOverviewBase extends React.Component<Props, State> {
     _window: window,
     createOverviewRef: () => React.createRef<HTMLDivElement>(),
     // This is the padding of the overview container.
+    getCodeLineAnchor: _getCodeLineAnchor,
     overviewPadding: 10,
     rowTopPadding: 2,
     // This is the height of the row, including rowTopPadding.
@@ -179,6 +186,7 @@ export class CodeOverviewBase extends React.Component<Props, State> {
     const {
       _document,
       content,
+      getCodeLineAnchor,
       location,
       rowHeight,
       rowTopPadding,

--- a/src/components/CodeOverview/index.tsx
+++ b/src/components/CodeOverview/index.tsx
@@ -6,7 +6,7 @@ import chunk from 'lodash.chunk';
 import debounce from 'lodash.debounce';
 
 import {
-  getCodeLineAnchor as _getCodeLineAnchor,
+  getCodeLineAnchor as defaultCodeLineAnchorGetter,
   getLines,
 } from '../CodeView/utils';
 import {
@@ -37,7 +37,7 @@ export type DefaultProps = {
     removeEventListener: typeof window.removeEventListener;
   };
   createOverviewRef: () => React.RefObject<HTMLDivElement> | null;
-  getCodeLineAnchor: typeof _getCodeLineAnchor;
+  getCodeLineAnchor: typeof defaultCodeLineAnchorGetter;
   overviewPadding: number;
   rowTopPadding: number;
   rowHeight: number;
@@ -56,8 +56,8 @@ export class CodeOverviewBase extends React.Component<Props, State> {
     _document: document,
     _window: window,
     createOverviewRef: () => React.createRef<HTMLDivElement>(),
+    getCodeLineAnchor: defaultCodeLineAnchorGetter,
     // This is the padding of the overview container.
-    getCodeLineAnchor: _getCodeLineAnchor,
     overviewPadding: 10,
     rowTopPadding: 2,
     // This is the height of the row, including rowTopPadding.

--- a/src/components/CodeView/utils.tsx
+++ b/src/components/CodeView/utils.tsx
@@ -44,3 +44,5 @@ export const getCodeLineAnchorID = (line: number) => {
 export const getCodeLineAnchor = (line: number) => {
   return `#${getCodeLineAnchorID(line)}`;
 };
+
+export type GetCodeLineAnchor = typeof getCodeLineAnchor;

--- a/src/components/VersionFileViewer/index.spec.tsx
+++ b/src/components/VersionFileViewer/index.spec.tsx
@@ -222,6 +222,20 @@ describe(__filename, () => {
     expect(overview).toHaveProp('version', version);
   });
 
+  it('passes getCodeLineAnchor to CodeOverview', () => {
+    const getCodeLineAnchor = jest.fn();
+    const { file, version } = getInternalVersionAndFile();
+    const root = renderPanel(
+      { getCodeLineAnchor, file, version },
+      PanelAttribs.altSidePanel,
+    );
+
+    expect(root.find(CodeOverview)).toHaveProp(
+      'getCodeLineAnchor',
+      getCodeLineAnchor,
+    );
+  });
+
   it('does not render CodeOverview without a file', () => {
     const root = renderPanel({ file: null }, PanelAttribs.altSidePanel);
 

--- a/src/components/VersionFileViewer/index.tsx
+++ b/src/components/VersionFileViewer/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import AccordionMenu, { AccordionItem } from '../AccordionMenu';
-import CodeOverview from '../CodeOverview';
+import CodeOverview, { GetCodeLineAnchor } from '../CodeOverview';
 import FileMetadata from '../FileMetadata';
 import FileTree, { PublicProps as FileTreeProps } from '../FileTree';
 import ContentShell from '../FullscreenGrid/ContentShell';
@@ -22,6 +22,7 @@ export enum ItemTitles {
 export type PublicProps = {
   children: AnyReactNode;
   compareInfo?: CompareInfo | null | void;
+  getCodeLineAnchor?: GetCodeLineAnchor;
   file: VersionFile | null | void;
   onSelectFile: FileTreeProps['onSelect'];
   showFileInfo: boolean;
@@ -32,6 +33,7 @@ const VersionFileViewer = ({
   children,
   compareInfo,
   file,
+  getCodeLineAnchor,
   onSelectFile,
   showFileInfo,
   version,
@@ -84,6 +86,7 @@ const VersionFileViewer = ({
         file ? (
           <CodeOverview
             content={file.type === 'image' ? '' : file.content}
+            getCodeLineAnchor={getCodeLineAnchor}
             version={version}
           />
         ) : null

--- a/src/components/VersionFileViewer/index.tsx
+++ b/src/components/VersionFileViewer/index.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 
 import AccordionMenu, { AccordionItem } from '../AccordionMenu';
-import CodeOverview, { GetCodeLineAnchor } from '../CodeOverview';
+import CodeOverview from '../CodeOverview';
+import { GetCodeLineAnchor } from '../CodeView/utils';
 import FileMetadata from '../FileMetadata';
 import FileTree, { PublicProps as FileTreeProps } from '../FileTree';
 import ContentShell from '../FullscreenGrid/ContentShell';

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -9,12 +9,14 @@ import {
   createFakeThunk,
   createStoreWithVersion,
   externallyLocalizedString,
+  fakeVersion,
   fakeVersionWithDiff,
   shallowUntilTarget,
   spyOn,
 } from '../../test-helpers';
 import configureStore from '../../configureStore';
 import {
+  ExternalVersionWithDiff,
   actions as versionsActions,
   createInternalDiff,
   createInternalVersion,
@@ -24,6 +26,7 @@ import DiffView from '../../components/DiffView';
 import Loading from '../../components/Loading';
 import VersionFileViewer from '../../components/VersionFileViewer';
 import styles from './styles.module.scss';
+import { ForwardComparisonMap } from './utils';
 
 import Compare, { CompareBase, PublicProps, mapStateToProps } from '.';
 
@@ -67,6 +70,7 @@ describe(__filename, () => {
 
   type RenderParams = {
     _fetchDiff?: PublicProps['_fetchDiff'];
+    _fetchVersionFile?: PublicProps['_fetchVersionFile'];
     _viewVersionFile?: PublicProps['_viewVersionFile'];
     addonId?: string;
     baseVersionId?: string;
@@ -78,6 +82,7 @@ describe(__filename, () => {
 
   const render = ({
     _fetchDiff,
+    _fetchVersionFile,
     _viewVersionFile,
     addonId = '999',
     baseVersionId = '1',
@@ -92,6 +97,7 @@ describe(__filename, () => {
         params: { lang, addonId, baseVersionId, headVersionId },
       }),
       _fetchDiff,
+      _fetchVersionFile,
       _viewVersionFile,
     };
 
@@ -116,6 +122,21 @@ describe(__filename, () => {
       }),
     );
     store.dispatch(
+      versionsActions.loadVersionFile({
+        path: version.file.selected_file,
+        // Make a version with file content out of the given version
+        // diff response.
+        version: {
+          ...fakeVersion,
+          id: version.id,
+          file: {
+            ...fakeVersion.file,
+            ...version.file,
+          },
+        },
+      }),
+    );
+    store.dispatch(
       versionsActions.loadDiff({
         addonId,
         baseVersionId,
@@ -130,11 +151,10 @@ describe(__filename, () => {
     // eslint-disable-next-line @typescript-eslint/camelcase
     selected_file = fakeVersionWithDiff.file.selected_file,
     store = configureStore(),
-  } = {}) => {
-    const addonId = 1;
-    const baseVersionId = 2;
-    const headVersionId = 3;
-    const version = {
+    addonId = 1,
+    baseVersionId = 2,
+    headVersionId = 3,
+    version = {
       ...fakeVersionWithDiff,
       id: headVersionId,
       file: {
@@ -142,9 +162,19 @@ describe(__filename, () => {
         // eslint-disable-next-line @typescript-eslint/camelcase
         selected_file,
       },
-    };
+    },
+  }: {
+    history?: History;
+    store?: Store;
+    addonId?: number;
+    baseVersionId?: number;
+    headVersionId?: number;
+    selected_file?: string;
+    version?: ExternalVersionWithDiff;
+  } = {}) => {
     const fakeThunk = createFakeThunk();
     const _fetchDiff = fakeThunk.createThunk;
+    const _fetchVersionFile = fakeThunk.createThunk;
     const _viewVersionFile = fakeThunk.createThunk;
 
     _loadDiff({ addonId, baseVersionId, headVersionId, store, version });
@@ -153,6 +183,7 @@ describe(__filename, () => {
 
     const root = render({
       _fetchDiff,
+      _fetchVersionFile,
       _viewVersionFile,
       addonId: String(addonId),
       baseVersionId: String(baseVersionId),
@@ -163,6 +194,7 @@ describe(__filename, () => {
 
     return {
       _fetchDiff,
+      _fetchVersionFile,
       _viewVersionFile,
       addonId,
       baseVersionId,
@@ -322,6 +354,106 @@ describe(__filename, () => {
       baseVersionId,
       headVersionId,
     });
+  });
+
+  it('dispatches fetchVersionFile() on mount', () => {
+    const addonId = 9999;
+    const baseVersionId = 1;
+    const headVersionId = baseVersionId + 1;
+    const version = { ...fakeVersionWithDiff, id: headVersionId };
+    const store = configureStore();
+
+    store.dispatch(
+      versionsActions.loadVersionInfo({
+        version,
+        comparedToVersionId: baseVersionId,
+      }),
+    );
+
+    store.dispatch(
+      versionsActions.loadDiff({
+        addonId,
+        baseVersionId,
+        headVersionId,
+        version,
+      }),
+    );
+
+    const dispatch = spyOn(store, 'dispatch');
+    const fakeThunk = createFakeThunk();
+    const _fetchVersionFile = fakeThunk.createThunk;
+
+    render({
+      ...getRouteParams({ addonId, baseVersionId, headVersionId }),
+      _fetchVersionFile,
+      store,
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
+    expect(_fetchVersionFile).toHaveBeenCalledWith({
+      addonId,
+      versionId: version.id,
+      path: version.file.selected_file,
+    });
+  });
+
+  it('does not dispatch fetchVersionFile() when a file is loading', () => {
+    const addonId = 9999;
+    const baseVersionId = 1;
+    const headVersionId = baseVersionId + 1;
+    const version = { ...fakeVersionWithDiff, id: headVersionId };
+    const store = configureStore();
+
+    store.dispatch(
+      versionsActions.loadVersionInfo({
+        version,
+        comparedToVersionId: baseVersionId,
+      }),
+    );
+
+    store.dispatch(
+      versionsActions.loadDiff({
+        addonId,
+        baseVersionId,
+        headVersionId,
+        version,
+      }),
+    );
+
+    // Simulate the beginning of a fetch.
+    store.dispatch(
+      versionsActions.beginFetchVersionFile({
+        path: version.file.selected_file,
+        versionId: version.id,
+      }),
+    );
+
+    const dispatch = spyOn(store, 'dispatch');
+
+    render({
+      ...getRouteParams({ addonId, baseVersionId, headVersionId }),
+      store,
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch fetchVersionFile() when the file is already loaded', () => {
+    const addonId = 999;
+    const baseVersionId = 1;
+    const version = { ...fakeVersionWithDiff, id: baseVersionId + 1 };
+    const headVersionId = version.id;
+
+    const store = configureStore();
+    _loadDiff({ addonId, baseVersionId, headVersionId, store, version });
+    const dispatch = spyOn(store, 'dispatch');
+
+    render({
+      ...getRouteParams({ addonId, baseVersionId, headVersionId }),
+      store,
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
   });
 
   it('redirects to a new compare url when the "old" version is newer than the "new" version', () => {
@@ -678,6 +810,61 @@ describe(__filename, () => {
     });
 
     expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('configures VersionFileViewer to show CodeOverview', () => {
+    const baseVersionId = 1;
+    const version = { ...fakeVersionWithDiff, id: baseVersionId + 1 };
+    const headVersionId = version.id;
+
+    const { root } = loadDiffAndRender({
+      baseVersionId,
+      headVersionId,
+      version,
+    });
+
+    const viewer = root.find(VersionFileViewer);
+    expect(viewer).toHaveProp('getCodeLineAnchor');
+    expect(viewer).toHaveProp(
+      'file',
+      expect.objectContaining({
+        id: version.file.id,
+        size: version.file.size,
+      }),
+    );
+
+    const diff = createInternalDiff({ baseVersionId, headVersionId, version });
+    if (!diff) {
+      throw new Error('diff was unexpectedly empty');
+    }
+    const map = new ForwardComparisonMap(diff);
+
+    const getCodeLineAnchor = viewer.prop('getCodeLineAnchor');
+    if (!getCodeLineAnchor) {
+      throw new Error('getCodeLineAnchor was unexpectedly empty');
+    }
+
+    // As a sanity check, call the configured getter to see if we get
+    // the same result as one returned by a simulated getter.
+    expect(getCodeLineAnchor(1)).toEqual(map.getCodeLineAnchor(1));
+  });
+
+  it('does not configure VersionFileViewer with a file for empty diffs', () => {
+    const headVersionId = 2;
+    const { root } = loadDiffAndRender({
+      baseVersionId: headVersionId - 1,
+      headVersionId,
+      version: {
+        ...fakeVersionWithDiff,
+        id: headVersionId,
+        file: {
+          ...fakeVersionWithDiff.file,
+          diff: null,
+        },
+      },
+    });
+
+    expect(root.find(VersionFileViewer)).toHaveProp('file', null);
   });
 
   it('sets a temporary page title without a version', () => {

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -420,7 +420,6 @@ describe(__filename, () => {
       }),
     );
 
-    // Simulate the beginning of a fetch.
     store.dispatch(
       versionsActions.beginFetchVersionFile({
         path: version.file.selected_file,

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -1,7 +1,12 @@
 import { Reducer } from 'redux';
 import { ActionType, createAction, getType } from 'typesafe-actions';
 import log from 'loglevel';
-import { DiffInfo, DiffInfoType, getChangeKey } from 'react-diff-view';
+import {
+  ChangeInfo,
+  DiffInfo,
+  DiffInfoType,
+  getChangeKey,
+} from 'react-diff-view';
 import { push } from 'connected-react-router';
 import queryString from 'query-string';
 
@@ -721,6 +726,24 @@ type CreateInternalDiffParams = {
   headVersionId: number;
 };
 
+export const createInternalChangeInfo = (
+  change: ExternalChange,
+): ChangeInfo => {
+  return {
+    content: change.content,
+    isDelete: change.type === 'delete',
+    isInsert: change.type === 'insert',
+    isNormal: change.type === 'normal',
+    lineNumber:
+      change.type === 'insert'
+        ? change.new_line_number
+        : change.old_line_number,
+    newLineNumber: change.new_line_number,
+    oldLineNumber: change.old_line_number,
+    type: change.type,
+  };
+};
+
 export const createInternalDiff = ({
   baseVersionId,
   headVersionId,
@@ -740,19 +763,7 @@ export const createInternalDiff = ({
       newRevision: String(headVersionId),
       oldRevision: String(baseVersionId),
       hunks: diff.hunks.map((hunk: ExternalHunk) => ({
-        changes: hunk.changes.map((change: ExternalChange) => ({
-          content: change.content,
-          isDelete: change.type === 'delete',
-          isInsert: change.type === 'insert',
-          isNormal: change.type === 'normal',
-          lineNumber:
-            change.type === 'insert'
-              ? change.new_line_number
-              : change.old_line_number,
-          newLineNumber: change.new_line_number,
-          oldLineNumber: change.old_line_number,
-          type: change.type,
-        })),
+        changes: hunk.changes.map(createInternalChangeInfo),
         content: hunk.header,
         isPlain: false,
         newLines: hunk.new_lines,


### PR DESCRIPTION
~~⚠️  Depends on https://github.com/mozilla/addons-code-manager/pull/860~~

This fixes https://github.com/mozilla/addons-code-manager/issues/672 by adding a code overview for the newer file (the head version). The overview won't be of the diff but maybe we could do that as a follow-up. It would be harder to make an overview of the diff.

<img width="1420" alt="Screenshot 2019-06-20 17 29 23" src="https://user-images.githubusercontent.com/55398/59889381-f8c0e980-9380-11e9-844e-8a081ed51953.png">
