### PR TITLE
Always show file information

### DIFF
--- a/src/components/VersionFileViewer/index.spec.tsx
+++ b/src/components/VersionFileViewer/index.spec.tsx
@@ -94,7 +94,6 @@ describe(__filename, () => {
       children: <div />,
       file,
       onSelectFile: jest.fn(),
-      showFileInfo: true,
       version,
       ...moreProps,
     };
@@ -155,20 +154,8 @@ describe(__filename, () => {
     expect(meta).toHaveProp('file', file);
   });
 
-  it('can hide the information panel', () => {
-    const root = renderPanel(
-      { showFileInfo: false },
-      PanelAttribs.mainSidePanel,
-    );
-
-    expect(getItem(root, ItemTitles.Information)).toHaveLength(0);
-  });
-
   it('renders a placeholder in the information panel without a file', () => {
-    const root = renderPanel(
-      { file: null, showFileInfo: true },
-      PanelAttribs.mainSidePanel,
-    );
+    const root = renderPanel({ file: null }, PanelAttribs.mainSidePanel);
     const item = getItem(root, ItemTitles.Information);
 
     expect(item.find(FileMetadata)).toHaveLength(0);

--- a/src/components/VersionFileViewer/index.tsx
+++ b/src/components/VersionFileViewer/index.tsx
@@ -26,7 +26,6 @@ export type PublicProps = {
   getCodeLineAnchor?: GetCodeLineAnchor;
   file: VersionFile | null | void;
   onSelectFile: FileTreeProps['onSelect'];
-  showFileInfo: boolean;
   version: Version | void | null;
 };
 
@@ -36,7 +35,6 @@ const VersionFileViewer = ({
   file,
   getCodeLineAnchor,
   onSelectFile,
-  showFileInfo,
   version,
 }: PublicProps) => {
   if (!version) {
@@ -54,15 +52,13 @@ const VersionFileViewer = ({
           <AccordionItem expandedByDefault title={ItemTitles.Files}>
             <FileTree onSelect={onSelectFile} versionId={version.id} />
           </AccordionItem>
-          {showFileInfo ? (
-            <AccordionItem title={ItemTitles.Information}>
-              {file ? (
-                <FileMetadata file={file} />
-              ) : (
-                <Loading message={gettext('Loading file...')} />
-              )}
-            </AccordionItem>
-          ) : null}
+          <AccordionItem title={ItemTitles.Information}>
+            {file ? (
+              <FileMetadata file={file} />
+            ) : (
+              <Loading message={gettext('Loading file...')} />
+            )}
+          </AccordionItem>
           <AccordionItem title={ItemTitles.Shortcuts}>
             <LinterProvider
               selectedPath={version.selectedPath}

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -164,7 +164,6 @@ export class BrowseBase extends React.Component<Props> {
         <VersionFileViewer
           file={file}
           onSelectFile={this.viewVersionFile}
-          showFileInfo
           version={version}
         >
           {this.getContent()}

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -848,6 +848,31 @@ describe(__filename, () => {
     expect(getCodeLineAnchor(1)).toEqual(map.getCodeLineAnchor(1));
   });
 
+  it('configures VersionFileViewer with a file even for empty diffs', () => {
+    const fileId = fakeVersionWithDiff.file.id + 1;
+    const headVersionId = 2;
+    const { root } = loadDiffAndRender({
+      baseVersionId: headVersionId - 1,
+      headVersionId,
+      version: {
+        ...fakeVersionWithDiff,
+        id: headVersionId,
+        file: {
+          ...fakeVersionWithDiff.file,
+          id: fileId,
+          diff: null,
+        },
+      },
+    });
+
+    expect(root.find(VersionFileViewer)).toHaveProp(
+      'file',
+      expect.objectContaining({
+        id: fileId,
+      }),
+    );
+  });
+
   it('sets a temporary page title without a version', () => {
     const root = render();
 

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -811,7 +811,7 @@ describe(__filename, () => {
     expect(dispatch).not.toHaveBeenCalled();
   });
 
-  it('configures VersionFileViewer to show CodeOverview', () => {
+  it('configures VersionFileViewer with a file', () => {
     const baseVersionId = 1;
     const version = { ...fakeVersionWithDiff, id: baseVersionId + 1 };
     const headVersionId = version.id;
@@ -846,24 +846,6 @@ describe(__filename, () => {
     // As a sanity check, call the configured getter to see if we get
     // the same result as one returned by a simulated getter.
     expect(getCodeLineAnchor(1)).toEqual(map.getCodeLineAnchor(1));
-  });
-
-  it('does not configure VersionFileViewer with a file for empty diffs', () => {
-    const headVersionId = 2;
-    const { root } = loadDiffAndRender({
-      baseVersionId: headVersionId - 1,
-      headVersionId,
-      version: {
-        ...fakeVersionWithDiff,
-        id: headVersionId,
-        file: {
-          ...fakeVersionWithDiff.file,
-          diff: null,
-        },
-      },
-    });
-
-    expect(root.find(VersionFileViewer)).toHaveProp('file', null);
   });
 
   it('sets a temporary page title without a version', () => {

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -177,8 +177,6 @@ export class CompareBase extends React.Component<Props> {
       getCodeLineAnchor = map.createCodeLineAnchorGetter();
     }
 
-    // TODO: set showFileInfo=true when we can:
-    // https://github.com/mozilla/addons-code-manager/issues/647
     return (
       <React.Fragment>
         <Helmet>
@@ -194,10 +192,9 @@ export class CompareBase extends React.Component<Props> {
         </Helmet>
         <VersionFileViewer
           compareInfo={compareInfo}
-          file={compareInfo && compareInfo.diff ? versionFile : null}
+          file={versionFile}
           getCodeLineAnchor={getCodeLineAnchor}
           onSelectFile={this.viewVersionFile}
-          showFileInfo={false}
           version={version}
         >
           <div className={styles.diffShell}>


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/647 by always showing file information now that we can (as of https://github.com/mozilla/addons-code-manager/issues/672 and https://github.com/mozilla/addons-code-manager/issues/846).

<img width="1443" alt="Screenshot 2019-06-25 13 32 16" src="https://user-images.githubusercontent.com/55398/60123716-be26ca80-974d-11e9-8b2f-5fe9177f13c8.png">
