### PR TITLE
Store the current version

### DIFF
--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -2913,11 +2913,15 @@ describe(__filename, () => {
       let state;
       state = reducer(
         state,
-        actions.abortFetchVersion({ versionId: version.id }),
+        actions.beginFetchVersion({ versionId: version.id }),
       );
       state = reducer(
         state,
         actions.setCurrentVersionId({ versionId: version.id }),
+      );
+      state = reducer(
+        state,
+        actions.abortFetchVersion({ versionId: version.id }),
       );
 
       expect(selectCurrentVersionInfo(state)).toEqual(null);

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -643,6 +643,8 @@ export const fetchVersion = ({
     const { api: apiState } = getState();
 
     dispatch(actions.beginFetchVersion({ versionId }));
+    // Set this as the current version so that components can track its
+    // loading progress.
     dispatch(actions.setCurrentVersionId({ versionId }));
 
     const response = await _getVersion({
@@ -902,7 +904,8 @@ export const fetchDiff = ({
     dispatch(
       actions.beginFetchDiff({ addonId, baseVersionId, headVersionId, path }),
     );
-    // Set the current version to the newer one (the head vesion).
+    // Set the current version to the newer one (the head vesion) so that
+    // components can track its loading progress.
     dispatch(actions.setCurrentVersionId({ versionId: headVersionId }));
 
     const response = await _getDiff({


### PR DESCRIPTION
This fixes https://github.com/mozilla/addons-code-manager/issues/884 by creating Redux storage for a *current version* and setting it while fetching versions. Other components can use this to access the current version or know when it's still loading.

Historically, we've used prop-drilling to pass a version object to those that need it. This created a problem for `FileTree` because of how React/Redux render caching works. We had to prop drill a `versionId` and create an [awkward mapping](https://github.com/mozilla/addons-code-manager/blob/dc18550b066dbb741cef5712b9a46b9611ecb1cf/src/components/FileTree/index.tsx#L186-L197).

To display general linter messages (https://github.com/mozilla/addons-code-manager/issues/805) and display the add-on name (https://github.com/mozilla/addons-code-manager/issues/756) we need access to the current version in the app header. Prop drilling is not even an option since the app header is higher up in the component tree.

This patches introduces a solution for that but it could also be used for other components that might need it, like `FileTree` and maybe `LinterProvider`, too.

What do you think?

Example usage: https://github.com/mozilla/addons-code-manager/pull/892