### PR TITLE
Move button's transition into AccordionMenu

### DIFF
--- a/src/components/AccordionMenu/styles.module.scss
+++ b/src/components/AccordionMenu/styles.module.scss
@@ -15,6 +15,7 @@
 }
 
 .itemButton {
+  transition: transform 0.5s ease-out;
   &:active {
     transform: translateY(4px);
   }

--- a/src/components/Button/styles.module.scss
+++ b/src/components/Button/styles.module.scss
@@ -5,7 +5,6 @@
   text-algin: center;
   overflow: hidden;
   padding: $default-padding;
-  transition: transform 0.5s ease-out;
   width: 100%;
 
   // The .btn-primary overrides are to win a specificity dance off


### PR DESCRIPTION
Fixes #882 
@kumar303  I used the second approach you mentioned https://github.com/mozilla/addons-code-manager/issues/882#issue-461151755, since moving all transition/transform into `Button` causes a problem with the toggle button (showing scrollbar when clicked). And it may be unwanted to see both push effect (vertical) of button and horizontal move of the side panel.
![a](https://user-images.githubusercontent.com/4984681/60233109-3da2bf80-985c-11e9-8f7d-29f1a1c78eed.gif)
