### PR TITLE
create GlobalLinterMessages component #872

### DIFF
--- a/src/components/CodeView/index.tsx
+++ b/src/components/CodeView/index.tsx
@@ -14,6 +14,7 @@ import refractor from '../../refractor';
 import { getLanguageFromMimeType } from '../../utils';
 import { Version } from '../../reducers/versions';
 import LinterProvider, { LinterProviderInfo } from '../LinterProvider';
+import GlobalLinterMessages from '../GlobalLinterMessages';
 
 // This function mimics what https://github.com/rexxars/react-refractor does,
 // but we need a different layout to inline comments so we cannot use this
@@ -36,7 +37,9 @@ const isLineSelected = (
   return `#${id}` === location.hash;
 };
 
-export const scrollToSelectedLine = (element: HTMLTableRowElement | null) => {
+export const scrollToSelectedLine = (
+  element: HTMLTableRowElement | HTMLDivElement | null,
+) => {
   if (element) {
     element.scrollIntoView();
   }
@@ -70,15 +73,15 @@ export class CodeViewBase extends React.Component<Props> {
 
     return (
       <React.Fragment>
-        {selectedMessageMap &&
-          selectedMessageMap.global.length > 0 &&
-          isLineSelected(getCodeLineAnchorID(0), location) && (
-            <div id={getCodeLineAnchorID(0)} ref={_scrollToSelectedLine} />
-          )}
-        {selectedMessageMap &&
-          selectedMessageMap.global.map((message) => {
-            return <LinterMessage key={message.uid} message={message} />;
-          })}
+        <GlobalLinterMessages
+          containerRef={
+            isLineSelected(getCodeLineAnchorID(0), location)
+              ? _scrollToSelectedLine
+              : undefined
+          }
+          messages={selectedMessageMap && selectedMessageMap.global}
+        />
+
         <div className={styles.CodeView}>
           <table className={styles.table}>
             <tbody className={styles.tableBody}>

--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -14,9 +14,9 @@ import { History, Location } from 'history';
 import basicDiff from './fixtures/basicDiff';
 import multipleDiff from './fixtures/multipleDiff';
 import diffWithDeletions from './fixtures/diffWithDeletions';
-import { getCodeLineAnchorID } from '../CodeView/utils';
 import LinterMessage from '../LinterMessage';
 import LinterProvider, { LinterProviderInfo } from '../LinterProvider';
+import GlobalLinterMessages from '../GlobalLinterMessages';
 import { getLanguageFromMimeType } from '../../utils';
 import { ScrollTarget, createInternalVersion } from '../../reducers/versions';
 import {
@@ -468,23 +468,12 @@ describe(__filename, () => {
       }),
     });
 
-    const globalMessages = root.find(`.${styles.globalLinterMessages}`);
-    expect(globalMessages).toHaveProp('id', getCodeLineAnchorID(0));
-
-    const messages = globalMessages.find(LinterMessage);
-    expect(messages).toHaveLength(2);
-    expect(messages.at(0)).toHaveProp(
-      'message',
-      expect.objectContaining({
-        uid: globalMessageUid1,
-      }),
-    );
-    expect(messages.at(1)).toHaveProp(
-      'message',
-      expect.objectContaining({
-        uid: globalMessageUid2,
-      }),
-    );
+    const globalMessages = root.find(GlobalLinterMessages);
+    expect(globalMessages).toHaveLength(1);
+    expect(globalMessages).toHaveProp('messages', [
+      expect.objectContaining({ uid: globalMessageUid1 }),
+      expect.objectContaining({ uid: globalMessageUid2 }),
+    ]);
   });
 
   it('renders multiple inline messages', () => {

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -15,9 +15,9 @@ import {
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import makeClassName from 'classnames';
 
-import { getCodeLineAnchorID } from '../CodeView/utils';
 import LinterProvider, { LinterProviderInfo } from '../LinterProvider';
 import LinterMessage from '../LinterMessage';
+import GlobalLinterMessages from '../GlobalLinterMessages';
 import refractor from '../../refractor';
 import {
   ScrollTarget,
@@ -208,12 +208,6 @@ export class DiffViewBase extends React.Component<Props> {
       // Remove the `#` if `location.hash` is defined
       location.hash.length > 2 ? [location.hash.substring(1)] : [];
 
-    const globalLinterMessages = selectedMessageMap
-      ? selectedMessageMap.global.map((message) => {
-          return <LinterMessage key={message.uid} message={message} />;
-        })
-      : [];
-
     return (
       <div className={styles.DiffView}>
         {!diff && (
@@ -225,14 +219,10 @@ export class DiffViewBase extends React.Component<Props> {
           </React.Fragment>
         )}
 
-        {globalLinterMessages.length ? (
-          <div
-            className={styles.globalLinterMessages}
-            id={getCodeLineAnchorID(0)}
-          >
-            {globalLinterMessages}
-          </div>
-        ) : null}
+        <GlobalLinterMessages
+          className={styles.globalLinterMessages}
+          messages={selectedMessageMap && selectedMessageMap.global}
+        />
 
         {diff && (
           <React.Fragment key={`${diff.oldRevision}-${diff.newRevision}`}>

--- a/src/components/GlobalLinterMessages/index.spec.tsx
+++ b/src/components/GlobalLinterMessages/index.spec.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { shallow, mount } from 'enzyme';
+
+import LinterMessage from '../LinterMessage';
+import {
+  fakeExternalLinterMessage,
+  createFakeLocation,
+  createContextWithFakeRouter,
+} from '../../test-helpers';
+import { createInternalMessage } from '../../reducers/linter';
+import { getCodeLineAnchorID } from '../CodeView/utils';
+
+import GlobalLinterMessages, { PublicProps } from '.';
+
+describe(__filename, () => {
+  const render = (props: PublicProps) => {
+    return shallow(<GlobalLinterMessages {...props} />);
+  };
+
+  const renderWithMount = (props: PublicProps) => {
+    const location = createFakeLocation();
+    const context = createContextWithFakeRouter({ location });
+    return mount(<GlobalLinterMessages {...props} />, context);
+  };
+
+  it('renders no linter messages', () => {
+    const root = render({ messages: [] });
+
+    expect(root.type()).toEqual(null);
+  });
+
+  it('renders multiple linter messages', () => {
+    const messages = [
+      createInternalMessage({
+        ...fakeExternalLinterMessage,
+        uid: 'first-message',
+      }),
+      createInternalMessage({
+        ...fakeExternalLinterMessage,
+        uid: 'second-message',
+      }),
+    ];
+    const root = render({ messages });
+
+    expect(root.find(LinterMessage)).toHaveLength(messages.length);
+  });
+
+  it('renders a custom className', () => {
+    const messages = [createInternalMessage(fakeExternalLinterMessage)];
+    const className = 'custom-classname';
+    const props = { messages, className };
+    const root = render(props);
+
+    expect(root.find(`.${className}`)).toHaveLength(1);
+  });
+
+  it('calls containerRef when rendering', () => {
+    const containerRef = jest.fn();
+    const messages = [createInternalMessage(fakeExternalLinterMessage)];
+    const root = renderWithMount({ containerRef, messages });
+
+    expect(containerRef).toHaveBeenCalledWith(
+      root.find(`#${getCodeLineAnchorID(0)}`).getDOMNode(),
+    );
+  });
+});

--- a/src/components/GlobalLinterMessages/index.spec.tsx
+++ b/src/components/GlobalLinterMessages/index.spec.tsx
@@ -23,8 +23,14 @@ describe(__filename, () => {
     return mount(<GlobalLinterMessages {...props} />, context);
   };
 
-  it('renders no linter messages', () => {
+  it('renders no linter messages when messages is an empty array', () => {
     const root = render({ messages: [] });
+
+    expect(root.type()).toEqual(null);
+  });
+
+  it('renders no linter messages when messages is undefined', () => {
+    const root = render({ messages: undefined });
 
     expect(root.type()).toEqual(null);
   });

--- a/src/components/GlobalLinterMessages/index.tsx
+++ b/src/components/GlobalLinterMessages/index.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import { LinterMessage as LinterMessageType } from '../../reducers/linter';
+import LinterMessage from '../LinterMessage';
+import { getCodeLineAnchorID } from '../CodeView/utils';
+
+export type PublicProps = {
+  className?: string;
+  messages?: LinterMessageType[] | null | void;
+  containerRef?: (element: HTMLDivElement | null) => void;
+};
+
+const GlobalLinterMessages = ({
+  className,
+  messages,
+  containerRef,
+}: PublicProps) => {
+  return messages && messages.length ? (
+    <div className={className} id={getCodeLineAnchorID(0)} ref={containerRef}>
+      {messages.map((msg) => (
+        <LinterMessage key={msg.uid} message={msg} />
+      ))}
+    </div>
+  ) : null;
+};
+
+export default GlobalLinterMessages;

--- a/src/components/GlobalLinterMessages/index.tsx
+++ b/src/components/GlobalLinterMessages/index.tsx
@@ -6,7 +6,7 @@ import { getCodeLineAnchorID } from '../CodeView/utils';
 
 export type PublicProps = {
   className?: string;
-  messages?: LinterMessageType[] | null | void;
+  messages: LinterMessageType[] | null | void;
   containerRef?: (element: HTMLDivElement | null) => void;
 };
 


### PR DESCRIPTION
Fixes #872 
@kumar303 
In refactoring, I found scrolling to linter messages in different files is not work well (Not sure why..) https://github.com/mozilla/addons-code-manager/issues/887#issuecomment-506862273. 
I tested some pages, this refactoring does not change behaviors when navigating between linter messages.
