### PR TITLE
remove TS hint for connect() HOC

### DIFF
--- a/src/components/AccordionMenu/index.tsx
+++ b/src/components/AccordionMenu/index.tsx
@@ -87,9 +87,7 @@ const mapStateToProps = (
   return { expanded: isExpanded(state.accordionMenu, ownProps.title) };
 };
 
-export const AccordionItem = connect(mapStateToProps)(
-  AccordionItemBase,
-) as React.ComponentType<PublicItemProps & Partial<DefaultItemProps>>;
+export const AccordionItem = connect(mapStateToProps)(AccordionItemBase);
 
 const AccordionMenu = ({ children }: { children: AnyReactNode }) => {
   return <div className={styles.menu}>{children}</div>;

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -204,6 +204,4 @@ const mapStateToProps = (
   };
 };
 
-export default connect(mapStateToProps)(FileTreeBase) as React.ComponentType<
-  PublicProps & Partial<DefaultProps>
->;
+export default connect(mapStateToProps)(FileTreeBase);

--- a/src/components/FileTreeNode/index.tsx
+++ b/src/components/FileTreeNode/index.tsx
@@ -315,6 +315,4 @@ const mapStateToProps = (
   return { version };
 };
 
-export default connect(mapStateToProps)(
-  FileTreeNodeBase,
-) as React.ComponentType<PublicProps>;
+export default connect(mapStateToProps)(FileTreeNodeBase);


### PR DESCRIPTION
Fixes #585 
@willdurand 
I see type hints with `withRouter()`. Should I change it to a type variable like  ` withRouter<PublicProps & Partial<DefaultProps> & RouterProps>`?
https://github.com/mozilla/addons-code-manager/blob/2f803e40135f0c7ffc3275618f7b7bec102c5675/src/components/DiffView/index.tsx#L275
https://github.com/mozilla/addons-code-manager/blob/2f803e40135f0c7ffc3275618f7b7bec102c5675/src/components/KeyboardShortcuts/index.tsx#L277