### PR TITLE
Use createCodeLineAnchorGetter in KeyboardShortcuts to accommodate both browse and compare views

### DIFF
--- a/src/components/KeyboardShortcuts/index.spec.tsx
+++ b/src/components/KeyboardShortcuts/index.spec.tsx
@@ -82,6 +82,7 @@ describe(__filename, () => {
   };
 
   const render = ({
+    _createCodeLineAnchorGetter = jest.fn(),
     compareInfo = null,
     currentPath = 'file1.js',
     location = createFakeLocation(),
@@ -93,6 +94,7 @@ describe(__filename, () => {
     ...moreProps
   }: RenderParams = {}) => {
     const props = {
+      _createCodeLineAnchorGetter,
       compareInfo,
       currentPath,
       location,
@@ -185,6 +187,21 @@ describe(__filename, () => {
       'keydown',
       keydownListener,
     );
+  });
+
+  it('generates a getCodeLineAnchor function using _createCodeLineAnchorGetter', () => {
+    const compareInfo = createFakeCompareInfo();
+    const _createCodeLineAnchorGetter = jest.fn();
+
+    renderAndTriggerKeyEvent(
+      { key: Object.keys(supportedKeys)[0] },
+      {
+        _createCodeLineAnchorGetter,
+        compareInfo,
+      },
+    );
+
+    expect(_createCodeLineAnchorGetter).toHaveBeenCalledWith({ compareInfo });
   });
 
   it.each([
@@ -356,6 +373,10 @@ describe(__filename, () => {
       const location = createFakeLocation({
         search: queryString.stringify({ messageUid, path: currentPath }),
       });
+      const getCodeLineAnchor = jest.fn();
+      const _createCodeLineAnchorGetter = jest
+        .fn()
+        .mockReturnValue(getCodeLineAnchor);
 
       const store = configureStoreWithFileTree({ versionId, pathList });
 
@@ -366,6 +387,7 @@ describe(__filename, () => {
       renderAndTriggerKeyEvent(
         { key: key as string },
         {
+          _createCodeLineAnchorGetter,
           _goToRelativeMessage,
           currentPath,
           location,
@@ -379,6 +401,7 @@ describe(__filename, () => {
       expect(_goToRelativeMessage).toHaveBeenCalledWith({
         currentMessageUid: messageUid,
         currentPath,
+        getCodeLineAnchor,
         messageMap,
         pathList,
         position,

--- a/src/components/KeyboardShortcuts/index.tsx
+++ b/src/components/KeyboardShortcuts/index.tsx
@@ -22,7 +22,11 @@ import {
 } from '../../reducers/versions';
 import { actions as fullscreenGridActions } from '../../reducers/fullscreenGrid';
 import styles from './styles.module.scss';
-import { gettext, messageUidQueryParam } from '../../utils';
+import {
+  createCodeLineAnchorGetter,
+  gettext,
+  messageUidQueryParam,
+} from '../../utils';
 
 export const supportedKeys: { [key: string]: string | null } = {
   k: gettext('Up file'),
@@ -51,6 +55,7 @@ type PropsFromState = {
 };
 
 export type DefaultProps = {
+  _createCodeLineAnchorGetter: typeof createCodeLineAnchorGetter;
   _document: typeof document;
   _goToRelativeDiff: typeof goToRelativeDiff;
   _goToRelativeFile: typeof goToRelativeFile;
@@ -65,6 +70,7 @@ type Props = RouteComponentProps &
 
 export class KeyboardShortcutsBase extends React.Component<Props> {
   static defaultProps: DefaultProps = {
+    _createCodeLineAnchorGetter: createCodeLineAnchorGetter,
     _document: document,
     _goToRelativeDiff: goToRelativeDiff,
     _goToRelativeFile: goToRelativeFile,
@@ -73,6 +79,7 @@ export class KeyboardShortcutsBase extends React.Component<Props> {
 
   keydownListener = (event: KeyboardEvent) => {
     const {
+      _createCodeLineAnchorGetter,
       _goToRelativeDiff,
       _goToRelativeFile,
       _goToRelativeMessage,
@@ -99,6 +106,8 @@ export class KeyboardShortcutsBase extends React.Component<Props> {
       Object.keys(supportedKeys).includes(event.key)
     ) {
       event.preventDefault();
+
+      const getCodeLineAnchor = _createCodeLineAnchorGetter({ compareInfo });
 
       switch (event.key) {
         case 'k':
@@ -177,6 +186,7 @@ export class KeyboardShortcutsBase extends React.Component<Props> {
               _goToRelativeMessage({
                 currentMessageUid: messageUid,
                 currentPath,
+                getCodeLineAnchor,
                 messageMap,
                 pathList,
                 position: RelativePathPosition.next,
@@ -191,6 +201,7 @@ export class KeyboardShortcutsBase extends React.Component<Props> {
               _goToRelativeMessage({
                 currentMessageUid: messageUid,
                 currentPath,
+                getCodeLineAnchor,
                 messageMap,
                 pathList,
                 position: RelativePathPosition.previous,

--- a/src/reducers/fileTree.tsx
+++ b/src/reducers/fileTree.tsx
@@ -12,7 +12,7 @@ import {
   pathQueryParam,
 } from '../utils';
 import { LinterMessage, LinterMessageMap, getMessagesForPath } from './linter';
-import { getCodeLineAnchor } from '../components/CodeView/utils';
+import { GetCodeLineAnchor } from '../components/CodeView/utils';
 
 export const ROOT_PATH = '~root~';
 
@@ -385,6 +385,7 @@ type GoToRelativeMessageParams = {
   _viewVersionFile?: typeof viewVersionFile;
   currentMessageUid: LinterMessage['uid'] | void;
   currentPath: string;
+  getCodeLineAnchor: GetCodeLineAnchor;
   messageMap: LinterMessageMap;
   pathList: string[];
   position: RelativePathPosition;
@@ -398,6 +399,7 @@ export const goToRelativeMessage = ({
   _viewVersionFile = viewVersionFile,
   currentMessageUid,
   currentPath,
+  getCodeLineAnchor,
   messageMap,
   pathList,
   position,


### PR DESCRIPTION
Fixes #887 

This does not resolve all of the outstanding issues with linter message navigation, but it does fix the STR in #887 by ensuring that `goToRelativeMessage` generates the correct anchor for both the Browse and Compare views.
