### PR TITLE
Temporarily ignore lodash prototype pollution

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -14,4 +14,8 @@ ignore:
     - '*':
         reason: We use http-proxy-middleware in development only and react-scripts does not accept user input to trigger an exploit
         expires: 2019-10-31T00:00:00.000Z
+  SNYK-JS-LODASH-450202:
+    - '*':
+        reason: While developers / XPIs do have the ability to inject JSON into our system, nothing that depends on this exact version of lodash is handling incoming JSON data
+        expires: 2019-08-01T00:00:00.000Z
 patch: {}


### PR DESCRIPTION
The affected packages aren't handling our incoming JSON so this seems safe to ignore. Can someone double check that? I don't see an upstream patch yet but I set the expiry low so we can resolve this soonish.