### PR TITLE
Return the anchor for the first diff from getRelativeDiffAnchor when a currentAnchor exists that doesn't point to a diff block

### DIFF
--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -2309,18 +2309,24 @@ describe(__filename, () => {
       },
     );
 
-    it('throws an error if the currentAnchor cannot be found', () => {
+    it('returns the first anchor if the currentAnchor cannot be found', () => {
       const diff = createFakeDiffWithChanges([
-        [{ lineNumber: 1, type: 'insert' }],
+        [
+          { lineNumber: 1, type: 'normal' },
+          { lineNumber: 2, type: 'delete' },
+          { lineNumber: 3, type: 'insert' },
+          { lineNumber: 4, type: 'normal' },
+          { lineNumber: 5, type: 'insert' },
+        ],
       ]);
-      const currentAnchor = 'D99';
-      expect(() => {
+
+      expect(
         getRelativeDiffAnchor({
-          currentAnchor,
+          currentAnchor: 'D99',
           diff,
           position: RelativePathPosition.next,
-        });
-      }).toThrow(`Could not locate anchor: ${currentAnchor} in the diff.`);
+        }),
+      ).toEqual('D2');
     });
 
     it('returns the next anchor in the diff', () => {

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -549,25 +549,20 @@ export type GetRelativeDiffAnchorParams = {
 };
 
 export const getRelativeDiffAnchor = ({
-  currentAnchor,
+  currentAnchor = '',
   diff,
   position = RelativePathPosition.next,
 }: GetRelativeDiffAnchorParams): string | null => {
   const anchors = getDiffAnchors(diff);
+  const currentIndex = anchors.indexOf(currentAnchor);
+
   if (anchors.length) {
     let newIndex;
-    if (!currentAnchor) {
-      // Since we aren't looking for an anchor relative to an existing one,
+    if (!currentAnchor || currentIndex < 0) {
+      // Since we do not have an anchor that corresponds to a diff in the file,
       // just get the first anchor.
       newIndex = 0;
     } else {
-      const currentIndex = anchors.indexOf(currentAnchor);
-      if (currentIndex < 0) {
-        throw new Error(
-          `Could not locate anchor: ${currentAnchor} in the diff.`,
-        );
-      }
-
       newIndex =
         position === RelativePathPosition.previous
           ? currentIndex - 1


### PR DESCRIPTION
Fixes #914 

Note that this is the initial "quick fix", which causes the navigation to always go to the first diff in the file if the currently selected line is not at the top of a diff block. The resolves the error in #914, but is only a partial solution. I will file a follow-up for option 2 as discussed at https://github.com/mozilla/addons-code-manager/issues/914#issuecomment-508554395.