### PR TITLE
Allow getRelativeDiffAnchor to work with an anchor that isn't a diff anchor

### DIFF
--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -2309,18 +2309,74 @@ describe(__filename, () => {
       },
     );
 
-    it('throws an error if the currentAnchor cannot be found', () => {
+    it('returns the next anchor in the diff given a non-diff anchor', () => {
       const diff = createFakeDiffWithChanges([
-        [{ lineNumber: 1, type: 'insert' }],
+        [
+          { lineNumber: 1, type: 'delete' },
+          { lineNumber: 2, type: 'insert' },
+          { lineNumber: 3, type: 'normal' },
+          { lineNumber: 4, type: 'insert' },
+        ],
       ]);
-      const currentAnchor = 'D99';
-      expect(() => {
+      expect(
         getRelativeDiffAnchor({
-          currentAnchor,
+          currentAnchor: 'N3',
           diff,
           position: RelativePathPosition.next,
-        });
-      }).toThrow(`Could not locate anchor: ${currentAnchor} in the diff.`);
+        }),
+      ).toEqual('I4');
+    });
+
+    it('returns null if there is no next anchor in the diff given a non-diff anchor', () => {
+      const diff = createFakeDiffWithChanges([
+        [
+          { lineNumber: 1, type: 'delete' },
+          { lineNumber: 2, type: 'insert' },
+          { lineNumber: 3, type: 'normal' },
+        ],
+      ]);
+      expect(
+        getRelativeDiffAnchor({
+          currentAnchor: 'I2',
+          diff,
+          position: RelativePathPosition.next,
+        }),
+      ).toEqual(null);
+    });
+
+    it('returns the previous anchor in the diff given a non-diff anchor', () => {
+      const diff = createFakeDiffWithChanges([
+        [
+          { lineNumber: 1, type: 'delete' },
+          { lineNumber: 2, type: 'insert' },
+          { lineNumber: 3, type: 'normal' },
+          { lineNumber: 4, type: 'insert' },
+        ],
+      ]);
+      expect(
+        getRelativeDiffAnchor({
+          currentAnchor: 'N3',
+          diff,
+          position: RelativePathPosition.previous,
+        }),
+      ).toEqual('D1');
+    });
+
+    it('returns null if there is no previous anchor in the diff given a non-diff anchor', () => {
+      const diff = createFakeDiffWithChanges([
+        [
+          { lineNumber: 1, type: 'normal' },
+          { lineNumber: 2, type: 'normal' },
+          { lineNumber: 3, type: 'delete' },
+        ],
+      ]);
+      expect(
+        getRelativeDiffAnchor({
+          currentAnchor: 'I2',
+          diff,
+          position: RelativePathPosition.previous,
+        }),
+      ).toEqual(null);
     });
 
     it('returns the next anchor in the diff', () => {

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -2336,6 +2336,8 @@ describe(__filename, () => {
           { lineNumber: 3, type: 'normal' },
         ],
       ]);
+      // In the diff above, the diff anchor is created for D1, therefore I2 is
+      // a non-diff anchor.
       expect(
         getRelativeDiffAnchor({
           currentAnchor: 'I2',

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -2301,7 +2301,6 @@ describe(__filename, () => {
         const position = pos as RelativePathPosition;
         expect(
           getRelativeDiffAnchor({
-            currentAnchor: '',
             diff,
             position,
           }),

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -2315,6 +2315,8 @@ describe(__filename, () => {
           { lineNumber: 2, type: 'insert' },
           { lineNumber: 3, type: 'normal' },
           { lineNumber: 4, type: 'insert' },
+          { lineNumber: 5, type: 'normal' },
+          { lineNumber: 6, type: 'insert' },
         ],
       ]);
       expect(
@@ -2350,15 +2352,17 @@ describe(__filename, () => {
           { lineNumber: 2, type: 'insert' },
           { lineNumber: 3, type: 'normal' },
           { lineNumber: 4, type: 'insert' },
+          { lineNumber: 5, type: 'normal' },
+          { lineNumber: 6, type: 'insert' },
         ],
       ]);
       expect(
         getRelativeDiffAnchor({
-          currentAnchor: 'N3',
+          currentAnchor: 'N5',
           diff,
           position: RelativePathPosition.previous,
         }),
-      ).toEqual('D1');
+      ).toEqual('I4');
     });
 
     it('returns null if there is no previous anchor in the diff given a non-diff anchor', () => {

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -578,11 +578,13 @@ export const getRelativeDiffAnchor = ({
 
     // We have a currentAnchor, but is doesn't match anything in anchors, so
     // we need to try to find the correct anchor closest to the currentAnchor.
-    let maybeAnchor;
-
     const currentAnchorNumber = extractNumber(currentAnchor);
+    const sortedAnchors: string[] =
+      position === RelativePathPosition.previous
+        ? [...anchors].reverse()
+        : anchors;
     if (currentAnchorNumber) {
-      for (const anchor of anchors) {
+      for (const anchor of sortedAnchors) {
         const anchorNumber = extractNumber(anchor);
         if (anchorNumber) {
           if (
@@ -591,15 +593,9 @@ export const getRelativeDiffAnchor = ({
             (position === RelativePathPosition.next &&
               anchorNumber >= currentAnchorNumber)
           ) {
-            maybeAnchor = anchor;
-          } else if (maybeAnchor) {
-            break;
+            return anchor;
           }
         }
-      }
-
-      if (maybeAnchor) {
-        return maybeAnchor;
       }
     }
   }

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -12,7 +12,7 @@ import queryString from 'query-string';
 
 import { ThunkActionCreator } from '../configureStore';
 import { getDiff, getVersion, getVersionsList, isErrorResponse } from '../api';
-import { LocalizedStringMap } from '../utils';
+import { LocalizedStringMap, extractNumber } from '../utils';
 import { actions as errorsActions } from './errors';
 import {
   ROOT_PATH,
@@ -549,37 +549,62 @@ export type GetRelativeDiffAnchorParams = {
 };
 
 export const getRelativeDiffAnchor = ({
-  currentAnchor,
+  currentAnchor = '',
   diff,
   position = RelativePathPosition.next,
 }: GetRelativeDiffAnchorParams): string | null => {
   const anchors = getDiffAnchors(diff);
   if (anchors.length) {
-    let newIndex;
     if (!currentAnchor) {
       // Since we aren't looking for an anchor relative to an existing one,
       // just get the first anchor.
-      newIndex = 0;
-    } else {
-      const currentIndex = anchors.indexOf(currentAnchor);
-      if (currentIndex < 0) {
-        throw new Error(
-          `Could not locate anchor: ${currentAnchor} in the diff.`,
-        );
-      }
+      return anchors[0];
+    }
 
-      newIndex =
+    const currentIndex = anchors.indexOf(currentAnchor);
+
+    if (currentIndex >= 0) {
+      const newIndex =
         position === RelativePathPosition.previous
           ? currentIndex - 1
           : currentIndex + 1;
+
+      if (newIndex >= 0 && newIndex < anchors.length) {
+        return anchors[newIndex];
+      }
+      // The currentAnchor is the only anchor in the diff.
+      return null;
     }
 
-    if (newIndex >= 0 && newIndex < anchors.length) {
-      return anchors[newIndex];
+    // We have a currentAnchor, but is doesn't match anything in anchors, so
+    // we need to try to find the correct anchor closest to the currentAnchor.
+    let maybeAnchor;
+
+    const currentAnchorNumber = extractNumber(currentAnchor);
+    if (currentAnchorNumber) {
+      for (const anchor of anchors) {
+        const anchorNumber = extractNumber(anchor);
+        if (anchorNumber) {
+          if (
+            (position === RelativePathPosition.previous &&
+              anchorNumber <= currentAnchorNumber) ||
+            (position === RelativePathPosition.next &&
+              anchorNumber >= currentAnchorNumber)
+          ) {
+            maybeAnchor = anchor;
+          } else if (maybeAnchor) {
+            break;
+          }
+        }
+      }
+
+      if (maybeAnchor) {
+        return maybeAnchor;
+      }
     }
   }
 
-  // There is no next/previous anchor in the file, so return null.
+  // We never found a valid next/previous anchor in the file, so return null.
   return null;
 };
 

--- a/src/utils.spec.tsx
+++ b/src/utils.spec.tsx
@@ -3,8 +3,9 @@ import queryString from 'query-string';
 
 import { getCodeLineAnchor } from './components/CodeView/utils';
 import {
-  formatFilesize,
   createCodeLineAnchorGetter,
+  extractNumber,
+  formatFilesize,
   getLanguageFromMimeType,
   getLocalizedString,
   getPathFromQueryString,
@@ -242,5 +243,17 @@ describe(__filename, () => {
         getterFromFactoryWithoutCompareInfo,
       );
     });
+  });
+});
+
+describe('extractNumber', () => {
+  it('returns a number from a string', () => {
+    expect(extractNumber('D12')).toEqual(12);
+  });
+  it('returns the first number from a string', () => {
+    expect(extractNumber('D12A13')).toEqual(12);
+  });
+  it('returns null if there are no numbers', () => {
+    expect(extractNumber('ABC')).toEqual(null);
   });
 });

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -77,3 +77,11 @@ export const createCodeLineAnchorGetter = ({
   }
   return getCodeLineAnchor;
 };
+
+export const extractNumber = (text: string): number | null => {
+  const matches = text.match(/\d+/);
+  if (Array.isArray(matches)) {
+    return parseInt(matches[0], 10);
+  }
+  return null;
+};


### PR DESCRIPTION
Fixes #914 

This enables option 2 from https://github.com/mozilla/addons-code-manager/issues/914#issuecomment-508554395, allowing any line in the file to be selected and navigating to the next/previous closest diff in the file.