### PR TITLE
Return an empty array from getLines when content is empty

### DIFF
--- a/src/components/CodeOverview/index.spec.tsx
+++ b/src/components/CodeOverview/index.spec.tsx
@@ -481,14 +481,9 @@ describe(__filename, () => {
   });
 
   it('handles empty content', () => {
-    const content = '';
-    const allLineShapes = generateLineShapes([content]);
+    const root = renderWithFixedHeight({ content: '' });
 
-    const root = renderWithFixedHeight({ content });
-
-    const lineShapes = root.find(CodeLineShapes);
-    expect(lineShapes.at(0)).toHaveProp('lineShapes', allLineShapes[0]);
-    expect(lineShapes).toHaveLength(1);
+    expect(root.find(CodeLineShapes)).toHaveLength(0);
   });
 
   it('renders CodeLineShapes for all lines', () => {

--- a/src/components/CodeView/index.spec.tsx
+++ b/src/components/CodeView/index.spec.tsx
@@ -170,7 +170,7 @@ describe(__filename, () => {
   it('handles empty content', () => {
     const root = renderWithLinterProvider({ content: '' });
 
-    expect(root.find('.tableBody')).toHaveProp('children', []);
+    expect(root.find(`.${styles.tableBody}`)).toHaveProp('children', []);
   });
 
   it('renders multiple lines of code', () => {

--- a/src/components/CodeView/index.spec.tsx
+++ b/src/components/CodeView/index.spec.tsx
@@ -168,11 +168,9 @@ describe(__filename, () => {
   });
 
   it('handles empty content', () => {
-    const content = '';
-    const mimeType = 'text/css';
-    const root = renderWithLinterProvider({ mimeType, content });
+    const root = renderWithLinterProvider({ content: '' });
 
-    expect(root.find('.language-css')).toHaveProp('children', content);
+    expect(root.find('.tableBody')).toHaveProp('children', []);
   });
 
   it('renders multiple lines of code', () => {

--- a/src/components/CodeView/utils.spec.tsx
+++ b/src/components/CodeView/utils.spec.tsx
@@ -24,6 +24,10 @@ describe(__filename, () => {
 
       expect(getLines(content)).toEqual(lines);
     });
+
+    it('returns an empty array when content is blank', () => {
+      expect(getLines('')).toEqual([]);
+    });
   });
 
   describe('map functions', () => {

--- a/src/components/CodeView/utils.tsx
+++ b/src/components/CodeView/utils.tsx
@@ -34,7 +34,7 @@ export const mapWithDepth = (depth: number, _mapChild = mapChild) => {
 };
 
 export const getLines = (content: string) => {
-  return content.replace('\r\n', '\n').split('\n');
+  return content ? content.replace('\r\n', '\n').split('\n') : [];
 };
 
 export const getCodeLineAnchorID = (line: number) => {


### PR DESCRIPTION
Fixes #909 

Before:

![Screenshot 2019-07-15 14 31 44](https://user-images.githubusercontent.com/142755/61239879-ec287a80-a70d-11e9-968b-8ddda75cb816.png)

After:

![Screenshot 2019-07-15 14 32 17](https://user-images.githubusercontent.com/142755/61239900-f34f8880-a70d-11e9-9b9c-878841ba3f6c.png)
