### PR TITLE
Build a comparison map faster for large files

### DIFF
--- a/src/pages/Compare/utils.tsx
+++ b/src/pages/Compare/utils.tsx
@@ -12,16 +12,16 @@ type ForwardChangeMap = {
   [line: string]: ChangeInfo[];
 };
 
-const mergeChangesInPlace = (
+const appendChangesInPlace = (
   changeMap: ForwardChangeMap,
   line: string,
   change: ChangeInfo,
 ) => {
-  // This destructively merges changes into each line's ChangeInfo array
-  // when it exists.
-  const lineChanges = changeMap[line] || [];
-  lineChanges.push(change);
-  return lineChanges;
+  // This destructively appends changes to the line's ChangeInfo array
+  // (when it exists).
+  // eslint-disable-next-line no-param-reassign
+  changeMap[line] = changeMap[line] || [];
+  changeMap[line].push(change);
 };
 
 // This is a map of an old vs. new file comparison, giving preference to the
@@ -32,12 +32,12 @@ export class ForwardComparisonMap {
   constructor(diff: DiffInfo) {
     this.changeMap = {};
     for (const change of getAllHunkChanges(diff.hunks)) {
-      this.changeMap[String(change.oldLineNumber)] = mergeChangesInPlace(
+      appendChangesInPlace(
         this.changeMap,
         String(change.oldLineNumber),
         change,
       );
-      this.changeMap[String(change.newLineNumber)] = mergeChangesInPlace(
+      appendChangesInPlace(
         this.changeMap,
         String(change.newLineNumber),
         change,


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/924

This doesn't make too big of a dent in the slow file loading problem but I noticed building the comparison map was slow and since it's an easy fix, why not?

Here's how I created the benchmark below
- Made a production build with `start-local-dev`
- Manually [turned off highlighting](https://github.com/mozilla/addons-code-manager/blob/d07fbc30e7571dd8d72b8db449de926fac59c2fc/src/components/DiffView/index.tsx#L202)
- In Chrome, profiled while loading `package-lock.json` from https://code.addons-dev.allizom.org/en-US/compare/495710/versions/1541610...1688333/ 
- Looked at the timing of [`createCodeLineAnchorGetter`](https://github.com/mozilla/addons-code-manager/blob/d07fbc30e7571dd8d72b8db449de926fac59c2fc/src/utils.tsx#L69)

Before (1.79 seconds)

<img width="1167" alt="Screenshot 2019-07-08 15 19 40" src="https://user-images.githubusercontent.com/55398/60840310-cd1d6c00-a194-11e9-89f0-5e1ff813bf09.png">


After (18.17 milleseconds)

<img width="362" alt="Screenshot 2019-07-08 15 23 32" src="https://user-images.githubusercontent.com/55398/60840315-d0185c80-a194-11e9-8150-14d0763aa80f.png">
