### PR TITLE
Speed up getWidgets() in DiffView for large files

### DIFF
--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -9,6 +9,7 @@ import {
   Hunk,
   Hunks,
   HunkInfo,
+  WidgetMap,
   getChangeKey,
   tokenize,
 } from 'react-diff-view';
@@ -124,7 +125,9 @@ export class DiffViewBase extends React.Component<Props> {
     hunks: Hunks,
     selectedMessageMap: LinterProviderInfo['selectedMessageMap'],
   ) => {
-    return getAllHunkChanges(hunks).reduce((widgets, change) => {
+    const allWidgets: WidgetMap = {};
+
+    for (const change of getAllHunkChanges(hunks)) {
       const changeKey = getChangeKey(change);
       const line = change.lineNumber;
 
@@ -144,8 +147,10 @@ export class DiffViewBase extends React.Component<Props> {
         );
       }
 
-      return { ...widgets, [changeKey]: widget };
-    }, {});
+      allWidgets[changeKey] = widget;
+    }
+
+    return allWidgets;
   };
 
   renderHeader({ hunks }: DiffInfo) {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/926

A significant amount of time is spend in `getWidgets()` for large files.

Here's how I created the benchmark below
- Made a production build with `start-local-dev`
- In Chrome, profiled while loading `package-lock.json` from https://code.addons-dev.allizom.org/en-US/compare/495710/versions/1541610...1688333/ 
- Looked at the timing of `getWidgets()`

Before (7.13 seconds)

<img width="1337" alt="Screenshot 2019-07-08 15 45 47" src="https://user-images.githubusercontent.com/55398/60842247-4323d200-a199-11e9-8c97-fcfdccc46b12.png">


After (6.12 milleseconds)

<img width="395" alt="Screenshot 2019-07-08 15 49 01" src="https://user-images.githubusercontent.com/55398/60842252-46b75900-a199-11e9-91ac-36d3553d208f.png">
