### PR TITLE
Show add-on name in top bar

### DIFF
--- a/src/components/Navbar/index.spec.tsx
+++ b/src/components/Navbar/index.spec.tsx
@@ -5,7 +5,14 @@ import { Store } from 'redux';
 import configureStore from '../../configureStore';
 import LoginButton from '../LoginButton';
 import styles from './styles.module.scss';
-import { createFakeThunk, fakeUser, spyOn } from '../../test-helpers';
+import {
+  createFakeThunk,
+  createStoreWithVersion,
+  fakeUser,
+  fakeVersion,
+  fakeVersionAddon,
+  spyOn,
+} from '../../test-helpers';
 import { actions as userActions, requestLogOut } from '../../reducers/users';
 
 import Navbar from '.';
@@ -35,6 +42,30 @@ describe(__filename, () => {
     store.dispatch(userActions.loadCurrentUser({ user }));
     return store;
   };
+
+  describe('when a version is loaded', () => {
+    it('renders addon name', () => {
+      const addonName = 'addon name example';
+      const store = createStoreWithVersion(
+        {
+          ...fakeVersion,
+          addon: { ...fakeVersionAddon, name: { 'en-US': addonName } },
+        },
+        { makeCurrent: true },
+      );
+      const root = render({ store });
+
+      expect(root.find(`.${styles.addonName}`)).toHaveText(addonName);
+    });
+  });
+
+  describe('when version is undefined', () => {
+    it('does not render addon name', () => {
+      const root = render();
+
+      expect(root.find(`.${styles.addonName}`)).toHaveLength(0);
+    });
+  });
 
   describe('when a user is provided', () => {
     it('renders a username', () => {

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -40,7 +40,7 @@ export class NavbarBase extends React.Component<Props> {
         <Navbar.Brand className={styles.brand}>
           {currentVersion && (
             <span className={styles.addonName}>
-              {gettext(`${getLocalizedString(currentVersion.addon.name)}`)}
+              {getLocalizedString(currentVersion.addon.name)}
             </span>
           )}
         </Navbar.Brand>

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { Button, Navbar } from 'react-bootstrap';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
 
-import { gettext } from '../../utils';
+import { gettext, getLocalizedString } from '../../utils';
 import LoginButton from '../LoginButton';
 import { ApplicationState } from '../../reducers';
+import { Version, selectCurrentVersionInfo } from '../../reducers/versions';
 import { ConnectedReduxProps } from '../../configureStore';
 import { User, selectCurrentUser, requestLogOut } from '../../reducers/users';
 import styles from './styles.module.scss';
@@ -16,6 +16,7 @@ type PublicProps = {
 
 type PropsFromState = {
   user: User | null;
+  currentVersion: Version | null | undefined;
 };
 
 type Props = PublicProps & PropsFromState & ConnectedReduxProps;
@@ -32,12 +33,16 @@ export class NavbarBase extends React.Component<Props> {
   };
 
   render() {
-    const { user } = this.props;
+    const { user, currentVersion } = this.props;
 
     return (
       <Navbar bg="dark" className={styles.Navbar} expand="lg" variant="dark">
         <Navbar.Brand className={styles.brand}>
-          <Link to="/">addons-code-manager</Link>
+          {currentVersion && (
+            <span className={styles.addonName}>
+              {gettext(`${getLocalizedString(currentVersion.addon.name)}`)}
+            </span>
+          )}
         </Navbar.Brand>
         <Navbar.Text className={styles.text}>
           {user ? <span className={styles.username}>{user.name}</span> : null}
@@ -57,6 +62,7 @@ export class NavbarBase extends React.Component<Props> {
 const mapStateToProps = (state: ApplicationState): PropsFromState => {
   return {
     user: selectCurrentUser(state.users),
+    currentVersion: selectCurrentVersionInfo(state.versions),
   };
 };
 

--- a/src/components/Navbar/styles.module.scss
+++ b/src/components/Navbar/styles.module.scss
@@ -13,11 +13,11 @@
   padding: 0;
 }
 
-.brand a {
+.addonName {
   color: #fff;
 }
 
-.brand a,
+.addonName,
 .text,
 .Navbar {
   align-items: center;

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -716,9 +716,15 @@ export const createFakeRef = (
 export const createStoreWithVersion = (
   /* istanbul ignore next */
   version: ExternalVersionWithDiff | ExternalVersionWithContent = fakeVersion,
+  { makeCurrent = false } = {},
 ) => {
   const store = configureStore();
   store.dispatch(versionsActions.loadVersionInfo({ version }));
+  if (makeCurrent) {
+    store.dispatch(
+      versionsActions.setCurrentVersionId({ versionId: version.id }),
+    );
+  }
   return store;
 };
 


### PR DESCRIPTION
Fixes #756
Add-on name would be shown in Navbar (browse mode and compare mode).
![image](https://user-images.githubusercontent.com/4984681/60942982-d811f280-a2a1-11e9-82de-68fbc2af6ee9.png)
