### PR TITLE
Disable highlighting for long or wide diffs

### DIFF
--- a/src/components/DiffView/fixtures/minifiedDiff.tsx
+++ b/src/components/DiffView/fixtures/minifiedDiff.tsx
@@ -1,0 +1,6 @@
+export default `diff --git a/manifest.bundle.js b/manifest.bundle.js
+index 5ca1a30..4e2c90f 100644
+--- a/manifest.bundle.js
++++ b/manifest.bundle.js
+@@ -1 +1 @@
++(function(a){function b(c){if(d[c])return d[c].exports;var e=d[c]={i:c,l:!1,exports:{}};return a[c].call(e.exports,e,e.exports,b),e.l=!0,e.exports}var c=window.webpackJsonp;window.webpackJsonp=function(d,f,g){for(var h,j,k,l=0,i=[];l<d.length;l++)j=d[l],e[j]&&i.push(e[j][0]),e[j]=0;for(h in f)Object.prototype.hasOwnProperty.call(f,h)&&(a[h]=f[h]);for(c&&c(d,f,g);i.length;)i.shift()();if(g)for(l=0;l<g.length;l++)k=b(b.s=g[l]);return k};var d={},e={11:0};b.m=a,b.c=d,b.d=function(a,c,d){b.o(a,c)||Object.defineProperty(a,c,{configurable:!1,enumerable:!0,get:d})},b.n=function(a){var c=a&&a.__esModule?function(){return a["default"]}:function(){return a};return b.d(c,"a",c),c},b.o=function(a,b){return Object.prototype.hasOwnProperty.call(a,b)},b.p="",b.oe=function(a){throw console.error(a),a}})([]);`;

--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -618,7 +618,7 @@ describe(__filename, () => {
     expect(getWidgetNodes(widgets).length).toEqual(0);
   });
 
-  it('generates and passes in tokens for a diff that can be highlighted', () => {
+  it('enables syntax highlighting for diffs when possible', () => {
     const _tokenize = jest.fn(tokenize);
     const root = renderWithLinterProvider({
       _diffCanBeHighlighted: jest.fn(() => true),
@@ -632,9 +632,10 @@ describe(__filename, () => {
     expect(diff).toHaveProp('tokens');
     expect(diff.prop('tokens')).toBeDefined();
     expect(_tokenize).toHaveBeenCalled();
+    expect(root.find(`.${styles.highlightingDisabled}`)).toHaveLength(0);
   });
 
-  it('does not generate or pass in tokens for a diff that cannot be highlighted', () => {
+  it('disables syntax highlighting when not possible', () => {
     const _tokenize = jest.fn(tokenize);
     const root = renderWithLinterProvider({
       _diffCanBeHighlighted: jest.fn(() => false),
@@ -646,6 +647,13 @@ describe(__filename, () => {
 
     expect(root.find(Diff)).toHaveProp('tokens', undefined);
     expect(_tokenize).not.toHaveBeenCalled();
+    expect(root.find(`.${styles.highlightingDisabled}`)).toHaveLength(1);
+  });
+
+  it('does not show a message about disabled highlighting without a diff', () => {
+    const root = renderWithLinterProvider({ diff: null });
+
+    expect(root.find(`.${styles.highlightingDisabled}`)).toHaveLength(0);
   });
 
   describe('getAllHunkChanges', () => {

--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -7,6 +7,7 @@ import {
   WidgetMap,
   parseDiff,
   getChangeKey,
+  tokenize,
 } from 'react-diff-view';
 import { ShallowWrapper, shallow } from 'enzyme';
 import { History, Location } from 'history';
@@ -18,12 +19,19 @@ import LinterMessage from '../LinterMessage';
 import LinterProvider, { LinterProviderInfo } from '../LinterProvider';
 import GlobalLinterMessages from '../GlobalLinterMessages';
 import { getLanguageFromMimeType } from '../../utils';
-import { ScrollTarget, createInternalVersion } from '../../reducers/versions';
+import {
+  ExternalChange,
+  ExternalHunk,
+  ScrollTarget,
+  createInternalDiff,
+  createInternalVersion,
+} from '../../reducers/versions';
 import {
   createContextWithFakeRouter,
   createFakeHistory,
   createFakeLinterMessagesByPath,
   createFakeLocation,
+  fakeExternalDiff,
   fakeVersion,
   shallowUntilTarget,
   simulateLinterProvider,
@@ -34,6 +42,7 @@ import DiffView, {
   DefaultProps,
   DiffViewBase,
   PublicProps,
+  diffCanBeHighlighted,
   getAllHunkChanges,
 } from '.';
 
@@ -110,6 +119,43 @@ describe(__filename, () => {
   const getWidgetNodes = (widgets: WidgetMap) => {
     // Return a list of truthy React nodes in arbitrary order.
     return Object.values(widgets).filter(Boolean);
+  };
+
+  const createHunkWithChanges = (changes: Partial<ExternalChange>[]) => {
+    return {
+      ...fakeExternalDiff.hunks[0],
+      changes: changes.map((change) => {
+        return {
+          ...fakeExternalDiff.hunks[0].changes[0],
+          ...change,
+        };
+      }),
+    };
+  };
+
+  const createDiffWithHunks = (hunks: ExternalHunk[]) => {
+    const baseVersionId = 1;
+    const headVersionId = 2;
+    const version = {
+      ...fakeVersion,
+      id: headVersionId,
+      file: {
+        ...fakeVersion.file,
+        diff: {
+          ...fakeExternalDiff,
+          hunks,
+        },
+      },
+    };
+    const diff = createInternalDiff({
+      baseVersionId,
+      headVersionId,
+      version,
+    });
+    if (!diff) {
+      throw new Error('The diff was unexpectedly empty');
+    }
+    return diff;
   };
 
   it('renders with no differences', () => {
@@ -572,6 +618,36 @@ describe(__filename, () => {
     expect(getWidgetNodes(widgets).length).toEqual(0);
   });
 
+  it('generates and passes in tokens for a diff that can be highlighted', () => {
+    const _tokenize = jest.fn(tokenize);
+    const root = renderWithLinterProvider({
+      _diffCanBeHighlighted: jest.fn(() => true),
+      _tokenize,
+      diff: createDiffWithHunks([
+        createHunkWithChanges([{ content: '// example content' }]),
+      ]),
+    });
+
+    const diff = root.find(Diff);
+    expect(diff).toHaveProp('tokens');
+    expect(diff.prop('tokens')).toBeDefined();
+    expect(_tokenize).toHaveBeenCalled();
+  });
+
+  it('does not generate or pass in tokens for a diff that cannot be highlighted', () => {
+    const _tokenize = jest.fn(tokenize);
+    const root = renderWithLinterProvider({
+      _diffCanBeHighlighted: jest.fn(() => false),
+      _tokenize,
+      diff: createDiffWithHunks([
+        createHunkWithChanges([{ content: '// pretend this is a long line' }]),
+      ]),
+    });
+
+    expect(root.find(Diff)).toHaveProp('tokens', undefined);
+    expect(_tokenize).not.toHaveBeenCalled();
+  });
+
   describe('getAllHunkChanges', () => {
     it('returns a flattened list of all changes', () => {
       const diff = parseDiff(diffWithDeletions)[0];
@@ -589,6 +665,72 @@ describe(__filename, () => {
       expect(changes.filter((c) => c.lineNumber === 50)[0].content).toEqual(
         '          </Diff>',
       );
+    });
+  });
+
+  describe('diffCanBeHighlighted', () => {
+    it('returns true for a diff with short line lengths', () => {
+      expect(
+        diffCanBeHighlighted(
+          createDiffWithHunks([
+            createHunkWithChanges([{ content: '// example of short line' }]),
+            createHunkWithChanges([
+              { content: '// example of short line' },
+              { content: '// example of short line' },
+            ]),
+          ]),
+          { wideLineLength: 80 },
+        ),
+      ).toEqual(true);
+    });
+
+    it('returns false for a diff with wide line lengths', () => {
+      const wideLine = '// example of a really wide line';
+      expect(
+        diffCanBeHighlighted(
+          createDiffWithHunks([
+            createHunkWithChanges([{ content: '// short line' }]),
+            createHunkWithChanges([
+              { content: '// short line' },
+              { content: wideLine },
+            ]),
+          ]),
+          { wideLineLength: wideLine.length - 1 },
+        ),
+      ).toEqual(false);
+    });
+
+    it('returns true for a diff with a low line count', () => {
+      const highLineCount = 8;
+      expect(
+        diffCanBeHighlighted(
+          createDiffWithHunks([
+            createHunkWithChanges(
+              new Array(highLineCount - 1).fill({
+                content: '// example content',
+              }),
+            ),
+          ]),
+          { highLineCount },
+        ),
+      ).toEqual(true);
+    });
+
+    it('returns false for a diff with a high line count', () => {
+      expect(
+        diffCanBeHighlighted(
+          createDiffWithHunks([
+            createHunkWithChanges([
+              { content: '// example content' },
+              { content: '// example content' },
+              { content: '// example content' },
+              { content: '// example content' },
+            ]),
+            createHunkWithChanges([{ content: '// example content' }]),
+          ]),
+          { highLineCount: 4 },
+        ),
+      ).toEqual(false);
     });
   });
 });

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -13,6 +13,7 @@ import {
   getChangeKey,
   tokenize,
 } from 'react-diff-view';
+import { Alert } from 'react-bootstrap';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import makeClassName from 'classnames';
 
@@ -246,6 +247,13 @@ export class DiffViewBase extends React.Component<Props> {
       // Remove the `#` if `location.hash` is defined
       location.hash.length > 2 ? [location.hash.substring(1)] : [];
 
+    let tokens;
+    if (diff && _diffCanBeHighlighted(diff)) {
+      // TODO: always highlight when we can use a Web Worker.
+      // https://github.com/mozilla/addons-code-manager/issues/928
+      tokens = _tokenize(diff.hunks, options);
+    }
+
     return (
       <div className={styles.DiffView}>
         {!diff && (
@@ -262,6 +270,12 @@ export class DiffViewBase extends React.Component<Props> {
           messages={selectedMessageMap && selectedMessageMap.global}
         />
 
+        {diff && !tokens && (
+          <Alert className={styles.highlightingDisabled} variant="warning">
+            {gettext('Syntax highlighting was disabled for performance')}
+          </Alert>
+        )}
+
         {diff && (
           <React.Fragment key={`${diff.oldRevision}-${diff.newRevision}`}>
             {this.renderHeader(diff)}
@@ -269,13 +283,7 @@ export class DiffViewBase extends React.Component<Props> {
               className={styles.diff}
               diffType={diff.type}
               hunks={diff.hunks}
-              tokens={
-                // TODO: always highlight when we can use a Web Worker.
-                // https://github.com/mozilla/addons-code-manager/issues/928
-                _diffCanBeHighlighted(diff)
-                  ? _tokenize(diff.hunks, options)
-                  : undefined
-              }
+              tokens={tokens}
               viewType={viewType}
               gutterType="anchor"
               generateAnchorID={getChangeKey}

--- a/src/components/DiffView/styles.module.scss
+++ b/src/components/DiffView/styles.module.scss
@@ -46,6 +46,10 @@
   }
 }
 
+.highlightingDisabled {
+  margin: $default-padding;
+}
+
 .globalLinterMessages {
   padding: $default-padding $default-padding 0 $default-padding;
 }

--- a/stories/DiffView.stories.tsx
+++ b/stories/DiffView.stories.tsx
@@ -7,6 +7,7 @@ import DiffView, {
   PublicProps as DiffViewProps,
 } from '../src/components/DiffView';
 import basicDiff from '../src/components/DiffView/fixtures/basicDiff';
+import minifiedDiff from '../src/components/DiffView/fixtures/minifiedDiff';
 import diffWithDeletions from '../src/components/DiffView/fixtures/diffWithDeletions';
 import { LinterMessage, actions } from '../src/reducers/linter';
 import { createInternalVersion } from '../src/reducers/versions';
@@ -194,6 +195,36 @@ storiesOf('DiffView', module)
                   },
                 ],
                 { diff: parseDiff(diffWithDeletions)[0] },
+              );
+            },
+          },
+        ],
+      },
+    ],
+  })
+  .addWithChapters('syntax highlighting disabled', {
+    chapters: [
+      {
+        sections: [
+          {
+            title: 'warning',
+            sectionFn: () => {
+              return render({ diff: parseDiff(minifiedDiff)[0] });
+            },
+          },
+          {
+            title: 'warning with a global message',
+            sectionFn: () => {
+              return renderWithMessages(
+                [
+                  {
+                    line: null,
+                    message: 'There is a problem with this file.',
+                    description: ['This file has a problem'],
+                    type: 'warning',
+                  },
+                ],
+                { diff: parseDiff(minifiedDiff)[0] },
               );
             },
           },


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/942

~~I chose not to add any UI feedback about the disabled highlighting only because this is probably a temporary feature.~~ (there is UI feedback now)

<img width="1350" alt="Screenshot 2019-07-11 12 01 09" src="https://user-images.githubusercontent.com/55398/61070681-e4e33300-a3d4-11e9-8f8a-cd96a6115f14.png">
<img width="1350" alt="Screenshot 2019-07-11 12 01 40" src="https://user-images.githubusercontent.com/55398/61070682-e4e33300-a3d4-11e9-8946-b15b49d5f302.png">