### PR TITLE
Render CodeOverview story in a realistic container

### DIFF
--- a/stories/CodeOverview.stories.tsx
+++ b/stories/CodeOverview.stories.tsx
@@ -4,6 +4,8 @@ import { storiesOf } from '@storybook/react';
 
 import { LinterMessage, actions } from '../src/reducers/linter';
 import longFileSample from './fixtures/long-file-sample';
+import ContentShell from '../src/components/FullscreenGrid/ContentShell';
+import FullscreenGrid, { Header } from '../src/components/FullscreenGrid';
 import CodeOverview from '../src/components/CodeOverview';
 import CodeView from '../src/components/CodeView';
 import configureStore from '../src/configureStore';
@@ -15,7 +17,11 @@ import {
   fakeVersionFile,
   fakeVersionEntry,
 } from '../src/test-helpers';
-import { newLinterMessageUID, renderWithStoreAndRouter } from './utils';
+import {
+  newLinterMessageUID,
+  renderWithStoreAndRouter,
+  rootAttributeParams,
+} from './utils';
 
 const render = ({
   content = JS_SAMPLE,
@@ -48,51 +54,67 @@ const render = ({
   }
 
   return renderWithStoreAndRouter(
-    <div className="CodeOverview-container">
-      <div>
+    <FullscreenGrid>
+      <Header />
+      <ContentShell
+        altSidePanel={<CodeOverview content={content} version={version} />}
+      >
         <CodeView
           content={content}
           mimeType="application/javascript"
           version={version}
         />
-      </div>
-      <CodeOverview content={content} version={version} />
-    </div>,
+      </ContentShell>
+    </FullscreenGrid>,
     { store },
   );
 };
 
+const getParams = () => rootAttributeParams({ fullscreen: true });
+
 storiesOf('CodeOverview', module)
-  .add('short file', () => {
-    return render({ content: JS_SAMPLE });
-  })
-  .add('long file', () => {
-    return render({ content: longFileSample });
-  })
-  .add('long file with messages', () => {
-    return render({
-      content: longFileSample,
-      messages: [
-        {
-          line: 27,
-          type: 'warning',
-          message: 'Use of console.log() detected',
-          description: ['This call to console.log() is pretty much Okay.'],
-        },
-        {
-          line: 66,
-          type: 'notice',
-          message: 'Bizarre use of undefined',
-          description: ["...but I guess it's fine"],
-        },
-        {
-          line: 151,
-          type: 'error',
-          message: 'Use of queryTabs() is not permitted',
-          description: [
-            'Calls to queryTabs() will not work in a future version',
-          ],
-        },
-      ],
-    });
-  });
+  .add(
+    'short file',
+    () => {
+      return render({ content: JS_SAMPLE });
+    },
+    getParams(),
+  )
+  .add(
+    'long file',
+    () => {
+      return render({ content: longFileSample });
+    },
+    getParams(),
+  )
+  .add(
+    'long file with messages',
+    () => {
+      return render({
+        content: longFileSample,
+        messages: [
+          {
+            line: 27,
+            type: 'warning',
+            message: 'Use of console.log() detected',
+            description: ['This call to console.log() is pretty much Okay.'],
+          },
+          {
+            line: 66,
+            type: 'notice',
+            message: 'Bizarre use of undefined',
+            description: ["...but I guess it's fine"],
+          },
+          {
+            line: 151,
+            type: 'error',
+            message: 'Use of queryTabs() is not permitted',
+            description: [
+              'Calls to queryTabs() will not work in a future version',
+            ],
+          },
+        ],
+      });
+    },
+    getParams(),
+  );

--- a/stories/setup/styles.scss
+++ b/stories/setup/styles.scss
@@ -87,12 +87,6 @@ body.fullscreen {
   padding: $default-padding;
 }
 
-.CodeOverview-container {
-  display: grid;
-  grid-template-columns: 3fr 1fr;
-  grid-gap: 10px;
-}
-
 .AccordionMenuStory-ContentShell {
   align-items: center;
   display: flex;


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/952

This broke a while ago. I keep meaning to fix it.

Before:

<img width="904" alt="Screenshot 2019-07-16 20 34 18" src="https://user-images.githubusercontent.com/55398/61340834-9fc26500-a809-11e9-9220-ac4674829ee4.png">


After:

<img width="1050" alt="Screenshot 2019-07-16 20 38 05" src="https://user-images.githubusercontent.com/55398/61340837-a3ee8280-a809-11e9-8a6f-a066f1fd1cde.png">
