### PR TITLE
Add FadableContent to convey trimmed code

### DIFF
--- a/src/components/FadableContent/index.spec.tsx
+++ b/src/components/FadableContent/index.spec.tsx
@@ -1,0 +1,35 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import styles from './styles.module.scss';
+
+import FadableContent, { PublicProps } from '.';
+
+describe(__filename, () => {
+  const render = (props: PublicProps) => {
+    return shallow(<FadableContent {...props} />);
+  };
+
+  it('returns children without a shell when fade=false', () => {
+    const exampleClass = 'example';
+    const root = render({
+      fade: false,
+      children: <div className={exampleClass} />,
+    });
+
+    expect(root.find(`.${exampleClass}`)).toHaveLength(1);
+    expect(root.find(`.${styles.shell}`)).toHaveLength(0);
+  });
+
+  it('returns children in a shell when fade=true', () => {
+    const exampleClass = 'example';
+    const root = render({
+      fade: true,
+      children: <div className={exampleClass} />,
+    });
+
+    const shell = root.find(`.${styles.shell}`);
+    expect(shell).toHaveLength(1);
+    expect(shell.find(`.${exampleClass}`)).toHaveLength(1);
+  });
+});

--- a/src/components/FadableContent/index.tsx
+++ b/src/components/FadableContent/index.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import styles from './styles.module.scss';
+
+export type PublicProps = {
+  children: JSX.Element;
+  fade: boolean;
+};
+
+const FadableContentBase = ({ children, fade }: PublicProps) => {
+  if (!fade) {
+    return children;
+  }
+
+  return <div className={styles.shell}>{children}</div>;
+};
+
+export default FadableContentBase;

--- a/src/components/FadableContent/styles.module.scss
+++ b/src/components/FadableContent/styles.module.scss
@@ -1,0 +1,16 @@
+@import '../../scss/variables';
+
+.shell {
+  position: relative;
+
+  &::after {
+    // This uses rgba() instead of "transparent" because Safari
+    // doesn't handle that keyword well.
+    background-image: linear-gradient(rgba(255, 255, 255, 0), $white);
+    bottom: 0;
+    content: '';
+    height: 50vh;
+    position: absolute;
+    width: 100%;
+  }
+}

--- a/stories/FadableContent.stories.tsx
+++ b/stories/FadableContent.stories.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import configureStore from '../src/configureStore';
+import CodeView from '../src/components/CodeView';
+import FadableContent from '../src/components/FadableContent';
+import { createInternalVersion } from '../src/reducers/versions';
+import { fakeVersion } from '../src/test-helpers';
+import { JS_SAMPLE } from './CodeView.stories';
+import { generateParagraphs, renderWithStoreAndRouter } from './utils';
+
+const renderWithContent = (content: JSX.Element) => {
+  return renderWithStoreAndRouter(
+    <div className="FadableContent-shell">
+      <FadableContent fade>{content}</FadableContent>
+    </div>,
+    { store: configureStore() },
+  );
+};
+
+storiesOf('FadableContent', module)
+  .add('fading out code', () => {
+    return renderWithContent(
+      <CodeView
+        content={JS_SAMPLE}
+        mimeType="application/javascript"
+        version={createInternalVersion(fakeVersion)}
+      />,
+    );
+  })
+  .add('fading out text', () => {
+    return renderWithContent(
+      <React.Fragment>{generateParagraphs(6)}</React.Fragment>,
+    );
+  });

--- a/stories/setup/styles.scss
+++ b/stories/setup/styles.scss
@@ -49,12 +49,15 @@ body.fullscreen {
   }
 }
 
-.FileTreeNodeStory-shell {
+.DiffViewStory-panel,
+.FadableContent-shell,
+.FileTreeNodeStory-shell,
+.FullscreenGridStory-topContent {
   @include border-style();
 }
 
-.DiffViewStory-panel {
-  @include border-style();
+.FadableContent-shell {
+  padding: $default-padding;
 }
 
 .FullscreenGridStory-Header,
@@ -81,8 +84,6 @@ body.fullscreen {
 }
 
 .FullscreenGridStory-topContent {
-  @include border-style();
-
   background-color: lighten(yellow, 47);
   padding: $default-padding;
 }


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/959

Example from the storybook:

<img width="676" alt="Screenshot 2019-07-18 11 33 06" src="https://user-images.githubusercontent.com/55398/61475218-f043da80-a94f-11e9-9fdc-e2eed0b283ef.png">
