### PR TITLE
Add a SlowPageAlert to control optimizations

### DIFF
--- a/src/components/SlowPageAlert/index.spec.tsx
+++ b/src/components/SlowPageAlert/index.spec.tsx
@@ -1,0 +1,93 @@
+import { shallow } from 'enzyme';
+import queryString from 'query-string';
+import * as React from 'react';
+import { Alert } from 'react-bootstrap';
+
+import { allowSlowPagesParam } from '../../utils';
+import { createFakeLocation } from '../../test-helpers';
+
+import SlowPageAlert from '.';
+
+describe(__filename, () => {
+  const render = (otherProps = {}) => {
+    const props = {
+      location: createFakeLocation(),
+      getLinkText: () => 'example link text',
+      getMessage: () => 'example message',
+      ...otherProps,
+    };
+    return shallow(<SlowPageAlert {...props} />);
+  };
+
+  it('renders an alert with text callbacks', () => {
+    const text = 'This page is slow';
+    const linkText = 'Click here to speed it up';
+    const root = render({
+      getMessage: () => text,
+      getLinkText: () => linkText,
+    });
+
+    expect(root.find(Alert).text()).toMatch(text);
+    expect(root.find(Alert.Link).text()).toMatch(linkText);
+  });
+
+  it('calls text getters with slowness state', () => {
+    const location = createFakeLocation();
+    const getMessage = jest.fn(() => 'example message');
+    const getLinkText = jest.fn(() => 'example link text');
+
+    const allowSlowPages = false;
+    const _shouldAllowSlowPages = jest.fn(() => allowSlowPages);
+
+    render({
+      _shouldAllowSlowPages,
+      getMessage,
+      getLinkText,
+      location,
+    });
+
+    expect(_shouldAllowSlowPages).toHaveBeenCalledWith(location);
+
+    expect(getMessage).toHaveBeenCalledWith(allowSlowPages);
+    expect(getLinkText).toHaveBeenCalledWith(allowSlowPages);
+  });
+
+  it.each([true, false])(
+    'links to the inverse of allowSlowPages=%s',
+    (allowSlowPages) => {
+      const root = render({
+        _shouldAllowSlowPages: jest.fn(() => allowSlowPages),
+      });
+
+      expect(root.find(Alert.Link)).toHaveProp(
+        'href',
+        expect.urlWithTheseParams({
+          [allowSlowPagesParam]: String(!allowSlowPages),
+        }),
+      );
+    },
+  );
+
+  it('preserves existing query string parameters', () => {
+    const location = createFakeLocation({
+      search: queryString.stringify({ color: 'red' }),
+    });
+    const link = render({ location }).find(Alert.Link);
+
+    expect(link).toHaveProp(
+      'href',
+      expect.urlWithTheseParams({ color: 'red' }),
+    );
+  });
+
+  it('preserves existing location pathname', () => {
+    const pathname = '/some/path/to/page';
+    const location = createFakeLocation({ pathname });
+    const link = render({ location }).find(Alert.Link);
+
+    expect(link).toHaveProp(
+      'href',
+      expect.stringMatching(new RegExp(`^${pathname}`)),
+    );
+  });
+});

--- a/src/components/SlowPageAlert/index.tsx
+++ b/src/components/SlowPageAlert/index.tsx
@@ -1,0 +1,43 @@
+import { Location } from 'history';
+import * as React from 'react';
+import { Alert } from 'react-bootstrap';
+
+import {
+  allowSlowPagesParam,
+  createAdjustedQueryString,
+  shouldAllowSlowPages,
+} from '../../utils';
+
+type GetTextForSlowState = (allowSlowPages: boolean) => string;
+
+export type PublicProps = {
+  _shouldAllowSlowPages?: (location: Location) => boolean;
+  getLinkText: GetTextForSlowState;
+  getMessage: GetTextForSlowState;
+  location: Location;
+};
+
+const SlowPageAlertBase = ({
+  _shouldAllowSlowPages = shouldAllowSlowPages,
+  getLinkText,
+  getMessage,
+  location,
+}: PublicProps) => {
+  const allowSlowPages = _shouldAllowSlowPages(location);
+
+  const newLocation = `${location.pathname}${createAdjustedQueryString(
+    location,
+    {
+      [allowSlowPagesParam]: !allowSlowPages,
+    },
+  )}`;
+
+  return (
+    <Alert variant="danger">
+      {getMessage(allowSlowPages)}{' '}
+      <Alert.Link href={newLocation}>{getLinkText(allowSlowPages)}</Alert.Link>
+    </Alert>
+  );
+};
+
+export default SlowPageAlertBase;

--- a/src/utils.spec.tsx
+++ b/src/utils.spec.tsx
@@ -3,6 +3,7 @@ import queryString from 'query-string';
 
 import { getCodeLineAnchor } from './components/CodeView/utils';
 import {
+  allowSlowPagesParam,
   createAdjustedQueryString,
   createCodeLineAnchorGetter,
   extractNumber,
@@ -13,6 +14,7 @@ import {
   makeReviewersURL,
   nl2br,
   sanitizeHTML,
+  shouldAllowSlowPages,
 } from './utils';
 import {
   createFakeCompareInfo,
@@ -367,5 +369,33 @@ describe('extractNumber', () => {
   });
   it('returns null if there are no numbers', () => {
     expect(extractNumber('ABC')).toEqual(null);
+  });
+});
+
+describe('shouldAllowSlowPages', () => {
+  it('returns false without any query param', () => {
+    expect(shouldAllowSlowPages(createFakeLocation({ search: '' }))).toEqual(
+      false,
+    );
+  });
+
+  it('returns true with a true query param', () => {
+    expect(
+      shouldAllowSlowPages(
+        createFakeLocation({
+          search: queryString.stringify({ [allowSlowPagesParam]: true }),
+        }),
+      ),
+    ).toEqual(true);
+  });
+
+  it('returns false with a false query param', () => {
+    expect(
+      shouldAllowSlowPages(
+        createFakeLocation({
+          search: queryString.stringify({ [allowSlowPagesParam]: false }),
+        }),
+      ),
+    ).toEqual(false);
   });
 });

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -12,6 +12,7 @@ import { CompareInfo } from './reducers/versions';
 // Querystring params used by the app.
 export const messageUidQueryParam = 'messageUid';
 export const pathQueryParam = 'path';
+export const allowSlowPagesParam = 'allowSlowPages';
 
 export type LocalizedStringMap = {
   [lang: string]: string;
@@ -117,4 +118,8 @@ export const makeReviewersURL = ({
   }
 
   return path;
+};
+
+export const shouldAllowSlowPages = (location: Location) => {
+  return queryString.parse(location.search)[allowSlowPagesParam] === 'true';
 };

--- a/stories/SlowPageAlert.stories.tsx
+++ b/stories/SlowPageAlert.stories.tsx
@@ -1,0 +1,21 @@
+import { Location } from 'history';
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import SlowPageAlert, { PublicProps } from '../src/components/SlowPageAlert';
+import { createFakeLocation } from '../src/test-helpers';
+
+const render = (otherProps: Partial<PublicProps> = {}) => {
+  const props = {
+    getMessage: (allowSlowPages: boolean) =>
+      'This file has been shortened for performance.',
+    getLinkText: (allowSlowPages: boolean) => 'Show the original file.',
+    location: createFakeLocation(),
+    ...otherProps,
+  };
+  return <SlowPageAlert {...props} />;
+};
+
+storiesOf('SlowPageAlert', module).add('default', () => {
+  return render();
+});


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/962

Example:

<img width="679" alt="Screenshot 2019-07-19 16 16 16" src="https://user-images.githubusercontent.com/55398/61566078-966f0d80-aa40-11e9-8891-6c1c5ace1310.png">

Also see https://github.com/mozilla/addons-code-manager/pull/951 for more realistic usage.