### PR TITLE
Show an alert for slow loading files in CodeView

### DIFF
--- a/src/components/CodeView/index.spec.tsx
+++ b/src/components/CodeView/index.spec.tsx
@@ -1,3 +1,4 @@
+import queryString from 'query-string';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
@@ -7,13 +8,15 @@ import { Store } from 'redux';
 
 import configureStore from '../../configureStore';
 import refractor from '../../refractor';
+import FadableContent from '../FadableContent';
 import LinterMessage from '../LinterMessage';
 import LinterProvider, { LinterProviderInfo } from '../LinterProvider';
 import GlobalLinterMessages from '../GlobalLinterMessages';
+import SlowPageAlert from '../SlowPageAlert';
 import { ExternalLinterMessage, getMessageMap } from '../../reducers/linter';
 import { createInternalVersion } from '../../reducers/versions';
 import { getCodeLineAnchor, getCodeLineAnchorID, mapWithDepth } from './utils';
-import { getLanguageFromMimeType } from '../../utils';
+import { allowSlowPagesParam, getLanguageFromMimeType } from '../../utils';
 import {
   createContextWithFakeRouter,
   createFakeExternalLinterResult,
@@ -25,13 +28,19 @@ import {
 } from '../../test-helpers';
 import styles from './styles.module.scss';
 
-import CodeView, { CodeViewBase, PublicProps, scrollToSelectedLine } from '.';
+import CodeView, {
+  CodeViewBase,
+  DefaultProps,
+  PublicProps,
+  scrollToSelectedLine,
+} from '.';
 
 describe(__filename, () => {
-  type RenderParams = Partial<PublicProps> & {
-    location?: Location<{}>;
-    store?: Store;
-  };
+  type RenderParams = Partial<PublicProps> &
+    Partial<DefaultProps> & {
+      location?: Location<{}>;
+      store?: Store;
+    };
 
   const createGlobalExternalMessage = (props = {}) => {
     return {
@@ -136,6 +145,29 @@ describe(__filename, () => {
     });
 
     return { root, selectedMessageMap };
+  };
+
+  const renderSlowLoadingCode = ({
+    _slowLoadingLineCount = 3,
+    content,
+    contentLineCount,
+    ...moreProps
+  }: RenderParams & { contentLineCount?: number } = {}) => {
+    return renderWithLinterProvider({
+      _slowLoadingLineCount,
+      content:
+        content ||
+        // Simulate a long file (which will load slowly) by exceeding the
+        // line limit.
+        new Array(
+          contentLineCount !== undefined
+            ? contentLineCount
+            : _slowLoadingLineCount + 1,
+        )
+          .fill('// example code')
+          .join('\n'),
+      ...moreProps,
+    });
   };
 
   it('renders plain text code when mime type is not supported', () => {
@@ -381,6 +413,64 @@ describe(__filename, () => {
     });
 
     expect(root.find(GlobalLinterMessages)).toHaveProp('messages', []);
+  });
+
+  it('trims the code when too long', () => {
+    const _slowLoadingLineCount = 2;
+    const root = renderSlowLoadingCode({ _slowLoadingLineCount });
+
+    const fadable = root.find(FadableContent);
+    expect(fadable).toHaveProp('fade', true);
+
+    expect(fadable.find(`.${styles.line}`)).toHaveLength(_slowLoadingLineCount);
+
+    // Show the warning twice: top and bottom.
+    expect(root.find(SlowPageAlert)).toHaveLength(2);
+  });
+
+  it('does not trim code when slow pages are allowed', () => {
+    const contentLineCount = 3;
+    const location = createFakeLocation({
+      search: queryString.stringify({ [allowSlowPagesParam]: true }),
+    });
+    const root = renderSlowLoadingCode({
+      _slowLoadingLineCount: contentLineCount - 1,
+      contentLineCount,
+      location,
+    });
+
+    const fadable = root.find(FadableContent);
+    expect(fadable).toHaveProp('fade', false);
+
+    expect(fadable.find(`.${styles.line}`)).toHaveLength(contentLineCount);
+
+    // The warning should only be shown once, at the top.
+    expect(root.find(SlowPageAlert)).toHaveLength(1);
+  });
+
+  it('configures SlowPageAlert', () => {
+    const location = createFakeLocation();
+    const root = renderSlowLoadingCode({ location });
+
+    const message = root.find(SlowPageAlert).at(0);
+
+    expect(message).toHaveProp('location', location);
+
+    expect(message).toHaveProp('getMessage');
+    expect(message).toHaveProp('getLinkText');
+
+    const getMessage = message.prop('getMessage');
+    const getLinkText = message.prop('getLinkText');
+
+    // Pass in allowSlowPages=true|false to test messaging.
+
+    expect(getMessage(true)).toEqual('This file is loading slowly.');
+    expect(getMessage(false)).toEqual(
+      'This file has been shortened to load faster.',
+    );
+
+    expect(getLinkText(true)).toEqual('View a shortened file.');
+    expect(getLinkText(false)).toEqual('View the original file.');
   });
 
   describe('scrollToSelectedLine', () => {

--- a/src/components/CodeView/index.spec.tsx
+++ b/src/components/CodeView/index.spec.tsx
@@ -149,23 +149,21 @@ describe(__filename, () => {
 
   const renderSlowLoadingCode = ({
     _slowLoadingLineCount = 3,
-    content,
     contentLineCount,
+    content = new Array(
+      contentLineCount !== undefined
+        ? contentLineCount
+        : // Simulate a long file (which will load slowly) by exceeding the
+          // line limit.
+          _slowLoadingLineCount + 1,
+    )
+      .fill('// example code')
+      .join('\n'),
     ...moreProps
   }: RenderParams & { contentLineCount?: number } = {}) => {
     return renderWithLinterProvider({
       _slowLoadingLineCount,
-      content:
-        content ||
-        // Simulate a long file (which will load slowly) by exceeding the
-        // line limit.
-        new Array(
-          contentLineCount !== undefined
-            ? contentLineCount
-            : _slowLoadingLineCount + 1,
-        )
-          .fill('// example code')
-          .join('\n'),
+      content,
       ...moreProps,
     });
   };

--- a/src/components/CodeView/index.tsx
+++ b/src/components/CodeView/index.tsx
@@ -3,6 +3,7 @@ import { withRouter, Link, RouteComponentProps } from 'react-router-dom';
 import makeClassName from 'classnames';
 
 import styles from './styles.module.scss';
+import FadableContent from '../FadableContent';
 import LinterMessage from '../LinterMessage';
 import {
   getCodeLineAnchor,
@@ -11,10 +12,18 @@ import {
   mapWithDepth,
 } from './utils';
 import refractor from '../../refractor';
-import { getLanguageFromMimeType } from '../../utils';
+import {
+  gettext,
+  getLanguageFromMimeType,
+  shouldAllowSlowPages,
+} from '../../utils';
 import { Version } from '../../reducers/versions';
 import LinterProvider, { LinterProviderInfo } from '../LinterProvider';
 import GlobalLinterMessages from '../GlobalLinterMessages';
+import SlowPageAlert from '../SlowPageAlert';
+
+// This is how many lines of code it takes to slow down the UI.
+const SLOW_LOADING_LINE_COUNT = 1000;
 
 // This function mimics what https://github.com/rexxars/react-refractor does,
 // but we need a different layout to inline comments so we cannot use this
@@ -46,13 +55,17 @@ export const scrollToSelectedLine = (
 };
 
 export type PublicProps = {
-  _scrollToSelectedLine?: typeof scrollToSelectedLine;
   mimeType: string;
   content: string;
   version: Version;
 };
 
-type Props = PublicProps & RouteComponentProps;
+export type DefaultProps = {
+  _scrollToSelectedLine: typeof scrollToSelectedLine;
+  _slowLoadingLineCount: number;
+};
+
+type Props = PublicProps & DefaultProps & RouteComponentProps;
 
 type RowProps = {
   className: string;
@@ -61,15 +74,46 @@ type RowProps = {
 };
 
 export class CodeViewBase extends React.Component<Props> {
+  static defaultProps: DefaultProps = {
+    _scrollToSelectedLine: scrollToSelectedLine,
+    _slowLoadingLineCount: SLOW_LOADING_LINE_COUNT,
+  };
+
   renderWithLinterInfo = ({ selectedMessageMap }: LinterProviderInfo) => {
     const {
-      _scrollToSelectedLine = scrollToSelectedLine,
+      _scrollToSelectedLine,
+      _slowLoadingLineCount,
       content,
       location,
       mimeType,
     } = this.props;
 
     const language = getLanguageFromMimeType(mimeType);
+    let codeLines = getLines(content);
+    let codeWasTrimmed = false;
+    let codeIsSlowAlert;
+
+    if (codeLines.length >= _slowLoadingLineCount) {
+      if (!shouldAllowSlowPages(location)) {
+        codeLines = codeLines.slice(0, _slowLoadingLineCount);
+        codeWasTrimmed = true;
+      }
+      codeIsSlowAlert = (
+        <SlowPageAlert
+          location={location}
+          getMessage={(allowSlowPages: boolean) => {
+            return allowSlowPages
+              ? gettext('This file is loading slowly.')
+              : gettext('This file has been shortened to load faster.');
+          }}
+          getLinkText={(allowSlowPages: boolean) => {
+            return allowSlowPages
+              ? gettext('View a shortened file.')
+              : gettext('View the original file.');
+          }}
+        />
+      );
+    }
 
     return (
       <React.Fragment>
@@ -82,69 +126,75 @@ export class CodeViewBase extends React.Component<Props> {
           messages={selectedMessageMap && selectedMessageMap.global}
         />
 
-        <div className={styles.CodeView}>
-          <table className={styles.table}>
-            <tbody className={styles.tableBody}>
-              {getLines(content).map((code, i) => {
-                const line = i + 1;
+        {codeIsSlowAlert}
 
-                let rowProps: RowProps = {
-                  id: getCodeLineAnchorID(line),
-                  className: styles.line,
-                };
+        <FadableContent fade={codeWasTrimmed}>
+          <div className={styles.CodeView}>
+            <table className={styles.table}>
+              <tbody className={styles.tableBody}>
+                {codeLines.map((code, i) => {
+                  const line = i + 1;
 
-                if (isLineSelected(rowProps.id, location)) {
-                  rowProps = {
-                    ...rowProps,
-                    className: makeClassName(
-                      rowProps.className,
-                      styles.selectedLine,
-                    ),
-                    ref: _scrollToSelectedLine,
+                  let rowProps: RowProps = {
+                    id: getCodeLineAnchorID(line),
+                    className: styles.line,
                   };
-                }
 
-                return (
-                  <React.Fragment key={`fragment-${line}`}>
-                    <tr {...rowProps}>
-                      <td className={styles.lineNumber}>
-                        <Link
-                          to={{
-                            ...location,
-                            hash: getCodeLineAnchor(line),
-                          }}
-                        >{`${line}`}</Link>
-                      </td>
+                  if (isLineSelected(rowProps.id, location)) {
+                    rowProps = {
+                      ...rowProps,
+                      className: makeClassName(
+                        rowProps.className,
+                        styles.selectedLine,
+                      ),
+                      ref: _scrollToSelectedLine,
+                    };
+                  }
 
-                      <td className={styles.code}>
-                        {renderHighlightedCode(code, language)}
-                      </td>
-                    </tr>
-                    {selectedMessageMap && selectedMessageMap.byLine[line] && (
-                      <tr>
-                        <td
-                          id={`line-${line}-messages`}
-                          className={styles.linterMessages}
-                          colSpan={2}
-                        >
-                          {selectedMessageMap.byLine[line].map((msg) => {
-                            return (
-                              <LinterMessage
-                                inline
-                                key={msg.uid}
-                                message={msg}
-                              />
-                            );
-                          })}
+                  return (
+                    <React.Fragment key={`fragment-${line}`}>
+                      <tr {...rowProps}>
+                        <td className={styles.lineNumber}>
+                          <Link
+                            to={{
+                              ...location,
+                              hash: getCodeLineAnchor(line),
+                            }}
+                          >{`${line}`}</Link>
+                        </td>
+
+                        <td className={styles.code}>
+                          {renderHighlightedCode(code, language)}
                         </td>
                       </tr>
-                    )}
-                  </React.Fragment>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+                      {selectedMessageMap && selectedMessageMap.byLine[line] && (
+                        <tr>
+                          <td
+                            id={`line-${line}-messages`}
+                            className={styles.linterMessages}
+                            colSpan={2}
+                          >
+                            {selectedMessageMap.byLine[line].map((msg) => {
+                              return (
+                                <LinterMessage
+                                  inline
+                                  key={msg.uid}
+                                  message={msg}
+                                />
+                              );
+                            })}
+                          </td>
+                        </tr>
+                      )}
+                    </React.Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </FadableContent>
+        {/* Only show a slow alert at the bottom if the code was trimmed. */}
+        {codeWasTrimmed && codeIsSlowAlert}
       </React.Fragment>
     );
   };
@@ -164,4 +214,6 @@ export class CodeViewBase extends React.Component<Props> {
   }
 }
 
-export default withRouter(CodeViewBase);
+export default withRouter(CodeViewBase) as React.ComponentType<
+  PublicProps & Partial<DefaultProps>
+>;

--- a/src/components/CodeView/index.tsx
+++ b/src/components/CodeView/index.tsx
@@ -23,7 +23,7 @@ import GlobalLinterMessages from '../GlobalLinterMessages';
 import SlowPageAlert from '../SlowPageAlert';
 
 // This is how many lines of code it takes to slow down the UI.
-const SLOW_LOADING_LINE_COUNT = 1000;
+const SLOW_LOADING_LINE_COUNT = 500;
 
 // This function mimics what https://github.com/rexxars/react-refractor does,
 // but we need a different layout to inline comments so we cannot use this

--- a/src/components/CodeView/index.tsx
+++ b/src/components/CodeView/index.tsx
@@ -91,14 +91,14 @@ export class CodeViewBase extends React.Component<Props> {
     const language = getLanguageFromMimeType(mimeType);
     let codeLines = getLines(content);
     let codeWasTrimmed = false;
-    let codeIsSlowAlert;
+    let slowAlert;
 
     if (codeLines.length >= _slowLoadingLineCount) {
       if (!shouldAllowSlowPages(location)) {
         codeLines = codeLines.slice(0, _slowLoadingLineCount);
         codeWasTrimmed = true;
       }
-      codeIsSlowAlert = (
+      slowAlert = (
         <SlowPageAlert
           location={location}
           getMessage={(allowSlowPages: boolean) => {
@@ -126,7 +126,7 @@ export class CodeViewBase extends React.Component<Props> {
           messages={selectedMessageMap && selectedMessageMap.global}
         />
 
-        {codeIsSlowAlert}
+        {slowAlert}
 
         <FadableContent fade={codeWasTrimmed}>
           <div className={styles.CodeView}>
@@ -194,7 +194,7 @@ export class CodeViewBase extends React.Component<Props> {
           </div>
         </FadableContent>
         {/* Only show a slow alert at the bottom if the code was trimmed. */}
-        {codeWasTrimmed && codeIsSlowAlert}
+        {codeWasTrimmed && slowAlert}
       </React.Fragment>
     );
   };


### PR DESCRIPTION
This fixes https://github.com/mozilla/addons-code-manager/issues/947 by trimming code when it's too long and showing an alert about it.

There are **some caveats** listed in https://github.com/mozilla/addons-code-manager/pull/951#issue-298222030 which also apply here.

Large files are trimmed like this:

<img width="1121" alt="Screenshot 2019-07-22 11 56 52" src="https://user-images.githubusercontent.com/55398/61650111-935e6200-ac78-11e9-9475-f5a5642be133.png">

When scrolled to the bottom of the trim, the alert is shown again:

<img width="1137" alt="Screenshot 2019-07-22 11 57 21" src="https://user-images.githubusercontent.com/55398/61650126-9f4a2400-ac78-11e9-8300-374ba34ccb4f.png">

When clicking the button to allow slow pages, it does a full refresh and shows the alert again (only at the top):

<img width="1122" alt="Screenshot 2019-07-22 11 58 05" src="https://user-images.githubusercontent.com/55398/61650181-bee14c80-ac78-11e9-9271-235415fd1ea0.png">
