### PR TITLE
Continue ignoring lodash vulnerability; no user input can exploit it

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -17,5 +17,5 @@ ignore:
   SNYK-JS-LODASH-450202:
     - '*':
         reason: While developers / XPIs do have the ability to inject JSON into our system, nothing that depends on this exact version of lodash is handling incoming JSON data
-        expires: 2019-08-01T00:00:00.000Z
+        expires: 2019-10-01T00:00:00.000Z
 patch: {}


### PR DESCRIPTION
This continues to ignore the [lodash vulnerability](https://snyk.io/vuln/SNYK-JS-LODASH-450202) since none of the affected packages handle user input.

Here is the output of `yarn why lodash` showing everywhere it's used:

<details>
<summary>Output</summary>

```
yarn why v1.17.3
[1/4] Why do we have the module "lodash"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
info 
=> Found "lodash@4.17.11"
info Reasons this module exists
   - "http-proxy-middleware" depends on it
   - Hoisted from "http-proxy-middleware#lodash"
   - Hoisted from "inquirer#lodash"
   - Hoisted from "node-sass#lodash"
   - Hoisted from "@babel#core#lodash"
   - Hoisted from "@storybook#react#lodash"
   - Hoisted from "snyk#lodash"
   - Hoisted from "snyk#snyk-mvn-plugin#lodash"
   - Hoisted from "stmux#pegjs-otf#lodash"
   - Hoisted from "react-scripts#webpack-manifest-plugin#lodash"
   - Hoisted from "snyk#@snyk#dep-graph#lodash"
   - Hoisted from "node-sass#sass-graph#lodash"
   - Hoisted from "enzyme#cheerio#lodash"
   - Hoisted from "snyk#snyk-nuget-plugin#lodash"
   - Hoisted from "react-scripts#eslint-plugin-flowtype#lodash"
   - Hoisted from "react-scripts#eslint#lodash"
   - Hoisted from "react-scripts#eslint-plugin-import#lodash"
   - Hoisted from "@babel#plugin-transform-classes#@babel#helper-define-map#lodash"
   - Hoisted from "snyk#snyk-nodejs-lockfile-parser#lodash"
   - Hoisted from "@babel#preset-env#@babel#plugin-transform-block-scoping#lodash"
   - Hoisted from "snyk#snyk-config#lodash"
   - Hoisted from "@babel#core#@babel#generator#lodash"
   - Hoisted from "eslint-config-amo#eslint-plugin-import#lodash"
   - Hoisted from "@babel#core#@babel#traverse#lodash"
   - Hoisted from "react-scripts#html-webpack-plugin#lodash"
   - Hoisted from "react-scripts#@babel#core#lodash"
   - Hoisted from "@babel#preset-env#@babel#types#lodash"
   - Hoisted from "@storybook#react#babel-plugin-react-docgen#lodash"
   - Hoisted from "jest-enzyme#enzyme-to-json#lodash"
   - Hoisted from "@types#redux-logger#redux#lodash"
   - Hoisted from "snyk#snyk-php-plugin#@snyk#composer-lockfile-parser#lodash"
   - Hoisted from "storybook-addon-root-attribute#@storybook#addons#@storybook#api#lodash"
   - Hoisted from "@storybook#react#@storybook#core#@storybook#ui#lodash"
   - Hoisted from "react-scripts#babel-preset-react-app#@babel#core#lodash"
   - Hoisted from "@babel#preset-env#@babel#plugin-transform-sticky-regex#@babel#helper-regex#lodash"
   - Hoisted from "@storybook#react#react-dev-utils#inquirer#lodash"
   - Hoisted from "react-scripts#eslint#table#lodash"
   - Hoisted from "@babel#preset-env#@babel#plugin-transform-modules-amd#@babel#helper-module-transforms#lodash"
   - Hoisted from "@storybook#react#@storybook#core#@storybook#client-api#lodash"
   - Hoisted from "snyk#snyk-go-plugin#graphlib#lodash"
   - Hoisted from "react-scripts#optimize-css-assets-webpack-plugin#last-call-webpack-plugin#lodash"
   - Hoisted from "node-sass#gaze#globule#lodash"
   - Hoisted from "@storybook#react#@storybook#core#@storybook#ui#react-resize-detector#lodash"
   - Hoisted from "@storybook#react#babel-plugin-react-docgen#react-docgen#async#lodash"
   - Hoisted from "@storybook#storybook-deployer#git-url-parse#parse-domain#mocha#yargs-unparser#lodash"
   - Hoisted from "react-scripts#jest-environment-jsdom-fourteen#jsdom#request-promise-native#request-promise-core#lodash"
info Disk size without dependencies: "4.86MB"
info Disk size with unique dependencies: "4.86MB"
info Disk size with transitive dependencies: "4.86MB"
info Number of shared dependencies: 0
Done in 0.92s.
```

</details>