### PR TITLE
Update storybook for file trees

### DIFF
--- a/stories/setup/styles.scss
+++ b/stories/setup/styles.scss
@@ -100,3 +100,7 @@ body.fullscreen {
   grid-gap: 5px;
   grid-template-columns: min-content auto;
 }
+
+.FileTreeStory-smallWidth {
+  width: 200px;
+}


### PR DESCRIPTION
Fixes #431 
<details><summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/4984681/62830101-10b92a80-bbc6-11e9-9ca0-855ec0a67fdf.png)
</details>

We have to adjust the browser size to see the long file name truncated. I am not sure if  I should limit the width of the FileTree like this.
<details><summary> Patch </summary>

``` diff
diff --git a/stories/FileTree.stories.tsx b/stories/FileTree.stories.tsx
index ef3aede..c8bce15 100644
--- a/stories/FileTree.stories.tsx
+++ b/stories/FileTree.stories.tsx
@@ -176,4 +176,6 @@ const render = ({ ...moreProps }: Partial<FileTreeProps> = {}) => {
   return renderWithStoreAndRouter(<FileTree {...props} />, { store });
 };
 
-storiesOf('FileTree', module).add('default', () => render());
+storiesOf('FileTree', module).add('default', () => {
+  return <div className='FileTreeStory-container'> {render()}</div>;
+});
diff --git a/stories/setup/styles.scss b/stories/setup/styles.scss
index e9e2dbf..51c81c2 100644
--- a/stories/setup/styles.scss
+++ b/stories/setup/styles.scss
@@ -93,3 +93,7 @@ body.fullscreen {
   display: flex;
   justify-content: center;
 }
+
+.FileTreeStory-container {
+    width: 25%;
+}

```
</details>