### PR TITLE
Adds a thunk for creating / updating a comment

### DIFF
--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -293,26 +293,6 @@ type CommentRequest = {
   lineno?: number | null;
 };
 
-type CreateOrUpdateCommentParamsBase = {
-  _callApi?: typeof callApi;
-  addonId: number;
-  apiState: ApiState;
-  commentId: number | void;
-  fileName: string | null;
-  line: number | null;
-  versionId: number;
-};
-
-type CreateOrUpdateCommentParams = CreateOrUpdateCommentParamsBase & {
-  cannedResponseId?: undefined;
-  comment: string;
-};
-
-type CreateOrUpdateCannedCommentParams = CreateOrUpdateCommentParamsBase & {
-  cannedResponseId: number;
-  comment?: undefined;
-};
-
 export const createOrUpdateComment = async ({
   /* istanbul ignore next */
   _callApi = callApi,
@@ -324,7 +304,17 @@ export const createOrUpdateComment = async ({
   fileName,
   line,
   versionId,
-}: CreateOrUpdateCommentParams | CreateOrUpdateCannedCommentParams) => {
+}: {
+  _callApi?: typeof callApi;
+  addonId: number;
+  apiState: ApiState;
+  cannedResponseId?: number;
+  comment?: string;
+  commentId: number | void;
+  fileName: string | null;
+  line: number | null;
+  versionId: number;
+}) => {
   if (cannedResponseId === undefined && comment === undefined) {
     throw new Error('Either cannedResponseId or comment must be specified');
   }


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/988

~~⚠️ This depends on https://github.com/mozilla/addons-code-manager/pull/1040~~

@bobsilverberg I removed the type safety around accepting `comment` or `cannedResponseId` because I ran into errors. I'd need to switch the params to [discriminated unions](https://basarat.gitbooks.io/typescript/docs/types/discriminated-unions.html) to fix it; I don't think that's worth it. For example, I'd need to add a literal `type` field so that one call has `{ type: 'COMMENT' }` and the other has `{ type: 'CANNED_COMMENT' }`.