### PR TITLE
Fix problem generating UnhandledPromiseRejectionWarnings

### DIFF
--- a/src/components/KeyboardShortcuts/index.spec.tsx
+++ b/src/components/KeyboardShortcuts/index.spec.tsx
@@ -23,6 +23,7 @@ import {
   createFakeLocation,
   createFakeThunk,
   createStoreWithVersion,
+  fakeAction,
   fakeExternalLinterMessage,
   fakeVersion,
   fakeVersionEntry,
@@ -83,6 +84,9 @@ describe(__filename, () => {
 
   const render = ({
     _createCodeLineAnchorGetter = jest.fn(),
+    _goToRelativeDiff = jest.fn(),
+    _goToRelativeFile = jest.fn().mockReturnValue(fakeAction),
+    _goToRelativeMessage = jest.fn().mockReturnValue(fakeAction),
     compareInfo = null,
     currentPath = 'file1.js',
     location = createFakeLocation(),
@@ -95,6 +99,9 @@ describe(__filename, () => {
   }: RenderParams = {}) => {
     const props = {
       _createCodeLineAnchorGetter,
+      _goToRelativeDiff,
+      _goToRelativeFile,
+      _goToRelativeMessage,
       compareInfo,
       currentPath,
       location,

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -7,6 +7,7 @@ import { History, Location } from 'history';
 import { ShallowWrapper, shallow } from 'enzyme';
 import { Store } from 'redux';
 import log from 'loglevel';
+import { createAction } from 'typesafe-actions';
 
 import configureStore, { ThunkActionCreator } from './configureStore';
 import { ApplicationState } from './reducers';
@@ -775,3 +776,5 @@ export const createFakeComment = (comment: Partial<Comment> = {}) => {
     ...comment,
   };
 };
+
+export const fakeAction = createAction('FAKE_ACTION');


### PR DESCRIPTION
Fixes #1046 

The removes the `UnhandledPromiseRejectionWarning`s and also fixes the test failures that came from just using plain `jest` stubs. I'm not sure if this is the correct or proper fix, though, so feedback is appreciated.