### PR TITLE
Add a CommentList component

### DIFF
--- a/src/components/Comment/index.spec.tsx
+++ b/src/components/Comment/index.spec.tsx
@@ -10,6 +10,7 @@ import {
   createFakeChangeEvent,
   createFakeEvent,
   createFakeThunk,
+  dispatchComments,
   shallowUntilTarget,
   spyOn,
 } from '../../test-helpers';
@@ -40,17 +41,6 @@ describe(__filename, () => {
     });
   };
 
-  const dispatchComment = ({
-    store = configureStore(),
-    comment = createFakeExternalComment(),
-    fileName = null,
-    line = null,
-    versionId = 1,
-  } = {}) => {
-    store.dispatch(actions.setComment({ fileName, line, versionId, comment }));
-    return { store };
-  };
-
   const createFakeTextareaRef = (currentProps = {}) => {
     return {
       ...React.createRef(),
@@ -63,6 +53,13 @@ describe(__filename, () => {
       },
     };
   };
+
+  it('lets you set a custom class', () => {
+    const className = 'ExampleClass';
+    const root = render({ className });
+
+    expect(root).toHaveClassName(className);
+  });
 
   it('requires a comment when readOnly=true', () => {
     expect(() => render({ readOnly: true, commentId: null })).toThrow(
@@ -79,7 +76,7 @@ describe(__filename, () => {
   it('renders a comment when readOnly=true', () => {
     const content = 'Example of a comment';
     const comment = createFakeExternalComment({ comment: content });
-    const { store } = dispatchComment({ comment });
+    const { store } = dispatchComments({ comments: [comment] });
 
     const root = render({ commentId: comment.id, store, readOnly: true });
 
@@ -91,7 +88,7 @@ describe(__filename, () => {
 
   it('sanitizes the content of a comment', () => {
     const comment = createFakeExternalComment({ comment: '<span>foo</span>' });
-    const { store } = dispatchComment({ comment });
+    const { store } = dispatchComments({ comments: [comment] });
 
     const root = render({ commentId: comment.id, store, readOnly: true });
 
@@ -108,7 +105,7 @@ describe(__filename, () => {
     const comment = createFakeExternalComment({
       comment: `${firstLine}\n${secondLine}`,
     });
-    const { store } = dispatchComment({ comment });
+    const { store } = dispatchComments({ comments: [comment] });
 
     const root = render({ commentId: comment.id, store, readOnly: true });
 
@@ -118,7 +115,7 @@ describe(__filename, () => {
 
   it('renders a form to edit a comment when readOnly=false', () => {
     const comment = createFakeExternalComment({ comment: 'Example' });
-    const { store } = dispatchComment({ comment });
+    const { store } = dispatchComments({ comments: [comment] });
     const root = render({ commentId: comment.id, store, readOnly: false });
 
     expect(root.find(`.${styles.form}`)).toHaveLength(1);
@@ -210,7 +207,7 @@ describe(__filename, () => {
       id: commentId,
       comment: commentText,
     });
-    const { store } = dispatchComment({ comment });
+    const { store } = dispatchComments({ comments: [comment] });
 
     const root = render({ commentId, store });
 
@@ -240,7 +237,7 @@ describe(__filename, () => {
       id: commentId,
       comment: previousCommentText,
     });
-    const { store } = dispatchComment({ comment });
+    const { store } = dispatchComments({ comments: [comment] });
     const dispatchSpy = spyOn(store, 'dispatch');
 
     const commentText = 'Example of an edited comment';

--- a/src/components/Comment/index.spec.tsx
+++ b/src/components/Comment/index.spec.tsx
@@ -10,7 +10,7 @@ import {
   createFakeChangeEvent,
   createFakeEvent,
   createFakeThunk,
-  dispatchComments,
+  dispatchComment,
   shallowUntilTarget,
   spyOn,
 } from '../../test-helpers';
@@ -76,7 +76,7 @@ describe(__filename, () => {
   it('renders a comment when readOnly=true', () => {
     const content = 'Example of a comment';
     const comment = createFakeExternalComment({ comment: content });
-    const { store } = dispatchComments({ comments: [comment] });
+    const { store } = dispatchComment({ comment });
 
     const root = render({ commentId: comment.id, store, readOnly: true });
 
@@ -88,7 +88,7 @@ describe(__filename, () => {
 
   it('sanitizes the content of a comment', () => {
     const comment = createFakeExternalComment({ comment: '<span>foo</span>' });
-    const { store } = dispatchComments({ comments: [comment] });
+    const { store } = dispatchComment({ comment });
 
     const root = render({ commentId: comment.id, store, readOnly: true });
 
@@ -105,7 +105,7 @@ describe(__filename, () => {
     const comment = createFakeExternalComment({
       comment: `${firstLine}\n${secondLine}`,
     });
-    const { store } = dispatchComments({ comments: [comment] });
+    const { store } = dispatchComment({ comment });
 
     const root = render({ commentId: comment.id, store, readOnly: true });
 
@@ -115,7 +115,7 @@ describe(__filename, () => {
 
   it('renders a form to edit a comment when readOnly=false', () => {
     const comment = createFakeExternalComment({ comment: 'Example' });
-    const { store } = dispatchComments({ comments: [comment] });
+    const { store } = dispatchComment({ comment });
     const root = render({ commentId: comment.id, store, readOnly: false });
 
     expect(root.find(`.${styles.form}`)).toHaveLength(1);
@@ -207,7 +207,7 @@ describe(__filename, () => {
       id: commentId,
       comment: commentText,
     });
-    const { store } = dispatchComments({ comments: [comment] });
+    const { store } = dispatchComment({ comment });
 
     const root = render({ commentId, store });
 
@@ -237,7 +237,7 @@ describe(__filename, () => {
       id: commentId,
       comment: previousCommentText,
     });
-    const { store } = dispatchComments({ comments: [comment] });
+    const { store } = dispatchComment({ comment });
     const dispatchSpy = spyOn(store, 'dispatch');
 
     const commentText = 'Example of an edited comment';

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import makeClassName from 'classnames';
 import { connect } from 'react-redux';
 import Textarea from 'react-textarea-autosize';
 import { Button, Form } from 'react-bootstrap';
@@ -18,6 +19,7 @@ type TextareaRef = React.RefObject<HTMLTextAreaElement> | undefined;
 
 export type PublicProps = {
   addonId: number;
+  className?: string;
   commentId: number | null;
   fileName: string | null;
   line: number | null;
@@ -166,9 +168,9 @@ export class CommentBase extends React.Component<Props, State> {
   }
 
   render() {
-    const { readOnly } = this.props;
+    const { className, readOnly } = this.props;
     return (
-      <div className={styles.container}>
+      <div className={makeClassName(styles.container, className)}>
         {readOnly ? this.renderComment() : this.renderForm()}
       </div>
     );

--- a/src/components/CommentList/index.spec.tsx
+++ b/src/components/CommentList/index.spec.tsx
@@ -1,0 +1,207 @@
+import * as React from 'react';
+import { Store } from 'redux';
+
+import Comment from '../Comment';
+import configureStore from '../../configureStore';
+import {
+  ExternalComment,
+  actions as commentsActions,
+} from '../../reducers/comments';
+import {
+  createFakeExternalComment,
+  dispatchComments,
+  shallowUntilTarget,
+} from '../../test-helpers';
+
+import CommentList, { CommentListBase, PublicProps } from '.';
+
+describe(__filename, () => {
+  type RenderParams = Partial<PublicProps> & { store?: Store };
+
+  const render = ({
+    addonId = 1,
+    children = (content: JSX.Element) => content,
+    fileName = null,
+    line = null,
+    versionId = 2,
+    store = configureStore(),
+    ...moreProps
+  }: RenderParams = {}) => {
+    const props = {
+      addonId,
+      children,
+      fileName,
+      line,
+      versionId,
+      ...moreProps,
+    };
+    return shallowUntilTarget(<CommentList {...props} />, CommentListBase, {
+      shallowOptions: { context: { store } },
+    });
+  };
+
+  const createKeyParams = () => {
+    return { fileName: null, line: null, versionId: 1 };
+  };
+
+  const renderComments = ({
+    comments = [createFakeExternalComment()],
+    fileName,
+    line,
+    versionId,
+    ...props
+  }: RenderParams & { comments?: ExternalComment[] } = {}) => {
+    if (
+      fileName !== undefined ||
+      line !== undefined ||
+      versionId !== undefined
+    ) {
+      throw new Error('Defining custom key parameters is not supported');
+    }
+    const keyParams = createKeyParams();
+    const { store } = dispatchComments({ ...keyParams, comments });
+
+    return render({ ...keyParams, store, ...props });
+  };
+
+  it('lets you add a custom class', () => {
+    const className = 'ExampleClass';
+    const root = renderComments({ className });
+
+    expect(root).toHaveClassName(className);
+  });
+
+  it('renders null when no comments exist', () => {
+    expect(render()).toBeEmptyRender();
+  });
+
+  it('renders saved comments', () => {
+    const addonId = 3214;
+    const keyParams = createKeyParams();
+    const comments = [
+      createFakeExternalComment({ id: 1 }),
+      createFakeExternalComment({ id: 2 }),
+    ];
+    const { store } = dispatchComments({ ...keyParams, comments });
+
+    const root = render({ ...keyParams, addonId, store });
+
+    const list = root.find(Comment);
+    expect(list).toHaveLength(comments.length);
+    expect(list.at(0)).toHaveProp('commentId', comments[0].id);
+    expect(list.at(1)).toHaveProp('commentId', comments[1].id);
+
+    // Check one sample to make sure it's configured:
+    const sample = list.at(1);
+    expect(sample).toHaveProp('readOnly', true);
+    expect(sample).toHaveProp('addonId', addonId);
+    expect(sample).toHaveProp('fileName', keyParams.fileName);
+    expect(sample).toHaveProp('line', keyParams.line);
+    expect(sample).toHaveProp('versionId', keyParams.versionId);
+  });
+
+  it('renders a comment entry form', () => {
+    const addonId = 3214;
+    const keyParams = createKeyParams();
+    const store = configureStore();
+    store.dispatch(commentsActions.beginComment(keyParams));
+
+    const root = render({ ...keyParams, addonId, store });
+
+    const comment = root.find(Comment);
+
+    expect(comment).toHaveLength(1);
+    expect(comment).toHaveProp('readOnly', false);
+    expect(comment).toHaveProp('commentId', null);
+    expect(comment).toHaveProp('addonId', addonId);
+    expect(comment).toHaveProp('fileName', keyParams.fileName);
+    expect(comment).toHaveProp('line', keyParams.line);
+    expect(comment).toHaveProp('versionId', keyParams.versionId);
+  });
+
+  it('renders a comment entry form and comments', () => {
+    const keyParams = createKeyParams();
+    const savedCommentId1 = 1;
+    const savedCommentId2 = 2;
+    const store = configureStore();
+
+    store.dispatch(commentsActions.beginComment(keyParams));
+    dispatchComments({
+      ...keyParams,
+      comments: [
+        createFakeExternalComment({ id: savedCommentId1 }),
+        createFakeExternalComment({ id: savedCommentId2 }),
+      ],
+      store,
+    });
+
+    const root = render({ ...keyParams, store });
+
+    const list = root.find(Comment);
+    expect(list).toHaveLength(3);
+
+    // Check the from entry.
+    expect(list.at(0)).toHaveProp('readOnly', false);
+    expect(list.at(0)).toHaveProp('commentId', null);
+
+    // Check the saved comments.
+    expect(list.at(1)).toHaveProp('readOnly', true);
+    expect(list.at(1)).toHaveProp('commentId', savedCommentId1);
+
+    expect(list.at(2)).toHaveProp('readOnly', true);
+    expect(list.at(2)).toHaveProp('commentId', savedCommentId2);
+  });
+
+  it('can render comments in a custom wrapper', () => {
+    const className = 'ExampleClass';
+    const comments = [createFakeExternalComment()];
+
+    const root = renderComments({
+      children: (content: JSX.Element) => {
+        return <div className={className}>{content}</div>;
+      },
+      comments,
+    });
+
+    expect(root).toHaveClassName(className);
+    expect(root.find(Comment)).toHaveLength(comments.length);
+  });
+
+  it('does not render in the custom wrapper without any output', () => {
+    const className = 'ExampleClass';
+
+    const root = render({
+      children: (content: JSX.Element) => {
+        return <div className={className}>{content}</div>;
+      },
+    });
+
+    expect(root).not.toHaveClassName(className);
+    expect(root).toBeEmptyRender();
+  });
+
+  it('does not render comments for different keys', () => {
+    const keyBase = { fileName: null, line: null };
+    const versionId1 = 1;
+    const versionId2 = 2;
+
+    const store = configureStore();
+
+    const keyParams = { ...keyBase, versionId: versionId1 };
+    store.dispatch(commentsActions.beginComment(keyParams));
+    dispatchComments({
+      ...keyParams,
+      comments: [
+        createFakeExternalComment({ id: 1 }),
+        createFakeExternalComment({ id: 2 }),
+      ],
+      store,
+    });
+
+    // Render for a different versionId.
+    const root = render({ ...keyBase, versionId: versionId2, store });
+
+    expect(root.find(Comment)).toHaveLength(0);
+    expect(root).toBeEmptyRender();
+  });
+});

--- a/src/components/CommentList/index.spec.tsx
+++ b/src/components/CommentList/index.spec.tsx
@@ -40,9 +40,7 @@ describe(__filename, () => {
     });
   };
 
-  const createKeyParams = () => {
-    return { fileName: null, line: null, versionId: 1 };
-  };
+  const keyParams = Object.freeze({ fileName: null, line: null, versionId: 1 });
 
   const renderComments = ({
     comments = [createFakeExternalComment()],
@@ -58,7 +56,6 @@ describe(__filename, () => {
     ) {
       throw new Error('Defining custom key parameters is not supported');
     }
-    const keyParams = createKeyParams();
     const { store } = dispatchComments({ ...keyParams, comments });
 
     return render({ ...keyParams, store, ...props });
@@ -77,7 +74,6 @@ describe(__filename, () => {
 
   it('renders saved comments', () => {
     const addonId = 3214;
-    const keyParams = createKeyParams();
     const comments = [
       createFakeExternalComment({ id: 1 }),
       createFakeExternalComment({ id: 2 }),
@@ -102,7 +98,6 @@ describe(__filename, () => {
 
   it('renders a comment entry form', () => {
     const addonId = 3214;
-    const keyParams = createKeyParams();
     const store = configureStore();
     store.dispatch(commentsActions.beginComment(keyParams));
 
@@ -120,7 +115,6 @@ describe(__filename, () => {
   });
 
   it('renders a comment entry form and comments', () => {
-    const keyParams = createKeyParams();
     const savedCommentId1 = 1;
     const savedCommentId2 = 2;
     const store = configureStore();
@@ -187,10 +181,10 @@ describe(__filename, () => {
 
     const store = configureStore();
 
-    const keyParams = { ...keyBase, versionId: versionId1 };
-    store.dispatch(commentsActions.beginComment(keyParams));
+    const otherKeyParams = { ...keyBase, versionId: versionId1 };
+    store.dispatch(commentsActions.beginComment(otherKeyParams));
     dispatchComments({
-      ...keyParams,
+      ...otherKeyParams,
       comments: [
         createFakeExternalComment({ id: 1 }),
         createFakeExternalComment({ id: 2 }),

--- a/src/components/CommentList/index.tsx
+++ b/src/components/CommentList/index.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+
+import { ApplicationState } from '../../reducers';
+import {
+  CommentKeyParams,
+  CommentInfo,
+  createCommentKey,
+} from '../../reducers/comments';
+import Comment from '../Comment';
+import styles from './styles.module.scss';
+
+export type PublicProps = CommentKeyParams & {
+  addonId: number;
+  children: (content: JSX.Element) => JSX.Element;
+  className?: string;
+};
+
+type PropsFromState = {
+  commentInfo: CommentInfo | undefined;
+};
+
+type Props = PublicProps & PropsFromState;
+
+export class CommentListBase extends React.Component<Props> {
+  render() {
+    const {
+      addonId,
+      children,
+      className,
+      commentInfo,
+      fileName,
+      line,
+      versionId,
+    } = this.props;
+    const comments = [];
+
+    if (commentInfo) {
+      const base = {
+        addonId,
+        className: styles.comment,
+        fileName,
+        line,
+        versionId,
+      };
+
+      if (commentInfo.beginNewComment) {
+        comments.push(
+          <Comment
+            {...base}
+            commentId={null}
+            key="comment-entry-form"
+            readOnly={false}
+          />,
+        );
+      }
+      for (const id of commentInfo.commentIds) {
+        comments.push(<Comment {...base} commentId={id} key={id} readOnly />);
+      }
+    }
+
+    if (comments.length === 0) {
+      return null;
+    }
+
+    return children(
+      // This is wrapped in a div so that :first-child works consistently.
+      <div className={className}>{comments}</div>,
+    );
+  }
+}
+
+const mapStateToProps = (
+  state: ApplicationState,
+  { versionId, fileName, line }: PublicProps,
+): PropsFromState => {
+  const key = createCommentKey({ versionId, fileName, line });
+  return {
+    commentInfo: state.comments.byKey[key],
+  };
+};
+
+export default connect(mapStateToProps)(CommentListBase);

--- a/src/components/CommentList/styles.module.scss
+++ b/src/components/CommentList/styles.module.scss
@@ -1,0 +1,3 @@
+.comment:not(:first-child) {
+  padding-top: 0;
+}

--- a/src/reducers/comments.tsx
+++ b/src/reducers/comments.tsx
@@ -90,7 +90,7 @@ export const createEmptyCommentInfo = (): CommentInfo => {
   };
 };
 
-type CommentKeyParams = {
+export type CommentKeyParams = {
   fileName: string | null;
   line: number | null;
   versionId: number;

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -806,3 +806,11 @@ export const dispatchComments = ({
   }
   return { store };
 };
+
+export const dispatchComment = ({
+  /* istanbul ignore next */
+  comment = createFakeExternalComment(),
+  ...params
+} = {}) => {
+  return dispatchComments({ comments: [comment], ...params });
+};

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -14,6 +14,7 @@ import { ApplicationState } from './reducers';
 import {
   Comment,
   ExternalComment,
+  actions as commentsActions,
   createInternalComment,
 } from './reducers/comments';
 import {
@@ -789,3 +790,19 @@ export const createFakeComment = (comment: Partial<Comment> = {}) => {
 };
 
 export const fakeAction = createAction('FAKE_ACTION');
+
+export const dispatchComments = ({
+  store = configureStore(),
+  /* istanbul ignore next */
+  comments = [createFakeExternalComment()],
+  fileName = null,
+  line = null,
+  versionId = 1,
+} = {}) => {
+  for (const comment of comments) {
+    store.dispatch(
+      commentsActions.setComment({ fileName, line, versionId, comment }),
+    );
+  }
+  return { store };
+};

--- a/stories/CommentList.stories.tsx
+++ b/stories/CommentList.stories.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react';
+import { Store } from 'redux';
+import { storiesOf } from '@storybook/react';
+
+import configureStore from '../src/configureStore';
+import { AnyReactNode } from '../src/typeUtils';
+import CommentList, { PublicProps } from '../src/components/CommentList';
+import {
+  ExternalComment,
+  actions as commentsActions,
+} from '../src/reducers/comments';
+import { createFakeExternalComment } from '../src/test-helpers';
+import { renderWithStoreAndRouter } from './utils';
+
+const render = ({
+  addonId = 1,
+  beginComment = false,
+  comments = [],
+  fileName = null,
+  line = null,
+  store = configureStore(),
+  versionId = 2,
+  ...moreProps
+}: Partial<PublicProps> & {
+  beginComment?: boolean;
+  store?: Store;
+  comments?: ExternalComment[];
+} = {}) => {
+  if (beginComment) {
+    store.dispatch(commentsActions.beginComment({ fileName, line, versionId }));
+  }
+  for (const comment of comments) {
+    store.dispatch(
+      commentsActions.setComment({
+        fileName,
+        line,
+        versionId,
+        comment,
+      }),
+    );
+  }
+
+  const indent = <>&nbsp;&nbsp;</>;
+  const codeLine = (...content: AnyReactNode[]) => {
+    return (
+      <p>
+        <code>{content}</code>
+      </p>
+    );
+  };
+
+  const props = {
+    addonId,
+    fileName,
+    line,
+    versionId,
+    ...moreProps,
+  };
+
+  return renderWithStoreAndRouter(
+    <div className="CommentListStory">
+      {codeLine('body {')}
+      {codeLine(indent, 'margin: 0;')}
+      {codeLine(indent, 'padding: 0;')}
+
+      <CommentList {...props}>{(content) => content}</CommentList>
+
+      {codeLine(indent, 'background-color: "fuschia";')}
+      {codeLine(indent, 'box-sizing: border-box;')}
+      {codeLine('}')}
+
+      {codeLine(indent)}
+
+      {codeLine('button {')}
+      {codeLine(indent, 'color: "blue";')}
+      {codeLine('}')}
+    </div>,
+    { store },
+  );
+};
+
+storiesOf('CommentList', module)
+  .add('One comment', () => {
+    return render({
+      comments: [
+        createFakeExternalComment({
+          id: 1,
+          comment: 'This is unnecessary due to the reset library up above',
+        }),
+      ],
+    });
+  })
+  .add('Multiple comments', () => {
+    return render({
+      comments: [
+        createFakeExternalComment({
+          id: 1,
+          comment: 'This is unnecessary due to the reset library up above',
+        }),
+        createFakeExternalComment({
+          id: 2,
+          comment: 'Thanks for promptly addressing our other change requests',
+        }),
+      ],
+    });
+  })
+  .add('Comment entry form', () => {
+    return render({ beginComment: true });
+  })
+  .add('Comment entry form with saved comments', () => {
+    return render({
+      beginComment: true,
+      comments: [
+        createFakeExternalComment({
+          id: 1,
+          comment: 'This is unnecessary due to the reset library up above',
+        }),
+        createFakeExternalComment({
+          id: 2,
+          comment: 'Thanks for promptly addressing our other change requests',
+        }),
+      ],
+    });
+  });

--- a/stories/setup/styles.scss
+++ b/stories/setup/styles.scss
@@ -104,3 +104,8 @@ body.fullscreen {
 .FileTreeStory-smallWidth {
   width: 200px;
 }
+
+.CommentListStory p {
+  margin: 0;
+  padding: 0 $default-padding;
+}


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/1054

This will be used in `CodeView` to show code comments inline (and in other places later). Here is an example from the storybook:

<img width="669" alt="Screenshot 2019-09-12 16 38 05" src="https://user-images.githubusercontent.com/55398/64824007-7e1df980-d57e-11e9-977a-8a4969b46347.png">
