### PR TITLE
Support commenting on a line of a file

### DIFF
--- a/.env
+++ b/.env
@@ -24,3 +24,6 @@ PUBLIC_URL=https://addons-code-manager.cdn.mozilla.net
 
 # When true, allow the app to trigger errors that will be reported to Sentry.
 REACT_APP_UNSAFE_ERROR_SIMULATION=false
+
+# When true, commenting features will be enabled.
+REACT_APP_ENABLE_COMMENTING=false

--- a/.env.dev
+++ b/.env.dev
@@ -6,3 +6,5 @@ PUBLIC_URL=https://addons-code-manager-dev-cdn.allizom.org
 
 # This is the reviewers host for images.
 REACT_APP_REVIEWERS_HOST=https://reviewers.addons-dev.allizom.org
+
+REACT_APP_ENABLE_COMMENTING=true

--- a/src/components/CodeView/index.spec.tsx
+++ b/src/components/CodeView/index.spec.tsx
@@ -172,13 +172,13 @@ describe(__filename, () => {
     const { provider, renderContent } = simulateCommentableLine({
       mimeType,
     });
-    const root = renderContent();
+    const line = renderContent();
 
     expect(provider.find(`.${styles.CodeView}`)).toHaveLength(1);
-    expect(root.find(`.${styles.lineNumber}`)).toHaveLength(1);
-    expect(root.find(`.${styles.code}`)).toHaveLength(1);
-    expect(root.find(`.${styles.highlightedCode}`)).toHaveLength(1);
-    expect(root.find('.language-text')).toHaveLength(1);
+    expect(line.find(`.${styles.lineNumber}`)).toHaveLength(1);
+    expect(line.find(`.${styles.code}`)).toHaveLength(1);
+    expect(line.find(`.${styles.highlightedCode}`)).toHaveLength(1);
+    expect(line.find('.language-text')).toHaveLength(1);
   });
 
   it('renders highlighted code when language is supported', () => {
@@ -188,14 +188,14 @@ describe(__filename, () => {
       mimeType,
       content,
     });
-    const root = renderContent();
+    const line = renderContent();
 
-    expect(root.find(`.${styles.lineNumber}`)).toHaveLength(1);
-    expect(root.find(`.${styles.code}`)).toHaveLength(1);
-    expect(root.find(`.${styles.highlightedCode}`)).toHaveLength(1);
+    expect(line.find(`.${styles.lineNumber}`)).toHaveLength(1);
+    expect(line.find(`.${styles.code}`)).toHaveLength(1);
+    expect(line.find(`.${styles.highlightedCode}`)).toHaveLength(1);
 
-    expect(root.find('.language-json')).toHaveLength(1);
-    expect(root.find('.language-json')).toHaveProp(
+    expect(line.find('.language-json')).toHaveLength(1);
+    expect(line.find('.language-json')).toHaveProp(
       'children',
       refractor
         .highlight(content, getLanguageFromMimeType(mimeType))
@@ -266,11 +266,11 @@ describe(__filename, () => {
       location,
     });
 
-    const root = renderContent();
+    const line = renderContent();
 
-    expect(root.find(`.${styles.lineNumber}`)).toHaveLength(1);
-    expect(root.find(`.${styles.lineNumber}`).find(Link)).toHaveLength(1);
-    expect(root.find(`.${styles.lineNumber}`).find(Link)).toHaveProp('to', {
+    expect(line.find(`.${styles.lineNumber}`)).toHaveLength(1);
+    expect(line.find(`.${styles.lineNumber}`).find(Link)).toHaveLength(1);
+    expect(line.find(`.${styles.lineNumber}`).find(Link)).toHaveProp('to', {
       ...location,
       hash: getCodeLineAnchor(1),
     });

--- a/src/components/CodeView/index.tsx
+++ b/src/components/CodeView/index.tsx
@@ -138,11 +138,7 @@ export class CodeViewBase extends React.Component<Props> {
                   let shellRef;
 
                   if (isLineSelected(id, location)) {
-                    className = makeClassName(
-                      styles.line,
-                      className,
-                      styles.selectedLine,
-                    );
+                    className = makeClassName(className, styles.selectedLine);
                     shellRef = _scrollToSelectedLine;
                   }
 

--- a/src/components/CodeView/index.tsx
+++ b/src/components/CodeView/index.tsx
@@ -3,6 +3,8 @@ import { withRouter, Link, RouteComponentProps } from 'react-router-dom';
 import makeClassName from 'classnames';
 
 import styles from './styles.module.scss';
+import Commentable from '../Commentable';
+import CommentList from '../CommentList';
 import FadableContent from '../FadableContent';
 import LinterMessage from '../LinterMessage';
 import {
@@ -46,9 +48,7 @@ const isLineSelected = (
   return `#${id}` === location.hash;
 };
 
-export const scrollToSelectedLine = (
-  element: HTMLTableRowElement | HTMLDivElement | null,
-) => {
+export const scrollToSelectedLine = (element: HTMLElement | null) => {
   if (element) {
     element.scrollIntoView();
   }
@@ -63,20 +63,16 @@ export type PublicProps = {
 export type DefaultProps = {
   _scrollToSelectedLine: typeof scrollToSelectedLine;
   _slowLoadingLineCount: number;
+  enableCommenting: boolean;
 };
 
 type Props = PublicProps & DefaultProps & RouteComponentProps;
-
-type RowProps = {
-  className: string;
-  id: string;
-  ref?: typeof scrollToSelectedLine;
-};
 
 export class CodeViewBase extends React.Component<Props> {
   static defaultProps: DefaultProps = {
     _scrollToSelectedLine: scrollToSelectedLine,
     _slowLoadingLineCount: SLOW_LOADING_LINE_COUNT,
+    enableCommenting: process.env.REACT_APP_ENABLE_COMMENTING === 'true',
   };
 
   renderWithLinterInfo = ({ selectedMessageMap }: LinterProviderInfo) => {
@@ -84,8 +80,10 @@ export class CodeViewBase extends React.Component<Props> {
       _scrollToSelectedLine,
       _slowLoadingLineCount,
       content,
+      enableCommenting,
       location,
       mimeType,
+      version,
     } = this.props;
 
     const language = getLanguageFromMimeType(mimeType);
@@ -134,39 +132,50 @@ export class CodeViewBase extends React.Component<Props> {
               <tbody className={styles.tableBody}>
                 {codeLines.map((code, i) => {
                   const line = i + 1;
+                  const id = getCodeLineAnchorID(line);
 
-                  let rowProps: RowProps = {
-                    id: getCodeLineAnchorID(line),
-                    className: styles.line,
-                  };
+                  let className = styles.line;
+                  let shellRef;
 
-                  if (isLineSelected(rowProps.id, location)) {
-                    rowProps = {
-                      ...rowProps,
-                      className: makeClassName(
-                        rowProps.className,
-                        styles.selectedLine,
-                      ),
-                      ref: _scrollToSelectedLine,
-                    };
+                  if (isLineSelected(id, location)) {
+                    className = makeClassName(
+                      styles.line,
+                      className,
+                      styles.selectedLine,
+                    );
+                    shellRef = _scrollToSelectedLine;
                   }
 
                   return (
                     <React.Fragment key={`fragment-${line}`}>
-                      <tr {...rowProps}>
-                        <td className={styles.lineNumber}>
-                          <Link
-                            to={{
-                              ...location,
-                              hash: getCodeLineAnchor(line),
-                            }}
-                          >{`${line}`}</Link>
-                        </td>
+                      <Commentable
+                        as="tr"
+                        id={id}
+                        className={className}
+                        line={line}
+                        fileName={version.selectedPath}
+                        shellRef={shellRef}
+                        versionId={version.id}
+                      >
+                        {(addCommentButton) => (
+                          <>
+                            <td className={styles.lineNumber}>
+                              <Link
+                                className={styles.lineNumberLink}
+                                to={{
+                                  ...location,
+                                  hash: getCodeLineAnchor(line),
+                                }}
+                              >{`${line}`}</Link>
+                              {enableCommenting && addCommentButton}
+                            </td>
 
-                        <td className={styles.code}>
-                          {renderHighlightedCode(code, language)}
-                        </td>
-                      </tr>
+                            <td className={styles.code}>
+                              {renderHighlightedCode(code, language)}
+                            </td>
+                          </>
+                        )}
+                      </Commentable>
                       {selectedMessageMap && selectedMessageMap.byLine[line] && (
                         <tr>
                           <td
@@ -185,6 +194,20 @@ export class CodeViewBase extends React.Component<Props> {
                             })}
                           </td>
                         </tr>
+                      )}
+                      {enableCommenting && (
+                        <CommentList
+                          addonId={version.addon.id}
+                          fileName={version.selectedPath}
+                          line={line}
+                          versionId={version.id}
+                        >
+                          {(commentList) => (
+                            <tr>
+                              <td colSpan={2}>{commentList}</td>
+                            </tr>
+                          )}
+                        </CommentList>
                       )}
                     </React.Fragment>
                   );
@@ -208,7 +231,10 @@ export class CodeViewBase extends React.Component<Props> {
         validationURL={version.validationURL}
         selectedPath={version.selectedPath}
       >
-        {this.renderWithLinterInfo}
+        {// This needs to be an anonymous function (which defeats memoization)
+        // so that the component gets re-rendered in the case of adding
+        // comments per line.
+        (info: LinterProviderInfo) => this.renderWithLinterInfo(info)}
       </LinterProvider>
     );
   }

--- a/src/components/CodeView/styles.module.scss
+++ b/src/components/CodeView/styles.module.scss
@@ -16,8 +16,10 @@
 }
 
 .lineNumber {
-  padding-right: $default-padding;
-  text-align: right;
+  display: grid;
+  grid-gap: $default-padding / 2;
+  grid-template-columns: auto min-content;
+  padding-right: $default-padding / 2;
   user-select: none;
 
   a {
@@ -30,6 +32,12 @@
       font-weight: 500;
     }
   }
+}
+
+.lineNumberLink {
+  align-items: center;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .code {

--- a/src/components/CommentList/index.tsx
+++ b/src/components/CommentList/index.tsx
@@ -10,9 +10,11 @@ import {
 import Comment from '../Comment';
 import styles from './styles.module.scss';
 
+export type ChildrenArgValue = JSX.Element;
+
 export type PublicProps = CommentKeyParams & {
   addonId: number;
-  children: (content: JSX.Element) => JSX.Element;
+  children: (content: ChildrenArgValue) => JSX.Element;
   className?: string;
 };
 

--- a/src/components/Commentable/index.tsx
+++ b/src/components/Commentable/index.tsx
@@ -5,10 +5,12 @@ import AddComment, { PublicProps as AddCommentProps } from './AddComment';
 import { AnyReactNode } from '../../typeUtils';
 import styles from './styles.module.scss';
 
+export type ChildrenArgValue = JSX.Element;
+
 export type PublicProps = {
   addCommentClassName?: string;
   as: React.ReactType;
-  children: (addComment: JSX.Element) => AnyReactNode;
+  children: (addComment: ChildrenArgValue) => AnyReactNode;
   className?: string;
   id?: string;
   shellRef?: (element: HTMLElement | null) => void;

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -709,19 +709,20 @@ export const simulateLinterProvider = (
  *
  * This is intended for testing render prop components that are typically
  * used multiple times, like in a list.
+ *
+ * The `children` render prop can only take one argument.
  */
-const multiRenderPropSimulator = <
-  T extends {
-    RenderArgType: {};
-    ComponentType: {};
-  }
->({
+const multiRenderPropSimulator = <RenderArgValue extends {}>({
   Component,
   renderArgValue,
   root,
 }: {
-  Component: T['ComponentType'];
-  renderArgValue: T['RenderArgType'];
+  // A specific component type would not be helpful here because
+  // ShallowWrapper does not enforce the Component's actual prop type
+  // when calling renderProp('children')(...args), unfortunately.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Component: React.ComponentType<any>;
+  renderArgValue: RenderArgValue;
   root: ShallowWrapper;
 }) => {
   const shell = root.find(Component);
@@ -750,14 +751,11 @@ export const simulateCommentable = ({
   addCommentButton = <button type="button">Add</button>,
   root,
 }: SimulateCommentableParams) => {
-  const Component = Commentable;
-  const renderArgValue = addCommentButton;
-  const simulatorParams = { root, Component, renderArgValue };
-
-  return multiRenderPropSimulator<{
-    ComponentType: typeof Component;
-    RenderArgType: typeof renderArgValue;
-  }>(simulatorParams);
+  return multiRenderPropSimulator<CommentableChildrenArgValue>({
+    Component: Commentable,
+    renderArgValue: addCommentButton,
+    root,
+  });
 };
 
 export type SimulateCommentListParams = {
@@ -775,14 +773,11 @@ export const simulateCommentList = ({
   commentList = <div />,
   root,
 }: SimulateCommentListParams) => {
-  const Component = CommentList;
-  const renderArgValue = commentList;
-  const simulatorParams = { root, Component, renderArgValue };
-
-  return multiRenderPropSimulator<{
-    ComponentType: typeof Component;
-    RenderArgType: typeof renderArgValue;
-  }>(simulatorParams);
+  return multiRenderPropSimulator<CommentListChildrenArgValue>({
+    Component: CommentList,
+    renderArgValue: commentList,
+    root,
+  });
 };
 
 /*

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -41,8 +41,12 @@ import {
   createInternalVersion,
   createInternalVersionEntry,
 } from './reducers/versions';
-import Commentable from './components/Commentable';
-import CommentList from './components/CommentList';
+import Commentable, {
+  ChildrenArgValue as CommentableChildrenArgValue,
+} from './components/Commentable';
+import CommentList, {
+  ChildrenArgValue as CommentListChildrenArgValue,
+} from './components/CommentList';
 import LinterProvider, {
   LinterProviderInfo,
 } from './components/LinterProvider';
@@ -732,7 +736,7 @@ const multiRenderPropSimulator = <
 };
 
 export type SimulateCommentableParams = {
-  addCommentButton?: JSX.Element;
+  addCommentButton?: CommentableChildrenArgValue;
   root: ShallowWrapper;
 };
 
@@ -757,7 +761,7 @@ export const simulateCommentable = ({
 };
 
 export type SimulateCommentListParams = {
-  commentList?: JSX.Element;
+  commentList?: CommentListChildrenArgValue;
   root: ShallowWrapper;
 };
 

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -41,6 +41,8 @@ import {
   createInternalVersion,
   createInternalVersionEntry,
 } from './reducers/versions';
+import Commentable from './components/Commentable';
+import CommentList from './components/CommentList';
 import LinterProvider, {
   LinterProviderInfo,
 } from './components/LinterProvider';
@@ -695,6 +697,88 @@ export const simulateLinterProvider = (
     messagesAreLoading,
     selectedMessageMap,
   });
+};
+
+/*
+ * Creates a helper for simulating the `children` render prop of a
+ * component.
+ *
+ * This is intended for testing render prop components that are typically
+ * used multiple times, like in a list.
+ */
+const multiRenderPropSimulator = <
+  T extends {
+    RenderArgType: {};
+    ComponentType: {};
+  }
+>({
+  Component,
+  renderArgValue,
+  root,
+}: {
+  Component: T['ComponentType'];
+  renderArgValue: T['RenderArgType'];
+  root: ShallowWrapper;
+}) => {
+  const shell = root.find(Component);
+
+  return {
+    shell,
+    renderContent(oneShell = shell) {
+      const render = oneShell.renderProp('children');
+      return render(renderArgValue);
+    },
+  };
+};
+
+export type SimulateCommentableParams = {
+  addCommentButton?: JSX.Element;
+  root: ShallowWrapper;
+};
+
+/*
+ * Given a component that uses <Commentable>, simulate the content
+ * returned by <Commentable>
+ */
+export const simulateCommentable = ({
+  // In reality this would be an instance of <AddComment /> but that
+  // doesn't matter here.
+  addCommentButton = <button type="button">Add</button>,
+  root,
+}: SimulateCommentableParams) => {
+  const Component = Commentable;
+  const renderArgValue = addCommentButton;
+  const simulatorParams = { root, Component, renderArgValue };
+
+  return multiRenderPropSimulator<{
+    ComponentType: typeof Component;
+    RenderArgType: typeof renderArgValue;
+  }>(simulatorParams);
+};
+
+export type SimulateCommentListParams = {
+  commentList?: JSX.Element;
+  root: ShallowWrapper;
+};
+
+/*
+ * Given a component that uses <CommentList>, simulate the content
+ * returned by <CommentList>
+ */
+export const simulateCommentList = ({
+  // In reality this would be a wrapper around an array of <Comment />
+  // components but that doesn't matter here.
+  commentList = <div />,
+  root,
+}: SimulateCommentListParams) => {
+  const Component = CommentList;
+  const renderArgValue = commentList;
+  const simulatorParams = { root, Component, renderArgValue };
+
+  return multiRenderPropSimulator<{
+    ComponentType: typeof Component;
+    RenderArgType: typeof renderArgValue;
+  }>(simulatorParams);
 };
 
 /*


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/112

This is the first patch where I can land an actual UI for adding a comment 🎸 🥁 🎹 🔥 🎵 

It will require a config flag which is off everywhere except the local development server. (**TODO**: file a PR to turn it on for the hosted dev site.)

This will only allow you to enter a comment and see it on the page. It *is* saved via the API but if you refresh the page you won't see the comment (that will happen later).

<details>
<summary>Screencast</summary>

![2019-09-19 12 57 02](https://user-images.githubusercontent.com/55398/65268783-7a89f580-dadd-11e9-98dc-a0b7d8c498be.gif)


</details>