### PR TITLE
Add Navbar actions to summarize all comments

### DIFF
--- a/src/components/Navbar/index.spec.tsx
+++ b/src/components/Navbar/index.spec.tsx
@@ -3,11 +3,14 @@ import React from 'react';
 import { Store } from 'redux';
 
 import configureStore from '../../configureStore';
+import CommentSummaryButton from '../CommentSummaryButton';
 import LoginButton from '../LoginButton';
 import styles from './styles.module.scss';
 import {
+  createFakeExternalComment,
   createFakeThunk,
   createStoreWithVersion,
+  createStoreWithVersionComments,
   fakeUser,
   fakeVersion,
   fakeVersionAddon,
@@ -55,7 +58,7 @@ describe(__filename, () => {
       });
       const root = render({ store });
 
-      expect(root.find(`.${styles.addonName}`)).toHaveText(addonName);
+      expect(root.find(`.${styles.info}`)).toHaveText(addonName);
     });
   });
 
@@ -63,7 +66,7 @@ describe(__filename, () => {
     it('does not render addon name', () => {
       const root = render();
 
-      expect(root.find(`.${styles.addonName}`)).toHaveLength(0);
+      expect(root.find(`.${styles.info}`)).toHaveText('');
     });
   });
 
@@ -122,6 +125,48 @@ describe(__filename, () => {
 
       root.find(`.${styles.logOut}`).simulate('click');
       expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
+    });
+  });
+
+  describe('comments', () => {
+    it('does not render a comment nav for undefined comments', () => {
+      const root = render();
+
+      expect(root.find(`.${styles.commentCount}`)).toHaveLength(0);
+      expect(root.find(CommentSummaryButton)).toHaveLength(0);
+    });
+
+    it('does not render a comment nav for zero comments', () => {
+      const root = render({
+        store: createStoreWithVersionComments({ comments: [] }),
+      });
+
+      expect(root.find(`.${styles.commentCount}`)).toHaveLength(0);
+      expect(root.find(CommentSummaryButton)).toHaveLength(0);
+    });
+
+    it('renders a comment count', () => {
+      const comments = [
+        createFakeExternalComment({ comment: 'first' }),
+        createFakeExternalComment({ comment: 'second' }),
+      ];
+      const root = render({
+        store: createStoreWithVersionComments({ comments }),
+      });
+
+      const count = root.find(`.${styles.commentCount}`);
+      expect(count).toHaveLength(1);
+      expect(count).toHaveText(String(comments.length));
+    });
+
+    it('renders CommentSummaryButton', () => {
+      const root = render({
+        store: createStoreWithVersionComments({
+          comments: [createFakeExternalComment()],
+        }),
+      });
+
+      expect(root.find(CommentSummaryButton)).toHaveLength(1);
     });
   });
 });

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -3,8 +3,10 @@ import { Button, Navbar } from 'react-bootstrap';
 import { connect } from 'react-redux';
 
 import { gettext, getLocalizedString } from '../../utils';
+import CommentSummaryButton from '../CommentSummaryButton';
 import LoginButton from '../LoginButton';
 import { ApplicationState } from '../../reducers';
+import { Comment, selectVersionComments } from '../../reducers/comments';
 import { Version, selectCurrentVersionInfo } from '../../reducers/versions';
 import { ConnectedReduxProps } from '../../configureStore';
 import { User, selectCurrentUser, requestLogOut } from '../../reducers/users';
@@ -15,6 +17,7 @@ type PublicProps = {
 };
 
 type PropsFromState = {
+  comments: Comment[] | undefined;
   user: User | null;
   currentVersion: Version | null | undefined | false;
 };
@@ -32,17 +35,40 @@ export class NavbarBase extends React.Component<Props> {
     dispatch(_requestLogOut());
   };
 
+  renderCommentsNavBar() {
+    const { comments } = this.props;
+
+    if (!comments || comments.length === 0) {
+      return null;
+    }
+
+    return (
+      <>
+        <div className={styles.infoItem}>
+          {gettext('Comments:')}
+          <div className={styles.commentCount}>{comments.length}</div>
+        </div>
+        <div className={styles.infoItem}>
+          <CommentSummaryButton />
+        </div>
+      </>
+    );
+  }
+
   render() {
     const { user, currentVersion } = this.props;
 
     return (
-      <Navbar bg="dark" className={styles.Navbar} expand="lg" variant="dark">
+      <Navbar className={styles.Navbar} expand="lg" variant="dark">
         <Navbar.Brand className={styles.brand}>
-          {currentVersion && (
-            <span className={styles.addonName}>
-              {getLocalizedString(currentVersion.addon.name)}
-            </span>
-          )}
+          <div className={styles.info}>
+            {currentVersion && (
+              <div className={styles.infoItem}>
+                {getLocalizedString(currentVersion.addon.name)}
+              </div>
+            )}
+            {this.renderCommentsNavBar()}
+          </div>
         </Navbar.Brand>
         <Navbar.Text className={styles.text}>
           {user ? <span className={styles.username}>{user.name}</span> : null}
@@ -60,9 +86,16 @@ export class NavbarBase extends React.Component<Props> {
 }
 
 const mapStateToProps = (state: ApplicationState): PropsFromState => {
+  const currentVersion = selectCurrentVersionInfo(state.versions);
   return {
+    comments: currentVersion
+      ? selectVersionComments({
+          comments: state.comments,
+          versionId: currentVersion.id,
+        })
+      : undefined,
     user: selectCurrentUser(state.users),
-    currentVersion: selectCurrentVersionInfo(state.versions),
+    currentVersion,
   };
 };
 

--- a/src/components/Navbar/styles.module.scss
+++ b/src/components/Navbar/styles.module.scss
@@ -1,6 +1,11 @@
 @import '../../scss/variables';
 
+$bg-color: $dark-gray;
+
 .Navbar {
+  // This is controlling the background color so that we can invert the colors
+  // for a comment count (below). This is equivalent to bg="dark" in Navbar.
+  background-color: $bg-color;
   display: flex;
   justify-content: space-between;
   padding: $default-padding;
@@ -13,17 +18,42 @@
   padding: 0;
 }
 
-.addonName {
-  color: $white;
-}
-
-.addonName,
+.info,
 .text,
 .Navbar {
   align-items: center;
   display: flex;
-  flex-align: center;
   font-size: 1rem;
+}
+
+.info {
+  align-items: stretch;
+  color: $white;
+  display: flex;
+}
+
+.infoItem {
+  align-items: center;
+  display: flex;
+
+  &:not(:first-child) {
+    border-left: 1px solid darken($white, 70);
+    padding-left: 10px;
+    margin-left: 10px;
+  }
+}
+
+.commentCount {
+  align-items: center;
+  background-color: $white;
+  border-radius: 2px;
+  color: $bg-color;
+  display: flex;
+  justify-content: center;
+  margin-left: 5px;
+  // Fix the width to minimize jumpiness.
+  min-width: 20px;
+  padding: 0 5px;
 }
 
 .username {

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -4,6 +4,7 @@
 $border-radius: 0.25rem;
 $default-padding: 10px;
 $light-gray: $gray-200;
+$dark-gray: $gray-800;
 $gray: $gray-500;
 $white: #fff;
 

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -855,7 +855,7 @@ export const createStoreWithVersion = (
   }: {
     version?: ExternalVersionWithDiff | ExternalVersionWithContent;
     makeCurrent?: boolean;
-  },
+  } = {},
 ) => {
   const store = configureStore();
   store.dispatch(versionsActions.loadVersionInfo({ version }));

--- a/stories/Navbar.stories.tsx
+++ b/stories/Navbar.stories.tsx
@@ -4,27 +4,50 @@ import { storiesOf } from '@storybook/react';
 import Navbar from '../src/components/Navbar';
 import configureStore from '../src/configureStore';
 import { actions as userActions } from '../src/reducers/users';
-import { fakeUser } from '../src/test-helpers';
+import {
+  createFakeExternalComment,
+  createStoreWithVersion,
+  createStoreWithVersionComments,
+  fakeUser,
+  fakeVersion,
+  fakeVersionAddon,
+} from '../src/test-helpers';
 import { renderWithStoreAndRouter } from './utils';
 
-storiesOf('Navbar', module).addWithChapters('all variants', {
-  chapters: [
-    {
-      sections: [
-        {
-          title: 'user is not signed in',
-          sectionFn: () => renderWithStoreAndRouter(<Navbar />),
-        },
-        {
-          title: 'user is signed in',
-          sectionFn: () => {
-            const store = configureStore();
-            store.dispatch(userActions.loadCurrentUser({ user: fakeUser }));
+const render = ({ store = configureStore(), ...props } = {}) => {
+  return renderWithStoreAndRouter(<Navbar {...props} />, { store });
+};
 
-            return renderWithStoreAndRouter(<Navbar />, { store });
-          },
-        },
+storiesOf('Navbar', module)
+  .add('user is not signed in', () => render())
+  .add('user is signed in', () => {
+    const store = configureStore();
+    store.dispatch(userActions.loadCurrentUser({ user: fakeUser }));
+
+    return render({ store });
+  })
+  .add('with current version', () => {
+    const version = {
+      ...fakeVersion,
+      addon: { ...fakeVersionAddon, name: { 'en-US': 'uBlock Origin' } },
+    };
+    const store = createStoreWithVersion({ version, makeCurrent: true });
+    return render({ store });
+  })
+  .add('user has entered comments', () => {
+    const store = createStoreWithVersionComments({
+      comments: [
+        createFakeExternalComment({
+          filename: 'manifest.json',
+          lineno: 23,
+          comment: 'This permission does not seem to be used anywhere. Is it?',
+        }),
+        createFakeExternalComment({
+          filename: 'background.js',
+          lineno: 344,
+          comment: 'This call to eval() is forbidden.',
+        }),
       ],
-    },
-  ],
-});
+    });
+    return render({ store });
+  });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/114

Notes
- This is a quick implementation of enabling reviewers to finish a review. They will have to copy / paste the text but at least it's a start.
- This is not hidden behind a config flag because comments will [never get loaded](https://github.com/mozilla/addons-code-manager/blob/6c62fb989785ee0802f41a961f3cf27e784b7f74/src/components/CodeView/index.tsx#L194-L207) unless the config flag is enabled.

<details>
<summary>Example screenshots</summary>

<img width="1213" alt="Screenshot 2019-10-28 13 26 58" src="https://user-images.githubusercontent.com/55398/67706755-5399cb80-f987-11e9-8f2b-6d1902475fcf.png">
<img width="1213" alt="Screenshot 2019-10-28 13 27 07" src="https://user-images.githubusercontent.com/55398/67706756-5399cb80-f987-11e9-911e-fe3d9e60faed.png">


</details>