### PR TITLE
Left-align delete button, improve confirm prompt

### DIFF
--- a/src/components/Comment/index.spec.tsx
+++ b/src/components/Comment/index.spec.tsx
@@ -424,7 +424,7 @@ describe(__filename, () => {
 
       const deleteButton = root.find(`.${styles.deleteButton}`);
       expect(deleteButton).toHaveLength(1);
-      expect(deleteButton).toHaveText('Delete, really?');
+      expect(deleteButton).toHaveText('Confirm delete');
       expect(deleteButton).toHaveProp('disabled', false);
 
       deleteButton.simulate('click');

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -166,7 +166,7 @@ export class CommentBase extends React.Component<Props, State> {
     let onDeleteClick = this.onConsiderDelete;
 
     if (initialComment.considerDelete) {
-      deletePrompt = gettext('Delete, really?');
+      deletePrompt = gettext('Confirm delete');
       onDeleteClick = this.onDelete;
       showCancel = true;
     } else if (initialComment.beginDelete) {
@@ -192,6 +192,16 @@ export class CommentBase extends React.Component<Props, State> {
           />
         </div>
         <div className={styles.commentControls}>
+          <Button
+            className={makeClassName(styles.controlButton, styles.deleteButton)}
+            disabled={deleteIsDisabled}
+            onClick={onDeleteClick}
+            size="sm"
+            type="button"
+            variant="danger"
+          >
+            {deletePrompt}
+          </Button>
           {showCancel && (
             <Button
               className={makeClassName(
@@ -206,16 +216,6 @@ export class CommentBase extends React.Component<Props, State> {
               {gettext('Cancel')}
             </Button>
           )}
-          <Button
-            className={makeClassName(styles.controlButton, styles.deleteButton)}
-            disabled={deleteIsDisabled}
-            onClick={onDeleteClick}
-            size="sm"
-            type="button"
-            variant="danger"
-          >
-            {deletePrompt}
-          </Button>
         </div>
       </div>
     );

--- a/src/components/Comment/styles.module.scss
+++ b/src/components/Comment/styles.module.scss
@@ -9,6 +9,7 @@
 .form {
   background-color: $light-gray;
   border: 1px solid darken($light-gray, 10);
+  border-radius: $border-radius;
   padding: $default-padding;
 }
 
@@ -26,8 +27,8 @@
 
 .commentControls {
   display: flex;
-  justify-content: flex-end;
-  padding-top: 5px;
+  justify-content: flex-start;
+  padding-top: 10px;
 }
 
 .controlButton {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/1147 by left-aligning the delete button and fixes https://github.com/mozilla/addons-code-manager/issues/1149 by adjusting the prompt.

I also added a `border-radius` to comments so they're more consistent with other app panels.

<details>
<summary>Before</summary>

![2019-10-28 14 25 39](https://user-images.githubusercontent.com/55398/67711351-d030a800-f98f-11e9-96b2-dd206f952dd2.gif)


</details>


<details>
<summary>After</summary>

![2019-10-28 14 27 53](https://user-images.githubusercontent.com/55398/67711356-d32b9880-f98f-11e9-84ff-98411817c85a.gif)


</details>