### PR TITLE
Revert "Update dependency react-textarea-autosize to v7.1.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-redux": "5.1.2",
     "react-router-dom": "4.3.1",
     "react-scripts": "3.2.0",
-    "react-textarea-autosize": "7.1.1",
+    "react-textarea-autosize": "7.1.0",
     "react-treefold": "1.0.0",
     "redux": "4.0.4",
     "redux-devtools-extension": "2.13.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13023,15 +13023,7 @@ react-test-renderer@^16.0.0-0:
     react-is "^16.9.0"
     scheduler "^0.15.0"
 
-react-textarea-autosize@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-7.1.1.tgz#66ff1b7d6e1ab759fdf35f09e60bdd0e15d8e143"
-  integrity sha512-dVDVXlUm5uUgWyZAL4gaxJiDb2xCWM/qk6Rl2ixXPSKNsngKhvAj3KbDS9mnQn/qIZSYVD+/iuZT/eQWmNjBLw==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    prop-types "^15.6.0"
-
-react-textarea-autosize@^7.1.0:
+react-textarea-autosize@7.1.0, react-textarea-autosize@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-7.1.0.tgz#3132cb77e65d94417558d37c0bfe415a5afd3445"
   integrity sha512-c2FlR/fP0qbxmlrW96SdrbgP/v0XZMTupqB90zybvmDVDutytUgPl7beU35klwcTeMepUIQEpQUn3P3bdshGPg==


### PR DESCRIPTION
Reverts mozilla/addons-code-manager#1179 because of https://github.com/andreypopp/react-textarea-autosize/issues/253