### PR TITLE
Load all API pages when fetching saved comments

### DIFF
--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -884,15 +884,16 @@ describe(__filename, () => {
 
       expect(_fetchAllPages).toHaveBeenCalled();
 
+      // Simulate the interface of fetchAllPages whereby it invokes
+      // getNext(nextPageUrl).
+      const nextPageUrl = 'endpoint/?page=2';
       const getNext = _fetchAllPages.mock.calls[0][0];
-
-      const nextUrl = 'endpoint/?page=2';
-      getNext(nextUrl);
+      getNext(nextPageUrl);
 
       expect(_getComments).toHaveBeenCalledWith({
         addonId,
         apiState,
-        endpointUrl: nextUrl,
+        endpointUrl: nextPageUrl,
         versionId,
       });
     });

--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -85,15 +85,13 @@ describe(__filename, () => {
       ).rejects.toThrow(/endpoint or endpointUrl must be defined/);
     });
 
-    it('uses endpointUrl instead of endpoint when both are defined', async () => {
-      const endpoint = 'some/api/endpoint/';
-      const endpointUrl = 'https://example.com/some/api/endpoint/';
-      await callApiWithDefaultApiState({ endpoint, endpointUrl });
-
-      expect(fetch).toHaveBeenCalledWith(
-        makeApiURL({ url: endpointUrl }),
-        expect.any(Object),
-      );
+    it('cannot accept both endpoint and endpointUrl', async () => {
+      await expect(
+        callApiWithDefaultApiState({
+          endpoint: 'api-endpoint',
+          endpointUrl: 'https://example.com/api-endpoint',
+        }),
+      ).rejects.toThrow(/endpoint and endpointUrl cannot both be defined/);
     });
 
     it('calls the API with an endpoint', async () => {
@@ -853,8 +851,6 @@ describe(__filename, () => {
     });
 
     it('can get comments with an endpointUrl', async () => {
-      const addonId = nextUniqueId();
-      const versionId = nextUniqueId();
       const endpointUrl = 'https://example.com/endpoint/?page=2';
       const _callApi = jest
         .fn()
@@ -862,13 +858,10 @@ describe(__filename, () => {
           createFakeCommentsResponse([createFakeExternalComment()]),
         );
 
-      await _getComments({ _callApi, addonId, endpointUrl, versionId });
+      await _getComments({ _callApi, endpointUrl });
 
       expect(_callApi).toHaveBeenCalledWith(
-        expect.objectContaining({
-          endpoint: `reviewers/addon/${addonId}/versions/${versionId}/draft_comments`,
-          endpointUrl,
-        }),
+        expect.objectContaining({ endpoint: undefined, endpointUrl }),
       );
     });
   });

--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -85,13 +85,15 @@ describe(__filename, () => {
       ).rejects.toThrow(/endpoint or endpointUrl must be defined/);
     });
 
-    it('cannot accept both endpoint and endpointUrl', async () => {
-      await expect(
-        callApiWithDefaultApiState({
-          endpoint: 'api-endpoint',
-          endpointUrl: 'https://example.com/api-endpoint',
-        }),
-      ).rejects.toThrow(/endpoint and endpointUrl cannot both be defined/);
+    it('uses endpointUrl instead of endpoint when both are defined', async () => {
+      const endpoint = 'some/api/endpoint/';
+      const endpointUrl = 'https://example.com/some/api/endpoint/';
+      await callApiWithDefaultApiState({ endpoint, endpointUrl });
+
+      expect(fetch).toHaveBeenCalledWith(
+        makeApiURL({ url: endpointUrl }),
+        expect.any(Object),
+      );
     });
 
     it('calls the API with an endpoint', async () => {
@@ -851,6 +853,8 @@ describe(__filename, () => {
     });
 
     it('can get comments with an endpointUrl', async () => {
+      const addonId = nextUniqueId();
+      const versionId = nextUniqueId();
       const endpointUrl = 'https://example.com/endpoint/?page=2';
       const _callApi = jest
         .fn()
@@ -858,10 +862,13 @@ describe(__filename, () => {
           createFakeCommentsResponse([createFakeExternalComment()]),
         );
 
-      await _getComments({ _callApi, endpointUrl });
+      await _getComments({ _callApi, addonId, endpointUrl, versionId });
 
       expect(_callApi).toHaveBeenCalledWith(
-        expect.objectContaining({ endpoint: undefined, endpointUrl }),
+        expect.objectContaining({
+          endpoint: `reviewers/addon/${addonId}/versions/${versionId}/draft_comments`,
+          endpointUrl,
+        }),
       );
     });
   });

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -178,15 +178,14 @@ export const callApi = async <
     body = JSON.stringify(bodyData);
   }
 
+  if (endpointUrl && endpoint) {
+    throw new Error('endpoint and endpointUrl cannot both be defined at once');
+  }
+
   let path;
   let url;
 
   if (endpointUrl) {
-    if (endpoint) {
-      log.debug(
-        `Ignoring endpoint "${endpoint}" in favor of endpointUrl "${endpointUrl}"`,
-      );
-    }
     url = endpointUrl;
   } else if (endpoint) {
     path = endpoint;
@@ -455,10 +454,16 @@ export const getComments = async ({
   endpointUrl,
   versionId,
 }: GetCommentsParams) => {
+  let endpoint;
+
+  if (!endpointUrl) {
+    endpoint = `reviewers/addon/${addonId}/versions/${versionId}/draft_comments`;
+  }
+
   return _callApi<ResponseOnly<GetCommentsResponse>>({
     apiState,
     endpointUrl: endpointUrl || undefined,
-    endpoint: `reviewers/addon/${addonId}/versions/${versionId}/draft_comments`,
+    endpoint,
     method: HttpMethod.GET,
   });
 };

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -178,14 +178,15 @@ export const callApi = async <
     body = JSON.stringify(bodyData);
   }
 
-  if (endpointUrl && endpoint) {
-    throw new Error('endpoint and endpointUrl cannot both be defined at once');
-  }
-
   let path;
   let url;
 
   if (endpointUrl) {
+    if (endpoint) {
+      log.debug(
+        `Ignoring endpoint "${endpoint}" in favor of endpointUrl "${endpointUrl}"`,
+      );
+    }
     url = endpointUrl;
   } else if (endpoint) {
     path = endpoint;
@@ -454,16 +455,10 @@ export const getComments = async ({
   endpointUrl,
   versionId,
 }: GetCommentsParams) => {
-  let endpoint;
-
-  if (!endpointUrl) {
-    endpoint = `reviewers/addon/${addonId}/versions/${versionId}/draft_comments`;
-  }
-
   return _callApi<ResponseOnly<GetCommentsResponse>>({
     apiState,
     endpointUrl: endpointUrl || undefined,
-    endpoint,
+    endpoint: `reviewers/addon/${addonId}/versions/${versionId}/draft_comments`,
     method: HttpMethod.GET,
   });
 };

--- a/src/reducers/comments.spec.tsx
+++ b/src/reducers/comments.spec.tsx
@@ -872,11 +872,13 @@ describe(__filename, () => {
 
   describe('fetchAndLoadComments', () => {
     const _fetchAndLoadComments = ({
-      _getComments = jest.fn().mockResolvedValue(createFakeCommentsResponse()),
+      _getAllComments = jest
+        .fn()
+        .mockResolvedValue(createFakeCommentsResponse()),
       addonId = 1,
       versionId = 2,
     }) => {
-      return fetchAndLoadComments({ _getComments, addonId, versionId });
+      return fetchAndLoadComments({ _getAllComments, addonId, versionId });
     };
 
     it('dispatches beginFetchVersionComments', async () => {
@@ -910,11 +912,12 @@ describe(__filename, () => {
 
     it('handles API errors', async () => {
       const error = new Error('API Error');
-      const _getComments = jest.fn().mockResolvedValue({ error });
+      const _getAllComments = jest.fn().mockResolvedValue({ error });
       const versionId = 1;
 
       const { dispatch, thunk } = thunkTester({
-        createThunk: () => _fetchAndLoadComments({ _getComments, versionId }),
+        createThunk: () =>
+          _fetchAndLoadComments({ _getAllComments, versionId }),
       });
 
       await thunk();
@@ -926,7 +929,7 @@ describe(__filename, () => {
     });
 
     it('fetches version comments', async () => {
-      const _getComments = jest
+      const _getAllComments = jest
         .fn()
         .mockResolvedValue(createFakeCommentsResponse());
       const store = configureStore();
@@ -935,13 +938,13 @@ describe(__filename, () => {
 
       const { thunk } = thunkTester({
         createThunk: () =>
-          _fetchAndLoadComments({ _getComments, addonId, versionId }),
+          _fetchAndLoadComments({ _getAllComments, addonId, versionId }),
         store,
       });
 
       await thunk();
 
-      expect(_getComments).toHaveBeenCalledWith({
+      expect(_getAllComments).toHaveBeenCalledWith({
         addonId,
         apiState: store.getState().api,
         versionId,
@@ -952,12 +955,13 @@ describe(__filename, () => {
       const versionId = 1;
       const comments = [1, 2, 3].map((id) => createFakeExternalComment({ id }));
 
-      const _getComments = jest
+      const _getAllComments = jest
         .fn()
         .mockResolvedValue(createFakeCommentsResponse(comments));
 
       const { dispatch, thunk } = thunkTester({
-        createThunk: () => _fetchAndLoadComments({ _getComments, versionId }),
+        createThunk: () =>
+          _fetchAndLoadComments({ _getAllComments, versionId }),
       });
 
       await thunk();

--- a/src/reducers/comments.tsx
+++ b/src/reducers/comments.tsx
@@ -11,7 +11,7 @@ import {
 import {
   createOrUpdateComment,
   deleteComment as apiDeleteComment,
-  getComments,
+  getAllComments,
   isErrorResponse,
 } from '../api';
 
@@ -251,11 +251,11 @@ export const selectFilePathHasComments = ({
 };
 
 export const fetchAndLoadComments = ({
-  _getComments = getComments,
+  _getAllComments = getAllComments,
   addonId,
   versionId,
 }: {
-  _getComments?: typeof getComments;
+  _getAllComments?: typeof getAllComments;
   addonId: number;
   versionId: number;
 }): ThunkActionCreator => {
@@ -270,7 +270,7 @@ export const fetchAndLoadComments = ({
 
     // TODO: fetch all pages to get all comments.
     // https://github.com/mozilla/addons-code-manager/issues/1093
-    const response = await _getComments({ addonId, apiState, versionId });
+    const response = await _getAllComments({ addonId, apiState, versionId });
 
     if (isErrorResponse(response)) {
       dispatch(actions.abortFetchVersionComments({ versionId }));


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/1093

Example of loading more than 25 saved comments:

<img width="685" alt="Screenshot 2019-10-31 15 04 39" src="https://user-images.githubusercontent.com/55398/67982561-ef7a4000-fbf0-11e9-8a94-2d602c3c54a0.png">
