### PR TITLE
Increase specificity to make gray buttons gray

### DIFF
--- a/src/components/Button/styles.module.scss
+++ b/src/components/Button/styles.module.scss
@@ -1,7 +1,9 @@
 @import '../../scss/variables';
 @import '../../scss/mixins';
 
-.button {
+// Prefixing this selector with `button` fixes some subtle specificity
+// issues that are not apparent in all layouts.
+button.button {
   background-color: $light-gray;
   text-align: center;
   overflow: hidden;

--- a/src/components/Commentable/styles.module.scss
+++ b/src/components/Commentable/styles.module.scss
@@ -5,7 +5,9 @@ $shellSize: 1.3rem;
 // Firefox. A fixed pixel size works better.
 $size: 6px;
 
-.button {
+// Prefixing this selector with `button` fixes some subtle specificity
+// issues that are not apparent in all layouts.
+button.button {
   align-items: center;
   display: flex;
   height: $shellSize;

--- a/src/components/SidePanel/styles.module.scss
+++ b/src/components/SidePanel/styles.module.scss
@@ -9,7 +9,9 @@
   padding: 0;
 }
 
-.ToggleButton {
+// Prefixing this selector with `button` fixes some subtle specificity
+// issues that are not apparent in all layouts.
+button.ToggleButton {
   height: auto;
   overflow: hidden;
   padding: $default-padding;


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/1198

This addresses a few other issues related to the same problem.

**Before**

<img width="1339" alt="Screenshot 2019-11-04 16 23 58" src="https://user-images.githubusercontent.com/55398/68163694-b7406d80-ff20-11e9-928a-fcb79b0e34ae.png">


**After**

<img width="1339" alt="Screenshot 2019-11-04 16 24 15" src="https://user-images.githubusercontent.com/55398/68163700-bad3f480-ff20-11e9-911b-84d3ab6e76b6.png">
