### PR TITLE
Wrap long CodeView lines to fix comment boxes

### DIFF
--- a/src/components/CodeView/index.tsx
+++ b/src/components/CodeView/index.tsx
@@ -36,7 +36,14 @@ const renderHighlightedCode = (code: string, language: string) => {
 
   return (
     <pre className={styles.highlightedCode}>
-      <code className={`language-${language}`}>{value}</code>
+      <code
+        className={makeClassName(
+          styles.innerHighlightedCode,
+          `language-${language}`,
+        )}
+      >
+        {value}
+      </code>
     </pre>
   );
 };

--- a/src/components/CodeView/styles.module.scss
+++ b/src/components/CodeView/styles.module.scss
@@ -55,6 +55,10 @@
   margin: 0;
 }
 
+code.innerHighlightedCode {
+  white-space: pre-wrap;
+}
+
 .linterMessages {
   padding-top: 1rem;
 }

--- a/stories/CodeView.stories.tsx
+++ b/stories/CodeView.stories.tsx
@@ -11,6 +11,7 @@ import CodeView, {
 import { LinterMessage, actions } from '../src/reducers/linter';
 import { createInternalVersion } from '../src/reducers/versions';
 import {
+  loremIpsum,
   newLinterMessageUID,
   rootAttributeParams,
   renderWithStoreAndRouter,
@@ -54,12 +55,17 @@ const CSS = `html, body {
   display: none;
 }`;
 
+type RenderParams = { content?: string; store?: Store } & Partial<
+  CodeViewProps
+>;
+
 const render = ({
+  content = JS_SAMPLE,
   store = configureStore(),
   ...moreProps
-}: { store?: Store } & Partial<CodeViewProps> = {}) => {
+}: RenderParams = {}) => {
   const props: CodeViewProps = {
-    content: JS_SAMPLE,
+    content,
     mimeType: 'application/javascript',
     version: createInternalVersion(fakeVersion),
     ...moreProps,
@@ -77,10 +83,12 @@ const render = ({
 
 const renderJSWithMessages = (
   messages: Partial<LinterMessage>[],
-  moreProps: Partial<CodeViewProps> = {},
+  {
+    content = JS_SAMPLE,
+    store = configureStore(),
+    ...moreProps
+  }: RenderParams = {},
 ) => {
-  const store = configureStore();
-
   const path = 'lib/some-file.js';
   const version = createInternalVersion({
     ...fakeVersion,
@@ -102,7 +110,7 @@ const renderJSWithMessages = (
 
   return render({
     store,
-    content: JS_SAMPLE,
+    content,
     mimeType: 'application/javascript',
     version,
     ...moreProps,
@@ -225,5 +233,41 @@ storiesOf('CodeView', module)
         },
       ]);
     },
+    getParams(),
+  )
+  .add(
+    'Long line with a linter message',
+    () => {
+      return renderJSWithMessages(
+        [
+          {
+            line: 1,
+            message: 'Long line detected',
+            description: ['This is a long line of code.'],
+            type: 'notice',
+          },
+        ],
+        {
+          content: `const message = "${loremIpsum
+            .trim()
+            .replace(/\n/g, ' ')}";`,
+        },
+      );
+    },
+    getParams(),
+  )
+  .add(
+    'Code with tab characters',
+    () =>
+      render({
+        mimeType: 'application/javascript',
+        content: `
+          \t// This should be indented for each code level.
+          \tfunction log(msg, debug = false) {
+          \t\tif (debug) {
+          \t\t\tconsole.log(msg);
+          \t\t}
+          \t}`,
+      }),
     getParams(),
   );


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/997

This renders code lines as `pre-wrap` (just like `DiffView`) which lets the comment box span the view port in a sane way.

**Before**

<img width="1230" alt="Screenshot 2019-11-04 23 06 05" src="https://user-images.githubusercontent.com/55398/68180126-1d94b280-ff58-11e9-95be-e7f3a347401d.png">


**After**

<img width="1230" alt="Screenshot 2019-11-04 23 05 28" src="https://user-images.githubusercontent.com/55398/68180132-22596680-ff58-11e9-877e-53a02af6e4a7.png">
