### PR TITLE
Preserve expanded path when selecting new version

### DIFF
--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -276,7 +276,7 @@ describe(__filename, () => {
       expect(shallow(<div>{node}</div>).find(Loading)).toHaveLength(1);
     });
 
-    it('throws an error when isNodeExpanded is called without a version', () => {
+    it('throws an error when isNodeExpanded is called without expandedPaths set', () => {
       const node = {
         id: 'some/path',
         name: 'some name',
@@ -288,7 +288,7 @@ describe(__filename, () => {
 
       expect(() => {
         isNodeExpanded(node);
-      }).toThrow('Cannot check if node is expanded without a version');
+      }).toThrow('Cannot check if node is expanded without expandedPaths set');
     });
 
     it('throws an error when onToggleExpand is called without a version', () => {

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -40,6 +40,7 @@ export type DefaultProps = {
 };
 
 type PropsFromState = {
+  expandedPaths: string[] | undefined;
   tree: FileTree | undefined;
   version: Version | undefined | null;
 };
@@ -131,13 +132,15 @@ export class FileTreeBase extends React.Component<Props> {
   };
 
   isNodeExpanded = (node: TreeNode) => {
-    const { version } = this.props;
+    const { expandedPaths } = this.props;
 
-    if (!version) {
-      throw new Error('Cannot check if node is expanded without a version');
+    if (!expandedPaths) {
+      throw new Error(
+        'Cannot check if node is expanded without expandedPaths set',
+      );
     }
 
-    return version.expandedPaths.includes(node.id);
+    return expandedPaths.includes(node.id);
   };
 
   render() {
@@ -190,6 +193,7 @@ const mapStateToProps = (
 ): PropsFromState => {
   const { versionId } = ownProps;
   const version = getVersionInfo(state.versions, versionId);
+  const { expandedPaths } = state.versions;
 
   if (!version) {
     // TODO: support loading version objects as needed.
@@ -205,6 +209,7 @@ const mapStateToProps = (
   const tree = version ? getTree(state.fileTree, version.id) : undefined;
 
   return {
+    expandedPaths,
     tree,
     version,
   };

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -31,6 +31,7 @@ import reducer, {
   getEntryStatusMap,
   getMostRelevantEntryStatus,
   getParentFolders,
+  getPrunedExpandedPaths,
   getRelativeDiff,
   getRelativeDiffAnchor,
   getVersionFile,
@@ -64,6 +65,7 @@ import {
   fakeVersionsList,
   fakeVersionsListItem,
   getFakeVersionAndPathList,
+  nextUniqueId,
   thunkTester,
 } from '../test-helpers';
 
@@ -117,10 +119,82 @@ describe(__filename, () => {
 
       expect(state).toEqual({
         ...initialState,
+        expandedPaths: getParentFolders(version.file.selected_file),
         versionInfo: {
           [version.id]: createInternalVersion(version),
         },
       });
+    });
+
+    it('prunes expandedPaths when load version info', () => {
+      const path1 = 'path/1';
+      const path2 = 'path/2';
+      const expandedPaths = [path1, path2, ROOT_PATH];
+      const oldVersionId = nextUniqueId();
+      const oldVersion = createExternalVersionWithEntries(
+        [
+          createFakeEntry('directory', path1),
+          createFakeEntry('directory', path2),
+        ],
+        { id: oldVersionId },
+      );
+      const newVersion = createExternalVersionWithEntries(
+        [createFakeEntry('directory', path1)],
+        { id: nextUniqueId() },
+      );
+
+      let state = reducer(
+        undefined,
+        actions.loadVersionInfo({ version: oldVersion }),
+      );
+      state = reducer(state, actions.expandTree({ versionId: oldVersionId }));
+      state = reducer(state, actions.loadVersionInfo({ version: newVersion }));
+
+      expect(state).toHaveProperty(
+        'expandedPaths',
+        getPrunedExpandedPaths(
+          expandedPaths,
+          createInternalVersion(newVersion),
+        ),
+      );
+    });
+
+    it('prunes expanded paths when setCurrentVersionId is dispatched', () => {
+      const path1 = 'path/1';
+      const path2 = 'path/2';
+      const expandedPaths = [path1, path2, ROOT_PATH];
+      const oldVersionId = nextUniqueId();
+      const oldVersion = createExternalVersionWithEntries(
+        [
+          createFakeEntry('directory', path1),
+          createFakeEntry('directory', path2),
+        ],
+        { id: oldVersionId },
+      );
+      const newVersionId = nextUniqueId();
+      const newVersion = createExternalVersionWithEntries(
+        [createFakeEntry('directory', path1)],
+        { id: newVersionId },
+      );
+
+      let state = reducer(
+        undefined,
+        actions.loadVersionInfo({ version: oldVersion }),
+      );
+      state = reducer(state, actions.loadVersionInfo({ version: newVersion }));
+      state = reducer(state, actions.expandTree({ versionId: oldVersionId }));
+      state = reducer(
+        state,
+        actions.setCurrentVersionId({ versionId: newVersionId }),
+      );
+
+      expect(state).toHaveProperty(
+        'expandedPaths',
+        getPrunedExpandedPaths(
+          expandedPaths,
+          createInternalVersion(newVersion),
+        ),
+      );
     });
 
     it('loads entry status map', () => {
@@ -187,6 +261,10 @@ describe(__filename, () => {
         `versionInfo.${version.id}.expandedPaths`,
         getParentFolders(selectedPath),
       );
+      expect(state).toHaveProperty(
+        'expandedPaths',
+        getParentFolders(selectedPath),
+      );
     });
 
     it('retains all expanded folders when updateSelectedPath is dispatched', () => {
@@ -218,6 +296,11 @@ describe(__filename, () => {
         initialPath,
         newFolder,
       ]);
+      expect(state).toHaveProperty('expandedPaths', [
+        ...expandedPaths,
+        initialPath,
+        newFolder,
+      ]);
     });
 
     it('throws an error when toggleExpandedPath is called for an unknown version', () => {
@@ -227,6 +310,19 @@ describe(__filename, () => {
           actions.toggleExpandedPath({ path: 'pa/th', versionId: 123 }),
         );
       }).toThrow(/Version missing/);
+    });
+
+    it('throws an error when expandedPaths is undefined', () => {
+      const versionId = nextUniqueId();
+      const version = { ...fakeVersion, id: versionId };
+      const state = reducer(undefined, actions.loadVersionInfo({ version }));
+
+      expect(() => {
+        reducer(
+          { ...state, expandedPaths: undefined },
+          actions.toggleExpandedPath({ path: 'path.js', versionId }),
+        );
+      }).toThrow('ExpandedPaths is undefined');
     });
 
     it('does not duplicate paths in expandedPaths when updateSelectedPath is dispatched', () => {
@@ -256,6 +352,7 @@ describe(__filename, () => {
         ...expandedPaths,
         path,
       ]);
+      expect(state).toHaveProperty('expandedPaths', [...expandedPaths, path]);
     });
 
     it('adds a path to expandedPaths', () => {
@@ -274,6 +371,7 @@ describe(__filename, () => {
         ...expandedPaths,
         path,
       ]);
+      expect(state).toHaveProperty('expandedPaths', [...expandedPaths, path]);
     });
 
     it('removes a path from expandedPaths', () => {
@@ -297,6 +395,7 @@ describe(__filename, () => {
         `versionInfo.${version.id}.expandedPaths`,
         expandedPaths,
       );
+      expect(state).toHaveProperty('expandedPaths', expandedPaths);
     });
 
     it('maintains other paths when removing a path from expandedPaths', () => {
@@ -323,6 +422,11 @@ describe(__filename, () => {
         path1,
         path2,
       ]);
+      expect(state).toHaveProperty('expandedPaths', [
+        ...expandedPaths,
+        path1,
+        path2,
+      ]);
 
       // Remove the first path.
       state = reducer(
@@ -334,6 +438,7 @@ describe(__filename, () => {
         ...expandedPaths,
         path2,
       ]);
+      expect(state).toHaveProperty('expandedPaths', [...expandedPaths, path2]);
     });
 
     it('adds all paths to expandedPaths when expandTree is dispatched', () => {
@@ -354,6 +459,7 @@ describe(__filename, () => {
         path2,
         ROOT_PATH,
       ]);
+      expect(state).toHaveProperty('expandedPaths', [path1, path2, ROOT_PATH]);
     });
 
     it('throws an error when expandTree is called for an unknown version', () => {
@@ -379,6 +485,7 @@ describe(__filename, () => {
         path1,
         ROOT_PATH,
       ]);
+      expect(state).toHaveProperty('expandedPaths', [path1, ROOT_PATH]);
     });
 
     it('removes all paths from expandedPaths when collapseTree is dispatched', () => {
@@ -400,6 +507,7 @@ describe(__filename, () => {
       expect(state).toHaveProperty(`versionInfo.${version.id}.expandedPaths`, [
         ROOT_PATH,
       ]);
+      expect(state).toHaveProperty('expandedPaths', [ROOT_PATH]);
     });
 
     it('throws an error when collapseTree is called for an unknown version', () => {
@@ -3133,6 +3241,35 @@ describe(__filename, () => {
       const state = reducer(undefined, actions.unsetCurrentVersionId());
 
       expect(selectCurrentVersionInfo(state)).toEqual(false);
+    });
+  });
+
+  describe('getPrunedExpandedPaths', () => {
+    it('perserves the paths that exist in the new version', () => {
+      const path1 = 'path/1';
+      const path2 = 'path/2';
+      const expandedPaths = [path1];
+      const version = createExternalVersionWithEntries([
+        createFakeEntry('directory', path1),
+        createFakeEntry('directory', path2),
+      ]);
+
+      expect(
+        getPrunedExpandedPaths(expandedPaths, createInternalVersion(version)),
+      ).toEqual([path1]);
+    });
+
+    it('filters out the paths that do not exist in the new verison', () => {
+      const path1 = 'path/1';
+      const path2 = 'path/2';
+      const expandedPaths = [path1, path2];
+      const version = createExternalVersionWithEntries([
+        createFakeEntry('directory', path1),
+      ]);
+
+      expect(
+        getPrunedExpandedPaths(expandedPaths, createInternalVersion(version)),
+      ).toEqual([path1]);
     });
   });
 });

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -246,13 +246,13 @@ export const createExternalVersionWithEntries = (
       diff,
       entries: partialEntries.reduce((entries, file) => {
         return {
+          ...entries,
           [file.path]: {
             ...fakeVersionEntry,
             filename: pathLib.basename(file.path),
             path: file.path,
             ...file,
           },
-          ...entries,
         };
       }, {}),
       selected_file,


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/1248

This is an attempt to refactor `expandedPaths` out of `version` object in a progressive way according to https://github.com/mozilla/addons-code-manager/pull/1100#issuecomment-549474948