### PR TITLE
Encourage devs to ignore .vscode globally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,8 +73,3 @@ typings/
 
 # Storybook
 storybook-static/
-
-# IDE files
-# VSCode does not read local project files that might execute binaries by
-# default due to security so this config wouldn't have an effect, anyway.
-.vscode


### PR DESCRIPTION
Since it's not clear that `.vscode` files would ever need to be checked in, let's encourage devs to ignore them globally rather than explicitly in the shared ignore file. This patch reverts some changes from https://github.com/mozilla/addons-code-manager/pull/1210 after feedback.