### PR TITLE
Pass empty comments to the API

### DIFF
--- a/src/components/Comment/index.spec.tsx
+++ b/src/components/Comment/index.spec.tsx
@@ -182,6 +182,28 @@ describe(__filename, () => {
     });
   });
 
+  it('can submit an empty comment', () => {
+    const store = configureStore();
+    const dispatchSpy = spyOn(store, 'dispatch');
+
+    const fakeThunk = createFakeThunk();
+    const _manageComment = fakeThunk.createThunk;
+
+    const root = render({ _manageComment, store });
+
+    // Submit the comment before it has been typed in the input box.
+    root.find(`.${styles.form}`).simulate('submit', createFakeEvent());
+
+    expect(dispatchSpy).toHaveBeenCalledWith(fakeThunk.thunk);
+    expect(_manageComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        // Make sure an empty string is passed to the API so that the
+        // API can be responsible for raising an error.
+        comment: '',
+      }),
+    );
+  });
+
   it('renders a pending state while saving a comment', () => {
     const keyParams = { fileName: null, line: null, versionId: 1 };
     const pendingCommentText = 'Example of a comment being edited';

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -149,7 +149,10 @@ export class CommentBase extends React.Component<Props, State> {
         // TODO: support canned responses.
         // https://github.com/mozilla/addons-code-manager/issues/113
         cannedResponseId: undefined,
-        comment: this.state.commentText,
+        // If the comment is empty, pass an empty string so that
+        // the API can trigger an error. The error will be rendered like
+        // all other API errors.
+        comment: this.state.commentText || '',
         commentId: initialComment ? initialComment.id : undefined,
         fileName,
         line,


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/1106 by not throwing [this error](https://github.com/mozilla/addons-code-manager/blob/980d88413d4457f0b545d2dd413d9195934da6b4/src/api/index.tsx#L411).

After this patch, the UI will let you submit an empty comment until https://github.com/mozilla/addons-server/issues/12865 is fixed. Once that API issue is fixed, the error will show up at the top like other errors. I also confirmed that the comment form will remain open and editable when the error is displayed, allowing the user to correct the mistake and try again.