### PR TITLE
Add a link back to Reviewer Tools

### DIFF
--- a/.env.common-local
+++ b/.env.common-local
@@ -5,6 +5,7 @@ REACT_APP_FXA_CONFIG=local
 REACT_APP_USE_INSECURE_PROXY=true
 REACT_APP_CRA_PORT=3100
 REACT_APP_IS_LOCAL_DEV=true
+REACT_APP_REVIEWERS_HOST=https://reviewers.addons-dev.allizom.org
 
 # This is the DSN for the `addons-code-manager-test` Sentry project.
 # Uncomment the line with the variable below if you want to see (local) errors

--- a/src/components/Navbar/index.spec.tsx
+++ b/src/components/Navbar/index.spec.tsx
@@ -23,18 +23,23 @@ import Navbar from '.';
 describe(__filename, () => {
   type RenderParams = {
     _requestLogOut?: typeof requestLogOut;
+    reviewersHost?: string;
     store?: Store;
   };
 
   const render = ({
     _requestLogOut = jest.fn(),
+    reviewersHost,
     store = configureStore(),
   }: RenderParams = {}) => {
     // TODO: Use shallowUntilTarget()
     // https://github.com/mozilla/addons-code-manager/issues/15
-    const root = shallow(<Navbar _requestLogOut={_requestLogOut} />, {
-      context: { store },
-    }).shallow();
+    const root = shallow(
+      <Navbar _requestLogOut={_requestLogOut} reviewersHost={reviewersHost} />,
+      {
+        context: { store },
+      },
+    ).shallow();
 
     return root;
   };
@@ -58,7 +63,25 @@ describe(__filename, () => {
       });
       const root = render({ store });
 
-      expect(root.find(`.${styles.info}`)).toHaveText(addonName);
+      expect(root.find(`.${styles.addonName}`)).toHaveText(addonName);
+    });
+
+    it('renders a link to reviewer tools', () => {
+      const reviewersHost = 'https://example.com';
+      const slug = 'some-slug';
+      const store = createStoreWithVersion({
+        version: {
+          ...fakeVersion,
+          addon: { ...fakeVersionAddon, slug },
+        },
+        makeCurrent: true,
+      });
+      const root = render({ reviewersHost, store });
+
+      expect(root.find(`.${styles.reviewerToolsLink}`)).toHaveProp(
+        'href',
+        `${reviewersHost}/reviewers/review/${slug}`,
+      );
     });
   });
 
@@ -66,7 +89,13 @@ describe(__filename, () => {
     it('does not render addon name', () => {
       const root = render();
 
-      expect(root.find(`.${styles.info}`)).toHaveText('');
+      expect(root.find(`.${styles.addonName}`)).toHaveLength(0);
+    });
+
+    it('does not render a link to reviewer tools', () => {
+      const root = render();
+
+      expect(root.find(`.${styles.reviewerToolsLink}`)).toHaveLength(0);
     });
   });
 

--- a/src/components/Navbar/index.spec.tsx
+++ b/src/components/Navbar/index.spec.tsx
@@ -1,4 +1,3 @@
-import { shallow } from 'enzyme';
 import React from 'react';
 import { Store } from 'redux';
 
@@ -14,34 +13,28 @@ import {
   fakeUser,
   fakeVersion,
   fakeVersionAddon,
+  shallowUntilTarget,
   spyOn,
 } from '../../test-helpers';
-import { actions as userActions, requestLogOut } from '../../reducers/users';
+import { actions as userActions } from '../../reducers/users';
 
-import Navbar from '.';
+import Navbar, { NavbarBase, PublicProps } from '.';
 
 describe(__filename, () => {
-  type RenderParams = {
-    _requestLogOut?: typeof requestLogOut;
-    reviewersHost?: string;
-    store?: Store;
-  };
+  type RenderParams = Partial<PublicProps> & { store?: Store };
 
   const render = ({
-    _requestLogOut = jest.fn(),
-    reviewersHost,
     store = configureStore(),
+    ...moreProps
   }: RenderParams = {}) => {
-    // TODO: Use shallowUntilTarget()
-    // https://github.com/mozilla/addons-code-manager/issues/15
-    const root = shallow(
-      <Navbar _requestLogOut={_requestLogOut} reviewersHost={reviewersHost} />,
-      {
-        context: { store },
-      },
-    ).shallow();
+    const props = {
+      _requestLogOut: jest.fn(),
+      ...moreProps,
+    };
 
-    return root;
+    return shallowUntilTarget(<Navbar {...props} />, NavbarBase, {
+      shallowOptions: { context: { store } },
+    });
   };
 
   const storeWithUser = (user = fakeUser) => {

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -14,7 +14,7 @@ import { ConnectedReduxProps } from '../../configureStore';
 import { User, selectCurrentUser, requestLogOut } from '../../reducers/users';
 import styles from './styles.module.scss';
 
-type PublicProps = {
+export type PublicProps = {
   _requestLogOut: typeof requestLogOut;
   reviewersHost: string;
 };
@@ -75,7 +75,10 @@ export class NavbarBase extends React.Component<Props> {
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    <FontAwesomeIcon icon={['fas', 'arrow-left']} />
+                    <FontAwesomeIcon
+                      className={styles.reviewerToolsIcon}
+                      icon={['fas', 'arrow-left']}
+                    />
                     {gettext('Reviewer Tools')}
                   </a>
                 </div>

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -2,6 +2,7 @@ import makeClassName from 'classnames';
 import * as React from 'react';
 import { Button, Navbar } from 'react-bootstrap';
 import { connect } from 'react-redux';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { gettext, getLocalizedString } from '../../utils';
 import CommentSummaryButton from '../CommentSummaryButton';
@@ -67,11 +68,6 @@ export class NavbarBase extends React.Component<Props> {
           <div className={styles.info}>
             {currentVersion && (
               <>
-                <div
-                  className={makeClassName(styles.infoItem, styles.addonName)}
-                >
-                  {getLocalizedString(currentVersion.addon.name)}
-                </div>
                 <div className={styles.infoItem}>
                   <a
                     className={styles.reviewerToolsLink}
@@ -79,8 +75,14 @@ export class NavbarBase extends React.Component<Props> {
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    {gettext('Back to reviewer tools')}
+                    <FontAwesomeIcon icon={['fas', 'arrow-left']} />
+                    {gettext('Reviewer Tools')}
                   </a>
+                </div>
+                <div
+                  className={makeClassName(styles.infoItem, styles.addonName)}
+                >
+                  {getLocalizedString(currentVersion.addon.name)}
                 </div>
               </>
             )}

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -1,3 +1,4 @@
+import makeClassName from 'classnames';
 import * as React from 'react';
 import { Button, Navbar } from 'react-bootstrap';
 import { connect } from 'react-redux';
@@ -14,6 +15,7 @@ import styles from './styles.module.scss';
 
 type PublicProps = {
   _requestLogOut: typeof requestLogOut;
+  reviewersHost: string;
 };
 
 type PropsFromState = {
@@ -27,6 +29,7 @@ type Props = PublicProps & PropsFromState & ConnectedReduxProps;
 export class NavbarBase extends React.Component<Props> {
   static defaultProps = {
     _requestLogOut: requestLogOut,
+    reviewersHost: process.env.REACT_APP_REVIEWERS_HOST,
   };
 
   logOut = () => {
@@ -56,16 +59,30 @@ export class NavbarBase extends React.Component<Props> {
   }
 
   render() {
-    const { user, currentVersion } = this.props;
+    const { currentVersion, reviewersHost, user } = this.props;
 
     return (
       <Navbar className={styles.Navbar} expand="lg" variant="dark">
         <Navbar.Brand className={styles.brand}>
           <div className={styles.info}>
             {currentVersion && (
-              <div className={styles.infoItem}>
-                {getLocalizedString(currentVersion.addon.name)}
-              </div>
+              <>
+                <div
+                  className={makeClassName(styles.infoItem, styles.addonName)}
+                >
+                  {getLocalizedString(currentVersion.addon.name)}
+                </div>
+                <div className={styles.infoItem}>
+                  <a
+                    className={styles.reviewerToolsLink}
+                    href={`${reviewersHost}/reviewers/review/${currentVersion.addon.slug}`}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    {gettext('Back to reviewer tools')}
+                  </a>
+                </div>
+              </>
             )}
             {this.renderCommentsNavBar()}
           </div>

--- a/src/components/Navbar/styles.module.scss
+++ b/src/components/Navbar/styles.module.scss
@@ -1,5 +1,4 @@
 @import '../../scss/variables';
-@import '../../scss/mixins';
 
 $bg-color: $dark-gray;
 
@@ -68,8 +67,8 @@ $bg-color: $dark-gray;
     color: $white;
     text-decoration: underline;
   }
+}
 
-  svg {
-    margin-right: 10px;
-  }
+.reviewerToolsIcon {
+  margin-right: 10px;
 }

--- a/src/components/Navbar/styles.module.scss
+++ b/src/components/Navbar/styles.module.scss
@@ -1,4 +1,5 @@
 @import '../../scss/variables';
+@import '../../scss/mixins';
 
 $bg-color: $dark-gray;
 
@@ -58,4 +59,17 @@ $bg-color: $dark-gray;
 
 .username {
   margin-right: $default-padding;
+}
+
+.reviewerToolsLink {
+  &,
+  &:active,
+  &:hover {
+    color: $white;
+    text-decoration: underline;
+  }
+
+  svg {
+    margin-right: 10px;
+  }
 }


### PR DESCRIPTION
Fixes #984 

I wasn't sure whether we wanted a link *added* to the Navbar, or whether we wanted to use the existing label for the add-on name *as* the link back to the reviewer tools, so I did the former. It's easy enough to change this so no new link is added and we simply linkify the existing label. Because I wasn't sure about this, I didn't apply any styling to the new link, which is why it's currently blue. I will fix that if we decide to keep the new link.

Screenshot:

![Screenshot 2019-11-15 12 12 08](https://user-images.githubusercontent.com/142755/68961966-845c6c00-07a1-11ea-8230-8b2b69aa8596.png)
