### PR TITLE
Add an ErrorBoundary

### DIFF
--- a/src/components/ErrorBoundary/index.spec.tsx
+++ b/src/components/ErrorBoundary/index.spec.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { createFakeLogger } from '../../test-helpers';
 import styles from './styles.module.scss';
 
-import ErrorBoundary, { Props } from '.';
+import ErrorBoundary, { Props, State } from '.';
 
 describe(__filename, () => {
   const CustomComponent = ({
@@ -13,7 +13,7 @@ describe(__filename, () => {
     children?: JSX.Element;
   }) => children;
 
-  type RenderParams = Partial<Props> & { children?: JSX.Element };
+  type RenderParams = Partial<Props>;
 
   const render = ({
     _log = createFakeLogger(),
@@ -42,11 +42,15 @@ describe(__filename, () => {
     const error = new Error('test');
 
     root.find(CustomComponent).simulateError(error);
+
+    const state = root.state() as State;
+    const expectedErrorInfo = state.errorInfo as React.ErrorInfo;
+
     expect(root.find(`.${className}`)).toHaveLength(0);
     expect(root.find(`.${styles.errorDetails}`)).toHaveLength(1);
     expect(root.find(`.${styles.errorText}`)).toHaveText(error.toString());
     expect(root.find(`.${styles.componentStack}`)).toHaveText(
-      error.componentStack,
+      expectedErrorInfo.componentStack,
     );
   });
 

--- a/src/components/ErrorBoundary/index.spec.tsx
+++ b/src/components/ErrorBoundary/index.spec.tsx
@@ -1,0 +1,62 @@
+import { mount } from 'enzyme';
+import * as React from 'react';
+
+import { createFakeLogger } from '../../test-helpers';
+import styles from './styles.module.scss';
+
+import ErrorBoundary, { Props } from '.';
+
+describe(__filename, () => {
+  const CustomComponent = ({
+    children = <div />,
+  }: {
+    children?: JSX.Element;
+  }) => children;
+
+  type RenderParams = Partial<Props> & { children?: JSX.Element };
+
+  const render = ({
+    _log = createFakeLogger(),
+    children = <div />,
+  }: RenderParams = {}) => {
+    return mount(
+      <ErrorBoundary _log={_log}>
+        <CustomComponent>{children}</CustomComponent>
+      </ErrorBoundary>,
+    );
+  };
+
+  it('renders children if there is no error', () => {
+    const className = 'some-class-name';
+    const children = <div className={className}>A child to be rendered</div>;
+    const root = render({ children });
+
+    expect(root.find(`.${className}`)).toHaveLength(1);
+  });
+
+  it('renders an error page if there is an error', () => {
+    const className = 'some-class-name';
+    const children = <div className={className}>A child to be rendered</div>;
+    const root = render({ children });
+
+    const error = new Error('test');
+
+    root.find(CustomComponent).simulateError(error);
+    expect(root.find(`.${className}`)).toHaveLength(0);
+    expect(root.find(`.${styles.errorDetails}`)).toHaveLength(1);
+    expect(root.find(`.${styles.errorText}`)).toHaveText(error.toString());
+    expect(root.find(`.${styles.componentStack}`)).toHaveText(
+      error.componentStack,
+    );
+  });
+
+  it('logs an error if there is an error', () => {
+    const _log = createFakeLogger();
+    const root = render({ _log });
+
+    const error = new Error('test');
+
+    root.find(CustomComponent).simulateError(error);
+    expect(_log.error).toHaveBeenCalled();
+  });
+});

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -1,0 +1,60 @@
+import log from 'loglevel';
+import * as React from 'react';
+
+import styles from './styles.module.scss';
+
+export type Props = { _log: typeof log };
+
+type State = {
+  error: Error | null;
+  errorInfo: React.ErrorInfo | null;
+};
+
+export class ErrorBoundaryBase extends React.Component<Props, State> {
+  static defaultProps: Props = { _log: log };
+
+  constructor(props: Props) {
+    super(props);
+    this.state = { error: null, errorInfo: null };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    const { _log } = this.props;
+
+    this.setState({ error, errorInfo });
+    _log.error(error.toString());
+  }
+
+  render() {
+    const { error, errorInfo } = this.state;
+    if (errorInfo) {
+      return (
+        <div className={styles.container}>
+          <h2>Oops, something went wrong.</h2>
+          <p>
+            Please let us know what you were trying to do when this error
+            occured by{' '}
+            <a
+              href="https://github.com/mozilla/addons-code-manager/issues/new/"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              filing an issue
+            </a>
+            .
+          </p>
+          <details className={styles.errorDetails}>
+            <div className={styles.errorText}>{error && error.toString()}</div>
+            <div className={styles.componentStack}>
+              {errorInfo.componentStack}
+            </div>
+          </details>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundaryBase;

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -3,15 +3,17 @@ import * as React from 'react';
 
 import styles from './styles.module.scss';
 
-export type Props = { _log: typeof log };
+export type PublicProps = { children: JSX.Element };
+export type DefaultProps = { _log: typeof log };
+export type Props = PublicProps & DefaultProps;
 
-type State = {
+export type State = {
   error: Error | null;
   errorInfo: React.ErrorInfo | null;
 };
 
 export class ErrorBoundaryBase extends React.Component<Props, State> {
-  static defaultProps: Props = { _log: log };
+  static defaultProps: DefaultProps = { _log: log };
 
   constructor(props: Props) {
     super(props);
@@ -22,7 +24,7 @@ export class ErrorBoundaryBase extends React.Component<Props, State> {
     const { _log } = this.props;
 
     this.setState({ error, errorInfo });
-    _log.error(error.toString());
+    _log.error('Caught application error:', error, errorInfo);
   }
 
   render() {
@@ -46,7 +48,7 @@ export class ErrorBoundaryBase extends React.Component<Props, State> {
           <details className={styles.errorDetails}>
             <div className={styles.errorText}>{error && error.toString()}</div>
             <div className={styles.componentStack}>
-              {errorInfo.componentStack}
+              {errorInfo && errorInfo.componentStack}
             </div>
           </details>
         </div>

--- a/src/components/ErrorBoundary/styles.module.scss
+++ b/src/components/ErrorBoundary/styles.module.scss
@@ -1,0 +1,9 @@
+@import '../../scss/variables';
+
+.container {
+  padding: $default-padding;
+}
+
+.errorDetails {
+  white-space: pre-wrap;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import { createBrowserHistory } from 'history';
 
 import './styles.scss';
 import App from './components/App';
+import ErrorBoundary from './components/ErrorBoundary';
 import configureApplication from './configureApplication';
 import configureStore from './configureStore';
 
@@ -25,11 +26,13 @@ if (authToken === process.env.REACT_APP_AUTH_TOKEN_PLACEHOLDER) {
 
 const render = (AppComponent: typeof App) => {
   ReactDOM.render(
-    <Provider store={store}>
-      <ConnectedRouter history={history}>
-        <AppComponent authToken={authToken} />
-      </ConnectedRouter>
-    </Provider>,
+    <ErrorBoundary>
+      <Provider store={store}>
+        <ConnectedRouter history={history}>
+          <AppComponent authToken={authToken} />
+        </ConnectedRouter>
+      </Provider>
+    </ErrorBoundary>,
     rootElement,
   );
 };

--- a/stories/ErrorBoundary.stories.tsx
+++ b/stories/ErrorBoundary.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import ErrorBoundary from '../src/components/ErrorBoundary';
+
+const render = (children: JSX.Element) => {
+  return <ErrorBoundary>{children}</ErrorBoundary>;
+};
+
+storiesOf('ErrorBoundary', module)
+  .add('with error', () => {
+    return render(<div>{new Error('Test Error')}</div>);
+  })
+  .add('without error', () => {
+    return render(<div>This is error-less content</div>);
+  });


### PR DESCRIPTION
Fixes #900 

The page that is shown when an error is caught is ugly, but I'm not sure exactly what it should look like. All of the pages on the site currently use the `FullScreenGrid`, but I think this needs to be rendered as a standalone page in order to make sure no errors are thrown during the rendering of the error page.

We can either fix it up to make it prettier now (once we decide what it should look like), or we could make that a follow-up, as I don't think we envision many people ever seeing this page.

I'm also not sure how to create an STR for the error condition being encountered with production settings, but I think we need that to enable QA to test this.
