### PR TITLE
Fixes #1193: Add helper for creating an error response

### DIFF
--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -9,6 +9,7 @@ import {
   createFakeApiPage,
   createFakeCommentsResponse,
   createFakeExternalComment,
+  createErrorResponse,
   nextUniqueId,
   setMockFetchResponseJSON,
 } from '../test-helpers';
@@ -384,7 +385,9 @@ describe(__filename, () => {
 
   describe('isErrorResponse', () => {
     it('returns true if a response object is an error', () => {
-      const response = { error: 'this is an error' };
+      const response = createErrorResponse({
+        error: new Error('API Error'),
+      });
 
       expect(isErrorResponse(response)).toEqual(true);
     });
@@ -1035,9 +1038,11 @@ describe(__filename, () => {
     });
 
     it('passes errors through', async () => {
-      const error = new Error('API Error');
+      const errorResponse = createErrorResponse({
+        error: new Error('API Error'),
+      });
       const getNext = jest.fn().mockImplementation(() => {
-        return { error };
+        return errorResponse;
       });
 
       const response = await fetchAllPages<string>(getNext);

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -117,7 +117,7 @@ type CallApiParams<BodyDataType extends undefined | {}> = {
   version?: string;
 };
 
-type ErrorResponseType = { error: Error };
+export type ErrorResponseType = { error: Error };
 
 type CallApiResponse<SuccessResponseType> =
   | SuccessResponseType

--- a/src/components/App/index.spec.tsx
+++ b/src/components/App/index.spec.tsx
@@ -12,6 +12,7 @@ import { actions as userActions } from '../../reducers/users';
 import {
   createContextWithFakeRouter,
   createFakeThunk,
+  createErrorResponse,
   fakeUser,
   shallowUntilTarget,
   spyOn,
@@ -181,25 +182,33 @@ describe(__filename, () => {
   });
 
   it('renders application errors', () => {
-    const error1 = new Error('error 1');
-    const error2 = new Error('error 2');
+    const error1 = createErrorResponse({
+      error: new Error('error 1'),
+    });
+    const error2 = createErrorResponse({
+      error: new Error('error 2'),
+    });
     const store = configureStore();
-    store.dispatch(errorsActions.addError({ error: error1 }));
-    store.dispatch(errorsActions.addError({ error: error2 }));
+    store.dispatch(errorsActions.addError(error1));
+    store.dispatch(errorsActions.addError(error2));
 
     const root = render({ store });
 
     expect(root.find(Alert)).toHaveLength(2);
-    expect(root.find(Alert).at(0)).toIncludeText(error1.message);
-    expect(root.find(Alert).at(1)).toIncludeText(error2.message);
+    expect(root.find(Alert).at(0)).toIncludeText(error1.error.message);
+    expect(root.find(Alert).at(1)).toIncludeText(error2.error.message);
   });
 
   it('dispatches removeError() when dismissing an error', () => {
-    const error1 = new Error('first error');
-    const error2 = new Error('second error');
+    const error1 = createErrorResponse({
+      error: new Error('first error'),
+    });
+    const error2 = createErrorResponse({
+      error: new Error('second error'),
+    });
     const store = configureStore();
-    store.dispatch(errorsActions.addError({ error: error1 }));
-    store.dispatch(errorsActions.addError({ error: error2 }));
+    store.dispatch(errorsActions.addError(error1));
+    store.dispatch(errorsActions.addError(error2));
     const dispatch = spyOn(store, 'dispatch');
 
     const root = render({ store });

--- a/src/reducers/comments.spec.tsx
+++ b/src/reducers/comments.spec.tsx
@@ -26,6 +26,7 @@ import { createInternalVersion } from './versions';
 import {
   createFakeCommentsResponse,
   createFakeExternalComment,
+  createErrorResponse,
   fakeVersion,
   thunkTester,
 } from '../test-helpers';
@@ -941,8 +942,10 @@ describe(__filename, () => {
     });
 
     it('handles API errors', async () => {
-      const error = new Error('API Error');
-      const _getAllComments = jest.fn().mockResolvedValue({ error });
+      const errorResponse = createErrorResponse({
+        error: new Error('API Error'),
+      });
+      const _getAllComments = jest.fn().mockResolvedValue(errorResponse);
       const versionId = 1;
 
       const { dispatch, thunk } = thunkTester({
@@ -955,7 +958,9 @@ describe(__filename, () => {
       expect(dispatch).toHaveBeenCalledWith(
         actions.abortFetchVersionComments({ versionId }),
       );
-      expect(dispatch).toHaveBeenCalledWith(errorsActions.addError({ error }));
+      expect(dispatch).toHaveBeenCalledWith(
+        errorsActions.addError(errorResponse),
+      );
     });
 
     it('fetches version comments', async () => {
@@ -1238,8 +1243,10 @@ describe(__filename, () => {
 
     it('dispatches abortDeleteComment(), addError() on error', async () => {
       const commentId = 987;
-      const error = new Error('API Error');
-      const _apiDeleteComment = jest.fn().mockResolvedValue({ error });
+      const errorResponse = createErrorResponse({
+        error: new Error('API Error'),
+      });
+      const _apiDeleteComment = jest.fn().mockResolvedValue(errorResponse);
 
       const { dispatch, thunk } = thunkTester({
         createThunk: () => _deleteComment({ _apiDeleteComment, commentId }),
@@ -1251,7 +1258,9 @@ describe(__filename, () => {
         actions.abortDeleteComment({ commentId }),
       );
 
-      expect(dispatch).toHaveBeenCalledWith(errorsActions.addError({ error }));
+      expect(dispatch).toHaveBeenCalledWith(
+        errorsActions.addError(errorResponse),
+      );
     });
   });
 

--- a/src/reducers/linter.spec.tsx
+++ b/src/reducers/linter.spec.tsx
@@ -2,6 +2,7 @@
 import {
   createFakeExternalLinterResult,
   createFakeLinterMessagesByPath,
+  createErrorResponse,
   fakeExternalLinterResult,
   fakeExternalLinterMessage,
   setMockFetchResponseJSON,
@@ -495,7 +496,11 @@ describe(__filename, () => {
       await thunk();
 
       expect(dispatch).toHaveBeenCalledWith(
-        errorsActions.addError({ error: expect.any(Error) }),
+        errorsActions.addError(
+          createErrorResponse({
+            error: expect.any(Error),
+          }),
+        ),
       );
       expect(dispatch).toHaveBeenCalledWith(
         actions.abortFetchLinterResult({ versionId }),
@@ -514,7 +519,11 @@ describe(__filename, () => {
       await thunk();
 
       expect(dispatch).toHaveBeenCalledWith(
-        errorsActions.addError({ error: expect.any(Error) }),
+        errorsActions.addError(
+          createErrorResponse({
+            error: expect.any(Error),
+          }),
+        ),
       );
       expect(dispatch).toHaveBeenCalledWith(
         actions.abortFetchLinterResult({ versionId }),

--- a/src/reducers/users.spec.tsx
+++ b/src/reducers/users.spec.tsx
@@ -9,7 +9,7 @@ import reducer, {
   requestLogOut,
   selectCurrentUser,
 } from './users';
-import { fakeUser, thunkTester } from '../test-helpers';
+import { fakeUser, thunkTester, createErrorResponse } from '../test-helpers';
 import { actions as errorsActions } from './errors';
 
 describe(__filename, () => {
@@ -208,9 +208,11 @@ describe(__filename, () => {
 
     it('aborts loading a user when API response is not successful', async () => {
       const _getCurrentUser = jest.fn().mockReturnValue(
-        Promise.resolve({
-          error: new Error('Bad Request'),
-        }),
+        Promise.resolve(
+          createErrorResponse({
+            error: new Error('Bad Request'),
+          }),
+        ),
       );
 
       const { dispatch, thunk } = _fetchCurrentUser({ _getCurrentUser });

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -57,6 +57,7 @@ import {
   createStoreWithVersion,
   createFakeThunk,
   createVersionAndEntryStatusMap,
+  createErrorResponse,
   fakeExternalDiff,
   fakeVersion,
   fakeVersionAddon,
@@ -1276,7 +1277,11 @@ describe(__filename, () => {
       const version = { ...fakeVersion, id: 54123 };
       const _getVersion = jest
         .fn()
-        .mockReturnValue(Promise.resolve({ error: new Error('Bad Request') }));
+        .mockReturnValue(
+          Promise.resolve(
+            createErrorResponse({ error: new Error('Bad Request') }),
+          ),
+        );
 
       const { dispatch, thunk } = _fetchVersionFile({
         _getVersion,
@@ -1862,9 +1867,11 @@ describe(__filename, () => {
       const baseVersionId = 2;
       const headVersionId = 2;
       const _getDiff = jest.fn().mockReturnValue(
-        Promise.resolve({
-          error: new Error('Bad Request'),
-        }),
+        Promise.resolve(
+          createErrorResponse({
+            error: new Error('Bad Request'),
+          }),
+        ),
       );
 
       const { dispatch, thunk } = _fetchDiff({
@@ -1887,9 +1894,11 @@ describe(__filename, () => {
     it('dispatches abortFetchVersion() when the API call has failed', async () => {
       const headVersionId = 2;
       const _getDiff = jest.fn().mockReturnValue(
-        Promise.resolve({
-          error: new Error('Bad Request'),
-        }),
+        Promise.resolve(
+          createErrorResponse({
+            error: new Error('Bad Request'),
+          }),
+        ),
       );
 
       const { dispatch, thunk } = _fetchDiff({ _getDiff, headVersionId });

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -10,7 +10,11 @@ import { Store } from 'redux';
 import log from 'loglevel';
 import { createAction } from 'typesafe-actions';
 
-import { GetCommentsResponse, PaginatedResponse } from './api';
+import {
+  GetCommentsResponse,
+  PaginatedResponse,
+  ErrorResponseType,
+} from './api';
 import configureStore, { ThunkActionCreator } from './configureStore';
 import { ApplicationState } from './reducers';
 import {
@@ -965,6 +969,14 @@ export const createFakeCommentsResponse = (
   results = [createFakeExternalComment()],
 ) => {
   return createFakeApiPage<GetCommentsResponse>({ results });
+};
+
+export const createErrorResponse = (
+  errorResponse = {
+    error: new Error('Example error'),
+  },
+): ErrorResponseType => {
+  return errorResponse;
 };
 
 export const setMockFetchResponseJSON = (


### PR DESCRIPTION
reference issue #1193

**description:**
Refactor the creation of all {error: Error} objects with the createErrorResponse helper function for all the test cases that use it. Prettier-ed and linted.

**tests checked & passed:**
yarn lint, yarn eslint, yarn typecheck, yarn type-coverage, yarn test

- [x] This PR relates to an existing open issue and there are no existing PRs open for the same issue.
- [x] Add a description of the changes introduced in this PR.
- [x] The change has been successfully run locally.

