### PR TITLE
Comment on a line of a diff

### DIFF
--- a/src/@types/react-diff-view/index.d.ts
+++ b/src/@types/react-diff-view/index.d.ts
@@ -64,9 +64,9 @@ declare module 'react-diff-view' {
     viewType: ViewType;
     gutterType?: 'default' | 'anchor' | 'none';
     generateAnchorID?: (change: ChangeInfo) => string;
+    renderGutter?: (RenderGutterParams) => ReactElement;
     selectedChanges?: string[];
     widgets?: WidgetMap;
-    renderGutter?: (RenderGutterParams) => ReactElement;
   };
 
   // eslint-disable-next-line no-undef

--- a/src/@types/react-diff-view/index.d.ts
+++ b/src/@types/react-diff-view/index.d.ts
@@ -47,6 +47,14 @@ declare module 'react-diff-view' {
 
   export type WidgetMap = { [changeKey: string]: ReactNode };
 
+  export type RenderGutterParams = {
+    change: ChangeInfo;
+    side: 'new' | 'old';
+    renderDefault: () => ReactElement;
+    wrapInAnchor: (ReactElement) => ReactElement;
+    inHoverState: boolean;
+  };
+
   type DiffProps = {
     children: (hunks: HunkInfo[]) => ReactNode;
     className?: string;
@@ -58,6 +66,7 @@ declare module 'react-diff-view' {
     generateAnchorID?: (change: ChangeInfo) => string;
     selectedChanges?: string[];
     widgets?: WidgetMap;
+    renderGutter?: (RenderGutterParams) => ReactElement;
   };
 
   // eslint-disable-next-line no-undef

--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -683,11 +683,11 @@ describe(__filename, () => {
       for (const line of [firstLine, secondLine]) {
         const widget = renderWidget(diff.hunks, widgets, line);
 
-        const { shell, renderContent } = simulateCommentList({
+        const { renderContent } = simulateCommentList({
           commentList: <CommentListResult />,
           root: widget,
         });
-        const commentWidget = renderContent(shell.at(0));
+        const commentWidget = renderContent();
         expect(commentWidget.find(CommentListResult)).toHaveLength(1);
 
         const commentList = widget.find(CommentList);
@@ -1045,7 +1045,6 @@ describe(__filename, () => {
     }: Partial<RenderGutterParams> &
       RenderParams & {
         defaultGutter?: React.ReactElement;
-        shallowRender?: boolean;
       } = {}) => {
       const diff = createDiffWithHunks([
         createHunkWithChanges([{ content: change.content }]),
@@ -1094,7 +1093,6 @@ describe(__filename, () => {
         const commentableDiv = gutter.find(Commentable);
 
         expect(commentableDiv).toHaveLength(1);
-        expect(commentableDiv).toHaveProp('id', getChangeKey(change));
         expect(commentableDiv).toHaveProp('line', change.lineNumber);
         expect(commentableDiv).toHaveProp('fileName', version.selectedPath);
         expect(commentableDiv).toHaveProp('versionId', version.id);

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -206,7 +206,7 @@ export class DiffViewBase extends React.Component<Props> {
 
       let widget = (
         <>
-          {enableCommenting && line && change.isInsert && (
+          {enableCommenting && line && !change.isDelete && (
             <CommentList
               addonId={version.addon.id}
               fileName={version.selectedPath}
@@ -295,12 +295,12 @@ export class DiffViewBase extends React.Component<Props> {
   }: RenderGutterParams) => {
     const { enableCommenting, version } = this.props;
 
-    const { isInsert, lineNumber } = change;
+    const { isDelete, lineNumber } = change;
     const changeKey = getChangeKey(change);
 
     const defaultGutter = wrapInAnchor(renderDefault());
     let gutter = defaultGutter;
-    if (enableCommenting && isInsert && lineNumber && side === 'new') {
+    if (enableCommenting && !isDelete && lineNumber && side === 'new') {
       gutter = (
         <Commentable
           as="div"

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -204,16 +204,17 @@ export class DiffViewBase extends React.Component<Props> {
         messages = selectedMessageMap.byLine[line];
       }
 
-      let widget = enableCommenting && line && !change.isDelete && (
-        <CommentList
-          addonId={version.addon.id}
-          fileName={version.selectedPath}
-          line={line}
-          versionId={version.id}
-        >
-          {(commentList) => <div>{commentList}</div>}
-        </CommentList>
-      );
+      let widget =
+        enableCommenting && line && !change.isDelete ? (
+          <CommentList
+            addonId={version.addon.id}
+            fileName={version.selectedPath}
+            line={line}
+            versionId={version.id}
+          >
+            {(allComments) => allComments}
+          </CommentList>
+        ) : null;
 
       if (messages && messages.length) {
         widget = (
@@ -293,7 +294,6 @@ export class DiffViewBase extends React.Component<Props> {
     const { enableCommenting, version } = this.props;
 
     const { isDelete, lineNumber } = change;
-    const changeKey = getChangeKey(change);
 
     const defaultGutter = wrapInAnchor(renderDefault());
     let gutter = defaultGutter;
@@ -301,7 +301,6 @@ export class DiffViewBase extends React.Component<Props> {
       gutter = (
         <Commentable
           as="div"
-          id={changeKey}
           className={styles.gutter}
           line={lineNumber}
           fileName={version.selectedPath}

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -206,11 +206,11 @@ export class DiffViewBase extends React.Component<Props> {
 
       let widget = (
         <>
-          {enableCommenting && change.isInsert && (
+          {enableCommenting && line && change.isInsert && (
             <CommentList
               addonId={version.addon.id}
               fileName={version.selectedPath}
-              line={line || null}
+              line={line}
               versionId={version.id}
             >
               {(commentList) => <div>{commentList}</div>}
@@ -219,12 +219,15 @@ export class DiffViewBase extends React.Component<Props> {
         </>
       );
       if (messages && messages.length) {
-        widget = widget && (
-          <div className={styles.inlineLinterMessages}>
-            {messages.map((msg) => {
-              return <LinterMessage key={msg.uid} message={msg} inline />;
-            })}
-          </div>
+        widget = (
+          <>
+            {widget}
+            <div className={styles.inlineLinterMessages}>
+              {messages.map((msg) => {
+                return <LinterMessage key={msg.uid} message={msg} inline />;
+              })}
+            </div>
+          </>
         );
       }
       allWidgets[changeKey] = widget;
@@ -295,22 +298,25 @@ export class DiffViewBase extends React.Component<Props> {
     const { isInsert, lineNumber } = change;
     const changeKey = getChangeKey(change);
 
-    let gutter = wrapInAnchor(renderDefault());
+    const defaultGutter = wrapInAnchor(renderDefault());
+    let gutter = defaultGutter;
     if (enableCommenting && isInsert && lineNumber && side === 'new') {
       gutter = (
-        <div className={styles.gutter}>
-          {gutter}
-          <Commentable
-            as="span"
-            id={changeKey}
-            className={styles.commentButton}
-            line={lineNumber}
-            fileName={version.selectedPath}
-            versionId={version.id}
-          >
-            {(addCommentButton) => <>{addCommentButton}</>}
-          </Commentable>
-        </div>
+        <Commentable
+          as="div"
+          id={changeKey}
+          className={styles.gutter}
+          line={lineNumber}
+          fileName={version.selectedPath}
+          versionId={version.id}
+        >
+          {(addCommentButton) => (
+            <>
+              {defaultGutter}
+              <span className={styles.commentButton}>{addCommentButton}</span>
+            </>
+          )}
+        </Commentable>
       );
     }
 

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -204,20 +204,17 @@ export class DiffViewBase extends React.Component<Props> {
         messages = selectedMessageMap.byLine[line];
       }
 
-      let widget = (
-        <>
-          {enableCommenting && line && !change.isDelete && (
-            <CommentList
-              addonId={version.addon.id}
-              fileName={version.selectedPath}
-              line={line}
-              versionId={version.id}
-            >
-              {(commentList) => <div>{commentList}</div>}
-            </CommentList>
-          )}
-        </>
+      let widget = enableCommenting && line && !change.isDelete && (
+        <CommentList
+          addonId={version.addon.id}
+          fileName={version.selectedPath}
+          line={line}
+          versionId={version.id}
+        >
+          {(commentList) => <div>{commentList}</div>}
+        </CommentList>
       );
+
       if (messages && messages.length) {
         widget = (
           <>

--- a/src/components/DiffView/styles.module.scss
+++ b/src/components/DiffView/styles.module.scss
@@ -44,10 +44,6 @@
   .diff-line .diff-code-selected {
     background-color: $light-gray;
   }
-
-  .diff-gutter:hover button.btn {
-    visibility: visible;
-  }
 }
 
 .extraMessages {

--- a/src/components/DiffView/styles.module.scss
+++ b/src/components/DiffView/styles.module.scss
@@ -37,12 +37,17 @@
   .diff-gutter {
     font-family: $code-font-family;
     font-size: $code-font-size;
+    height: 100%;
     line-height: $code-line-height;
   }
 
-  .diff-line .diff-gutter-selected,
-  .diff-line .diff-code-selected {
-    background-color: $light-gray;
+  .diff-line {
+    height: 100%;
+
+    .diff-gutter-selected,
+    .diff-code-selected {
+      background-color: $light-gray;
+    }
   }
 }
 
@@ -60,6 +65,7 @@
 
 .gutter {
   display: flex;
+  height: 100%;
 }
 
 .commentButton {

--- a/src/components/DiffView/styles.module.scss
+++ b/src/components/DiffView/styles.module.scss
@@ -44,6 +44,10 @@
   .diff-line .diff-code-selected {
     background-color: $light-gray;
   }
+
+  .diff-gutter:hover button.btn {
+    visibility: visible;
+  }
 }
 
 .extraMessages {
@@ -56,4 +60,13 @@
 
 .inlineLinterMessages {
   padding: 1rem 1rem 0 1rem;
+}
+
+.gutter {
+  display: flex;
+}
+
+.commentButton {
+  display: inline-flex;
+  padding-left: 5px;
 }

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -8,6 +8,7 @@ import { History, Location } from 'history';
 import { ShallowRendererProps, ShallowWrapper, shallow } from 'enzyme';
 import { Store } from 'redux';
 import log from 'loglevel';
+import { ChangeInfo } from 'react-diff-view';
 import { createAction } from 'typesafe-actions';
 
 import {
@@ -1004,3 +1005,14 @@ export const simulatePopover = (root: ShallowWrapper) => {
     popover,
   };
 };
+
+export const fakeChangeInfo: ChangeInfo = Object.freeze({
+  content: 'change-content',
+  isDelete: false,
+  isInsert: true,
+  isNormal: false,
+  lineNumber: 1,
+  newLineNumber: undefined,
+  oldLineNumber: 1,
+  type: 'insert',
+});


### PR DESCRIPTION
Fixes #989 

This allows for commenting on a normal or inserted line, but not a deleted line as there are issues that need to be ironed out on the server side to enable that. An "add comment" button will appear when hovering over the line number, and any comments added will appear underneath the line, just as they do in the browse view.

Screenshot:

![2019-11-21 16 35 46](https://user-images.githubusercontent.com/142755/69378824-2d610600-0c7d-11ea-9ce6-1b6a0dc674f7.gif)
