### PR TITLE
Show base / current version indicators in NavBar

### DIFF
--- a/src/components/Navbar/index.spec.tsx
+++ b/src/components/Navbar/index.spec.tsx
@@ -1,7 +1,8 @@
+import { ShallowWrapper } from 'enzyme';
 import React from 'react';
 import { Store } from 'redux';
 
-import configureStore from '../../configureStore';
+import configureStore, { ConnectedReduxProps } from '../../configureStore';
 import CommentSummaryButton from '../CommentSummaryButton';
 import LoginButton from '../LoginButton';
 import styles from './styles.module.scss';
@@ -13,21 +14,25 @@ import {
   fakeUser,
   fakeVersion,
   fakeVersionAddon,
+  nextUniqueId,
   shallowUntilTarget,
   spyOn,
 } from '../../test-helpers';
 import { actions as userActions } from '../../reducers/users';
+import { actions as versionsActions } from '../../reducers/versions';
 
-import Navbar, { NavbarBase, PublicProps } from '.';
+import Navbar, { NavbarBase, PublicProps, mapStateToProps } from '.';
 
 describe(__filename, () => {
-  type RenderParams = Partial<PublicProps> & { store?: Store };
+  type RenderParams = Partial<PublicProps> &
+    Partial<ConnectedReduxProps> & { store?: Store };
 
   const render = ({
     store = configureStore(),
     ...moreProps
   }: RenderParams = {}) => {
     const props = {
+      _fetchVersion: jest.fn(),
       _requestLogOut: jest.fn(),
       ...moreProps,
     };
@@ -44,6 +49,22 @@ describe(__filename, () => {
     return store;
   };
 
+  const createStoreWithCurrentVersion = ({
+    addonId = nextUniqueId(),
+    id = nextUniqueId(),
+    versionString = '2.0.0',
+  } = {}) => {
+    return createStoreWithVersion({
+      version: {
+        ...fakeVersion,
+        id,
+        version: versionString,
+        addon: { ...fakeVersion.addon, id: addonId },
+      },
+      makeCurrent: true,
+    });
+  };
+
   describe('when a version is loaded', () => {
     it('renders addon name', () => {
       const addonName = 'addon name example';
@@ -56,7 +77,7 @@ describe(__filename, () => {
       });
       const root = render({ store });
 
-      expect(root.find(`.${styles.addonName}`)).toHaveText(addonName);
+      expect(root.find(`.${styles.addonName}`).text()).toContain(addonName);
     });
 
     it('renders a link to reviewer tools', () => {
@@ -189,6 +210,215 @@ describe(__filename, () => {
       });
 
       expect(root.find(CommentSummaryButton)).toHaveLength(1);
+    });
+  });
+
+  describe('loading data', () => {
+    const renderForFetching = ({
+      store = configureStore(),
+      ...moreProps
+    }: RenderParams = {}) => {
+      const dispatch = spyOn(store, 'dispatch');
+      const fakeThunk = createFakeThunk();
+      const _fetchVersion = fakeThunk.createThunk;
+
+      const props = { _fetchVersion, store, ...moreProps };
+      const root = render(props);
+
+      return { _fetchVersion, dispatch, root, fakeThunk };
+    };
+
+    it('loads data on mount', () => {
+      const loadData = jest.spyOn(NavbarBase.prototype, 'loadData');
+
+      renderForFetching();
+
+      expect(loadData).toHaveBeenCalled();
+    });
+
+    it('loads data on update', () => {
+      const loadData = jest.spyOn(NavbarBase.prototype, 'loadData');
+
+      const { root } = renderForFetching();
+      loadData.mockClear();
+
+      root.setProps({});
+
+      expect(loadData).toHaveBeenCalled();
+    });
+
+    it('fetches the base version when it has an ID and a current version', () => {
+      const addonId = nextUniqueId();
+      const store = createStoreWithCurrentVersion({ addonId });
+
+      const currentBaseVersionId = nextUniqueId();
+      store.dispatch(
+        versionsActions.setCurrentBaseVersionId({
+          versionId: currentBaseVersionId,
+        }),
+      );
+
+      const { _fetchVersion, dispatch, fakeThunk } = renderForFetching({
+        store,
+      });
+
+      expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
+      expect(_fetchVersion).toHaveBeenCalledWith({
+        addonId,
+        path: undefined,
+        setAsCurrent: false,
+        versionId: currentBaseVersionId,
+      });
+    });
+
+    it('does not fetch the base version without a current version', () => {
+      const store = createStoreWithVersion({ makeCurrent: false });
+      const { dispatch, fakeThunk } = renderForFetching({ store });
+
+      expect(dispatch).not.toHaveBeenCalledWith(fakeThunk.thunk);
+    });
+
+    it('does not fetch the base version without an ID', () => {
+      const store = createStoreWithVersion({ makeCurrent: true });
+      const { dispatch, fakeThunk } = renderForFetching({ store });
+
+      expect(dispatch).not.toHaveBeenCalledWith(fakeThunk.thunk);
+    });
+
+    it('does not fetch the base version when it already exists', () => {
+      const store = createStoreWithVersion({ makeCurrent: true });
+
+      const currentBaseVersionId = nextUniqueId();
+      store.dispatch(
+        versionsActions.loadVersionInfo({
+          version: { ...fakeVersion, id: currentBaseVersionId },
+        }),
+      );
+      store.dispatch(
+        versionsActions.setCurrentBaseVersionId({
+          versionId: currentBaseVersionId,
+        }),
+      );
+      const { dispatch, fakeThunk } = renderForFetching({ store });
+
+      expect(dispatch).not.toHaveBeenCalledWith(fakeThunk.thunk);
+    });
+
+    it('does not fetch the base version when there was an error fetching it', () => {
+      const store = createStoreWithVersion({ makeCurrent: true });
+
+      const currentBaseVersionId = nextUniqueId();
+      store.dispatch(
+        versionsActions.setCurrentBaseVersionId({
+          versionId: currentBaseVersionId,
+        }),
+      );
+      // Simulate a failed fetch.
+      store.dispatch(
+        versionsActions.abortFetchVersion({ versionId: currentBaseVersionId }),
+      );
+      const { dispatch, fakeThunk } = renderForFetching({ store });
+
+      expect(dispatch).not.toHaveBeenCalledWith(fakeThunk.thunk);
+    });
+  });
+
+  describe('version indicators', () => {
+    const dispatchBaseVersion = ({
+      store,
+      id = nextUniqueId(),
+      versionString = '1.0.0',
+    }: {
+      store: Store;
+      id?: number;
+      versionString?: string;
+    }) => {
+      const baseVersion = { ...fakeVersion, id, version: versionString };
+      store.dispatch(versionsActions.loadVersionInfo({ version: baseVersion }));
+      store.dispatch(
+        versionsActions.setCurrentBaseVersionId({ versionId: baseVersion.id }),
+      );
+    };
+
+    const simulateUpdate = ({
+      root,
+      store,
+    }: {
+      root: ShallowWrapper;
+      store: Store;
+    }) => {
+      root.setProps({
+        dispatch: jest.fn(),
+        ...mapStateToProps(store.getState()),
+      });
+    };
+
+    it('does not render version indicators without any versions', () => {
+      const root = render({ store: configureStore() });
+
+      expect(root.find(`.${styles.versionIndicator}`)).toHaveLength(0);
+    });
+
+    it('renders a current version indicator', () => {
+      const current = '1.0.0';
+      const root = render({
+        store: createStoreWithCurrentVersion({ versionString: current }),
+      });
+
+      const info = root.find(`.${styles.versionIndicator}`);
+      expect(info).toHaveText(current);
+    });
+
+    it('renders a base to current range indicator', () => {
+      const base = '1.0.0';
+      const current = '2.0.0';
+
+      const store = createStoreWithCurrentVersion({ versionString: current });
+      dispatchBaseVersion({ store, versionString: base });
+
+      const root = render({ store });
+
+      const info = root.find(`.${styles.versionIndicator}`);
+      expect(info).toHaveText(`${base}…${current}`);
+      expect(info.find(`.${styles.baseVersionIsLoading}`)).toHaveLength(0);
+    });
+
+    it('renders an imprint of the last base version while loading the next one', () => {
+      const base = '1.0.0';
+      const current = '3.0.0';
+
+      const store = createStoreWithCurrentVersion({ versionString: current });
+      dispatchBaseVersion({ store, versionString: base });
+
+      const root = render({ store });
+
+      // Simulate loading the next base version.
+      store.dispatch(
+        versionsActions.setCurrentBaseVersionId({ versionId: nextUniqueId() }),
+      );
+
+      simulateUpdate({ root, store });
+
+      const info = root.find(`.${styles.versionIndicator}`);
+      expect(info).toHaveText(`${base}…${current}`);
+      expect(info.find(`.${styles.baseVersionIsLoading}`)).toHaveLength(1);
+    });
+
+    it('does not render a base version imprint when the base version has been unset', () => {
+      const current = '3.0.0';
+
+      const store = createStoreWithCurrentVersion({ versionString: current });
+      dispatchBaseVersion({ store });
+
+      const root = render({ store });
+
+      // Unset the base version.
+      store.dispatch(versionsActions.unsetCurrentBaseVersionId());
+
+      simulateUpdate({ root, store });
+
+      const info = root.find(`.${styles.versionIndicator}`);
+      expect(info).toHaveText(`${current}`);
     });
   });
 });

--- a/src/components/Navbar/index.spec.tsx
+++ b/src/components/Navbar/index.spec.tsx
@@ -225,7 +225,12 @@ describe(__filename, () => {
       const props = { _fetchVersion, store, ...moreProps };
       const root = render(props);
 
-      return { _fetchVersion, dispatch, root, fakeThunk };
+      return {
+        _fetchVersion,
+        _fetchVersionThunk: fakeThunk.thunk,
+        dispatch,
+        root,
+      };
     };
 
     it('loads data on mount', () => {
@@ -258,11 +263,13 @@ describe(__filename, () => {
         }),
       );
 
-      const { _fetchVersion, dispatch, fakeThunk } = renderForFetching({
-        store,
-      });
+      const { _fetchVersion, _fetchVersionThunk, dispatch } = renderForFetching(
+        {
+          store,
+        },
+      );
 
-      expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
+      expect(dispatch).toHaveBeenCalledWith(_fetchVersionThunk);
       expect(_fetchVersion).toHaveBeenCalledWith({
         addonId,
         path: undefined,
@@ -273,16 +280,16 @@ describe(__filename, () => {
 
     it('does not fetch the base version without a current version', () => {
       const store = createStoreWithVersion({ makeCurrent: false });
-      const { dispatch, fakeThunk } = renderForFetching({ store });
+      const { _fetchVersionThunk, dispatch } = renderForFetching({ store });
 
-      expect(dispatch).not.toHaveBeenCalledWith(fakeThunk.thunk);
+      expect(dispatch).not.toHaveBeenCalledWith(_fetchVersionThunk);
     });
 
     it('does not fetch the base version without an ID', () => {
       const store = createStoreWithVersion({ makeCurrent: true });
-      const { dispatch, fakeThunk } = renderForFetching({ store });
+      const { _fetchVersionThunk, dispatch } = renderForFetching({ store });
 
-      expect(dispatch).not.toHaveBeenCalledWith(fakeThunk.thunk);
+      expect(dispatch).not.toHaveBeenCalledWith(_fetchVersionThunk);
     });
 
     it('does not fetch the base version when it already exists', () => {
@@ -299,9 +306,9 @@ describe(__filename, () => {
           versionId: currentBaseVersionId,
         }),
       );
-      const { dispatch, fakeThunk } = renderForFetching({ store });
+      const { _fetchVersionThunk, dispatch } = renderForFetching({ store });
 
-      expect(dispatch).not.toHaveBeenCalledWith(fakeThunk.thunk);
+      expect(dispatch).not.toHaveBeenCalledWith(_fetchVersionThunk);
     });
 
     it('does not fetch the base version when there was an error fetching it', () => {
@@ -317,9 +324,9 @@ describe(__filename, () => {
       store.dispatch(
         versionsActions.abortFetchVersion({ versionId: currentBaseVersionId }),
       );
-      const { dispatch, fakeThunk } = renderForFetching({ store });
+      const { _fetchVersionThunk, dispatch } = renderForFetching({ store });
 
-      expect(dispatch).not.toHaveBeenCalledWith(fakeThunk.thunk);
+      expect(dispatch).not.toHaveBeenCalledWith(_fetchVersionThunk);
     });
   });
 

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -20,7 +20,6 @@ import { User, selectCurrentUser, requestLogOut } from '../../reducers/users';
 import styles from './styles.module.scss';
 
 export type PublicProps = {
-  _nextBaseVersionImprint?: string;
   _requestLogOut: typeof requestLogOut;
   reviewersHost: string;
 };
@@ -53,7 +52,7 @@ export class NavbarBase extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      nextBaseVersionImprint: props._nextBaseVersionImprint || undefined,
+      nextBaseVersionImprint: undefined,
     };
   }
 

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -9,29 +9,98 @@ import CommentSummaryButton from '../CommentSummaryButton';
 import LoginButton from '../LoginButton';
 import { ApplicationState } from '../../reducers';
 import { Comment, selectVersionComments } from '../../reducers/comments';
-import { Version, selectCurrentVersionInfo } from '../../reducers/versions';
+import {
+  Version,
+  fetchVersion,
+  getVersionInfo,
+  selectCurrentVersionInfo,
+} from '../../reducers/versions';
 import { ConnectedReduxProps } from '../../configureStore';
 import { User, selectCurrentUser, requestLogOut } from '../../reducers/users';
 import styles from './styles.module.scss';
 
 export type PublicProps = {
+  _nextBaseVersionImprint?: string;
   _requestLogOut: typeof requestLogOut;
   reviewersHost: string;
+};
+
+export type DefaultProps = {
+  _fetchVersion: typeof fetchVersion;
 };
 
 type PropsFromState = {
   comments: Comment[] | undefined;
   user: User | null;
+  currentBaseVersion: Version | null | undefined | false;
+  currentBaseVersionId: number | undefined | false;
   currentVersion: Version | null | undefined | false;
 };
 
-type Props = PublicProps & PropsFromState & ConnectedReduxProps;
+type Props = PublicProps & DefaultProps & PropsFromState & ConnectedReduxProps;
 
-export class NavbarBase extends React.Component<Props> {
+type State = {
+  nextBaseVersionImprint: string | undefined;
+};
+
+export class NavbarBase extends React.Component<Props, State> {
   static defaultProps = {
+    _fetchVersion: fetchVersion,
     _requestLogOut: requestLogOut,
     reviewersHost: process.env.REACT_APP_REVIEWERS_HOST,
   };
+
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      nextBaseVersionImprint: props._nextBaseVersionImprint || undefined,
+    };
+  }
+
+  componentDidMount() {
+    this.loadData();
+  }
+
+  componentDidUpdate() {
+    this.loadData();
+  }
+
+  loadData() {
+    const {
+      _fetchVersion,
+      currentVersion,
+      currentBaseVersion,
+      currentBaseVersionId,
+      dispatch,
+    } = this.props;
+    const { nextBaseVersionImprint } = this.state;
+
+    if (
+      currentBaseVersion &&
+      nextBaseVersionImprint !== currentBaseVersion.version
+    ) {
+      this.setState({ nextBaseVersionImprint: currentBaseVersion.version });
+    }
+
+    if (
+      currentVersion &&
+      currentBaseVersion === undefined &&
+      currentBaseVersionId
+    ) {
+      dispatch(
+        _fetchVersion({
+          addonId: currentVersion.addon.id,
+          path: undefined,
+          setAsCurrent: false,
+          versionId: currentBaseVersionId,
+        }),
+      );
+    }
+
+    if (currentBaseVersionId === false && nextBaseVersionImprint) {
+      this.setState({ nextBaseVersionImprint: undefined });
+    }
+  }
 
   logOut = () => {
     const { _requestLogOut, dispatch } = this.props;
@@ -50,7 +119,9 @@ export class NavbarBase extends React.Component<Props> {
       <>
         <div className={styles.infoItem}>
           {gettext('Comments:')}
-          <div className={styles.commentCount}>{comments.length}</div>
+          <div className={makeClassName(styles.itemData, styles.commentCount)}>
+            {comments.length}
+          </div>
         </div>
         <div className={styles.infoItem}>
           <CommentSummaryButton />
@@ -60,7 +131,13 @@ export class NavbarBase extends React.Component<Props> {
   }
 
   render() {
-    const { currentVersion, reviewersHost, user } = this.props;
+    const {
+      currentBaseVersion,
+      currentVersion,
+      reviewersHost,
+      user,
+    } = this.props;
+    const { nextBaseVersionImprint } = this.state;
 
     return (
       <Navbar className={styles.Navbar} expand="lg" variant="dark">
@@ -86,6 +163,30 @@ export class NavbarBase extends React.Component<Props> {
                   className={makeClassName(styles.infoItem, styles.addonName)}
                 >
                   {getLocalizedString(currentVersion.addon.name)}
+                  <div
+                    className={makeClassName(
+                      styles.versionIndicator,
+                      styles.itemData,
+                    )}
+                  >
+                    {
+                      // Render a version range like `base…current`
+                      // or just `current`
+                    }
+                    {currentBaseVersion || nextBaseVersionImprint ? (
+                      <span
+                        className={makeClassName({
+                          [styles.baseVersionIsLoading]:
+                            !currentBaseVersion && nextBaseVersionImprint,
+                        })}
+                      >
+                        {`${(currentBaseVersion &&
+                          currentBaseVersion.version) ||
+                          nextBaseVersionImprint}…`}
+                      </span>
+                    ) : null}
+                    {currentVersion.version}
+                  </div>
                 </div>
               </>
             )}
@@ -107,8 +208,15 @@ export class NavbarBase extends React.Component<Props> {
   }
 }
 
-const mapStateToProps = (state: ApplicationState): PropsFromState => {
+export const mapStateToProps = (state: ApplicationState): PropsFromState => {
+  const { currentBaseVersionId } = state.versions;
+  let currentBaseVersion;
+  if (currentBaseVersionId) {
+    currentBaseVersion = getVersionInfo(state.versions, currentBaseVersionId);
+  }
+
   const currentVersion = selectCurrentVersionInfo(state.versions);
+
   return {
     comments: currentVersion
       ? selectVersionComments({
@@ -117,6 +225,8 @@ const mapStateToProps = (state: ApplicationState): PropsFromState => {
         })
       : undefined,
     user: selectCurrentUser(state.users),
+    currentBaseVersion,
+    currentBaseVersionId,
     currentVersion,
   };
 };

--- a/src/components/Navbar/styles.module.scss
+++ b/src/components/Navbar/styles.module.scss
@@ -43,7 +43,7 @@ $bg-color: $dark-gray;
   }
 }
 
-.commentCount {
+.itemData {
   align-items: center;
   background-color: $white;
   border-radius: 2px;
@@ -51,9 +51,28 @@ $bg-color: $dark-gray;
   display: flex;
   justify-content: center;
   margin-left: 5px;
+  padding: 0 5px;
+}
+
+.commentCount {
   // Fix the width to minimize jumpiness.
   min-width: 20px;
-  padding: 0 5px;
+}
+
+@keyframes pulseBaseVersion {
+  0%,
+  100% {
+    opacity: 0.1;
+  }
+
+  50% {
+    opacity: 0.6;
+  }
+}
+
+.baseVersionIsLoading {
+  animation: pulseBaseVersion 1s infinite;
+  transition: opacity ease-in-out;
 }
 
 .username {

--- a/src/components/VersionChooser/index.tsx
+++ b/src/components/VersionChooser/index.tsx
@@ -37,7 +37,7 @@ export type DefaultProps = {
 };
 
 type PropsFromState = {
-  currentBaseVersionId: number | undefined;
+  currentBaseVersionId: number | undefined | false;
   currentVersionId: number | undefined | false;
   versionsMap: VersionsMap;
   versions: VersionsState;

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -56,6 +56,7 @@ type PropsFromState = {
   nextFile: VersionFile | null | undefined;
   nextFileIsLoading: boolean;
   version: Version | undefined | null;
+  currentBaseVersionId: number | null | undefined | false;
   currentVersionId: number | null | undefined | false;
 };
 
@@ -85,6 +86,7 @@ export class BrowseBase extends React.Component<Props> {
     const {
       _fetchVersion,
       _fetchVersionFile,
+      currentBaseVersionId,
       currentVersionId,
       dispatch,
       file,
@@ -116,6 +118,10 @@ export class BrowseBase extends React.Component<Props> {
         }),
       );
       return;
+    }
+
+    if (currentBaseVersionId) {
+      dispatch(versionsActions.unsetCurrentBaseVersionId());
     }
 
     if (version && currentVersionId !== version.id) {
@@ -252,6 +258,7 @@ const mapStateToProps = (
         : false,
     nextFilePath,
     version,
+    currentBaseVersionId: state.versions.currentBaseVersionId,
     currentVersionId,
   };
 };

--- a/src/pages/Index/index.spec.tsx
+++ b/src/pages/Index/index.spec.tsx
@@ -101,13 +101,16 @@ describe(__filename, () => {
     expect(root.find('title')).toHaveText('Addons Code Manager');
   });
 
-  it('dispatches an action to unset current version id', () => {
+  it('dispatches actions to unset current versions', () => {
     const store = configureStore();
     const dispatch = spyOn(store, 'dispatch');
     render({ store });
 
     expect(dispatch).toHaveBeenCalledWith(
       versionsActions.unsetCurrentVersionId(),
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      versionsActions.unsetCurrentBaseVersionId(),
     );
   });
 });

--- a/src/pages/Index/index.tsx
+++ b/src/pages/Index/index.tsx
@@ -72,6 +72,7 @@ export class IndexBase extends React.Component<Props> {
 
   componentDidMount() {
     const { dispatch } = this.props;
+    dispatch(versionsActions.unsetCurrentBaseVersionId());
     dispatch(versionsActions.unsetCurrentVersionId());
   }
 

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -339,13 +339,13 @@ export type VersionsState = {
     [compareInfoKey: string]: boolean;
   };
   currentBaseVersionId:
-    | number // data successfully loaded
-    | undefined // data has not yet loaded
-    | false; // data loaded but it is empty
+    | number // This is an existing version ID.
+    | undefined // This indicates that the version may or may not exist.
+    | false; // This indicates that the version does not exist.
   currentVersionId:
-    | number // data successfully loaded
-    | undefined // data has not yet loaded
-    | false; // data loaded but it is empty
+    | number // This is an existing version ID.
+    | undefined // This indicates that the version may or may not exist.
+    | false; // This indicates that the version does not exist.
   entryStatusMaps: {
     [entryStatusMapKey: string]: EntryStatusMap;
   };

--- a/stories/Navbar.stories.tsx
+++ b/stories/Navbar.stories.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
+import { Store } from 'redux';
 import { storiesOf } from '@storybook/react';
 
-import Navbar from '../src/components/Navbar';
+import Navbar, { PublicProps } from '../src/components/Navbar';
 import configureStore from '../src/configureStore';
 import { actions as userActions } from '../src/reducers/users';
+import { actions as versionsActions } from '../src/reducers/versions';
 import {
   createFakeExternalComment,
   createStoreWithVersion,
@@ -11,10 +13,14 @@ import {
   fakeUser,
   fakeVersion,
   fakeVersionAddon,
+  nextUniqueId,
 } from '../src/test-helpers';
 import { renderWithStoreAndRouter } from './utils';
 
-const render = ({ store = configureStore(), ...props } = {}) => {
+const render = ({
+  store = configureStore(),
+  ...props
+}: Partial<PublicProps> & { store?: Store } = {}) => {
   return renderWithStoreAndRouter(<Navbar {...props} />, { store });
 };
 
@@ -33,6 +39,31 @@ storiesOf('Navbar', module)
     };
     const store = createStoreWithVersion({ version, makeCurrent: true });
     return render({ store });
+  })
+  .add('with base version, current version', () => {
+    const version = {
+      ...fakeVersion,
+      id: nextUniqueId(),
+      version: '2.0',
+      addon: { ...fakeVersionAddon, name: { 'en-US': 'uBlock Origin' } },
+    };
+    const store = createStoreWithVersion({ version, makeCurrent: true });
+
+    const baseVersion = { ...fakeVersion, id: nextUniqueId(), version: '1.0' };
+    store.dispatch(versionsActions.loadVersionInfo({ version: baseVersion }));
+    store.dispatch(
+      versionsActions.setCurrentBaseVersionId({ versionId: baseVersion.id }),
+    );
+    return render({ store });
+  })
+  .add('with new base version loading', () => {
+    const version = {
+      ...fakeVersion,
+      version: '2.0',
+      addon: { ...fakeVersionAddon, name: { 'en-US': 'uBlock Origin' } },
+    };
+    const store = createStoreWithVersion({ version, makeCurrent: true });
+    return render({ store, _nextBaseVersionImprint: '1.0' });
   })
   .add('user has entered comments', () => {
     const store = createStoreWithVersionComments({


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/1263

I noticed a few things in the tests that needed cleanup. I tried to exclude those changes but `git add -p` wasn't making it easy. Let me know if you'd rather I postpone the cleanup until later but I don't think it will make the patch much smaller.

Before:

<img width="964" alt="Screenshot 2019-11-22 12 33 17" src="https://user-images.githubusercontent.com/55398/69451219-73bd7000-0d24-11ea-8949-24abe4a5f7ea.png">


After (while browsing):

<img width="964" alt="Screenshot 2019-11-22 12 33 48" src="https://user-images.githubusercontent.com/55398/69451230-7c15ab00-0d24-11ea-94e5-368356493535.png">


After (while comparing versions):

<img width="964" alt="Screenshot 2019-11-22 12 34 11" src="https://user-images.githubusercontent.com/55398/69451246-8172f580-0d24-11ea-810c-c2c145e5b517.png">
