### PR TITLE
Browse a version from the compare popover

### DIFF
--- a/src/components/VersionChooser/index.tsx
+++ b/src/components/VersionChooser/index.tsx
@@ -138,6 +138,8 @@ export class VersionChooserBase extends React.Component<Props, State> {
     history.push(
       `/${lang}/compare/${addonId}/versions/${baseVersionId}...${headVersionId}/${query}`,
     );
+
+    this.setState({ baseVersionId: undefined, headVersionId: undefined });
   };
 
   onHeadVersionChange = (versionId: number) => {
@@ -147,6 +149,31 @@ export class VersionChooserBase extends React.Component<Props, State> {
   onBaseVersionChange = (versionId: number) => {
     this.setState({ baseVersionId: versionId });
   };
+
+  renderBrowseButton(versionId: string) {
+    const { addonId, dispatch, history } = this.props;
+    const lang = process.env.REACT_APP_DEFAULT_API_LANG;
+    const href = versionId
+      ? `/${lang}/browse/${addonId}/versions/${versionId}/`
+      : undefined;
+
+    return (
+      <Button
+        disabled={!versionId}
+        onClick={(event: React.FormEvent<HTMLButtonElement>) => {
+          event.preventDefault();
+          event.stopPropagation();
+          dispatch(popoverActions.hide(POPOVER_ID));
+          if (href) {
+            history.push(href);
+          }
+        }}
+        href={href}
+      >
+        {gettext('Browse')}
+      </Button>
+    );
+  }
 
   render() {
     const { _higherVersionsThan, _lowerVersionsThan, versionsMap } = this.props;
@@ -179,6 +206,7 @@ export class VersionChooserBase extends React.Component<Props, State> {
                 unlistedVersions={unlistedVersions}
                 value={baseVersionId}
               />
+              {this.renderBrowseButton(baseVersionId)}
             </div>
 
             <div className={styles.formRow}>
@@ -197,6 +225,7 @@ export class VersionChooserBase extends React.Component<Props, State> {
                 unlistedVersions={unlistedVersions}
                 value={headVersionId}
               />
+              {this.renderBrowseButton(headVersionId)}
             </div>
 
             <Button


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/1278

This allows the reviewer to easily bounce between comparison mode and browse mode.

<details>
<summary>Screencast</summary>

![2019-12-02 16 02 09](https://user-images.githubusercontent.com/55398/69999154-923e1b00-151d-11ea-990c-5d122cec76b0.gif)


</details>