### PR TITLE
Preserve VersionChooser form selections better

### DIFF
--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -3609,4 +3609,26 @@ describe(__filename, () => {
       expect(selectVersionIsLoading(state, nextUniqueId())).toEqual(false);
     });
   });
+
+  describe('setPendingBaseVersionId', () => {
+    it('sets a pending base version ID', () => {
+      const versionId = nextUniqueId();
+      expect(
+        reducer(undefined, actions.setPendingBaseVersionId({ versionId })),
+      ).toMatchObject({
+        pendingBaseVersionId: versionId,
+      });
+    });
+  });
+
+  describe('setPendingHeadVersionId', () => {
+    it('sets a pending head version ID', () => {
+      const versionId = nextUniqueId();
+      expect(
+        reducer(undefined, actions.setPendingHeadVersionId({ versionId })),
+      ).toMatchObject({
+        pendingHeadVersionId: versionId,
+      });
+    });
+  });
 });

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -326,6 +326,18 @@ export const actions = {
   abortFetchVersion: createAction('ABORT_FETCH_VERSION', (resolve) => {
     return (payload: { versionId: number }) => resolve(payload);
   }),
+  setPendingBaseVersionId: createAction(
+    'SET_PENDING_BASE_VERSION_ID',
+    (resolve) => {
+      return (payload: { versionId: number }) => resolve(payload);
+    },
+  ),
+  setPendingHeadVersionId: createAction(
+    'SET_PENDING_HEAD_VERSION_ID',
+    (resolve) => {
+      return (payload: { versionId: number }) => resolve(payload);
+    },
+  ),
 };
 
 export type VersionsState = {
@@ -353,6 +365,8 @@ export type VersionsState = {
     [entryStatusMapKey: string]: EntryStatusMap;
   };
   expandedPaths: string[] | undefined;
+  pendingBaseVersionId: number | undefined;
+  pendingHeadVersionId: number | undefined;
   selectedPath: string | null;
   visibleSelectedPath: string | null;
   versionInfo: {
@@ -387,6 +401,8 @@ export const initialState: VersionsState = {
   currentVersionId: undefined,
   entryStatusMaps: {},
   expandedPaths: undefined,
+  pendingBaseVersionId: undefined,
+  pendingHeadVersionId: undefined,
   selectedPath: null,
   visibleSelectedPath: null,
   versionFiles: {},
@@ -1591,6 +1607,20 @@ export const createReducer = ({
         return {
           ...state,
           currentBaseVersionId: versionId,
+        };
+      }
+      case getType(actions.setPendingBaseVersionId): {
+        const { versionId } = action.payload;
+        return {
+          ...state,
+          pendingBaseVersionId: versionId,
+        };
+      }
+      case getType(actions.setPendingHeadVersionId): {
+        const { versionId } = action.payload;
+        return {
+          ...state,
+          pendingHeadVersionId: versionId,
         };
       }
       case getType(actions.setCurrentVersionId): {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/1306

The bug was that local component state was not synchronized with Redux state properly.

My first attempt was to fix the local state synchronization but it became way too difficult due to the way these two state managers are different (mostly in relation to component lifecycles). 

In the end, it felt easier just to rely exclusively on Redux state. This also will work better with time travel debugging so I'm not sure why I didn't do it this way to begin with.