### PR TITLE
Fix file tree error when changing version number in compare mode

### DIFF
--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -64,7 +64,9 @@ describe(__filename, () => {
     };
 
     const _buildTree = (store: Store, version: Version) => {
-      store.dispatch(fileTreeActions.buildTree({ version }));
+      store.dispatch(
+        fileTreeActions.buildTree({ comparedToVersionId: null, version }),
+      );
     };
 
     it('calls loadData on construction', () => {
@@ -103,13 +105,15 @@ describe(__filename, () => {
     it('dispatches buildTree when tree is undefined', () => {
       const store = configureStore();
       const version = getVersion({ store });
+      const comparedToVersionId = null;
 
       const dispatch = spyOn(store, 'dispatch');
 
-      render({ store, versionId: version.id });
+      render({ comparedToVersionId, store, versionId: version.id });
 
       expect(dispatch).toHaveBeenCalledWith(
         fileTreeActions.buildTree({
+          comparedToVersionId,
           version,
         }),
       );

--- a/src/components/FileTree/index.tsx
+++ b/src/components/FileTree/index.tsx
@@ -69,10 +69,10 @@ export class FileTreeBase extends React.Component<Props> {
   }
 
   _loadData = () => {
-    const { dispatch, tree, version } = this.props;
+    const { comparedToVersionId, dispatch, tree, version } = this.props;
 
     if (version && !tree) {
-      dispatch(fileTreeActions.buildTree({ version }));
+      dispatch(fileTreeActions.buildTree({ comparedToVersionId, version }));
     }
   };
 

--- a/src/components/KeyboardShortcuts/index.spec.tsx
+++ b/src/components/KeyboardShortcuts/index.spec.tsx
@@ -76,6 +76,7 @@ describe(__filename, () => {
   } = {}) => {
     store.dispatch(
       fileTreeActions.buildTree({
+        comparedToVersionId: null,
         version: createInternalVersion(externalVersion),
       }),
     );

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -636,6 +636,7 @@ describe(__filename, () => {
       if (buildTree) {
         store.dispatch(
           fileTreeActions.buildTree({
+            comparedToVersionId: null,
             version: createInternalVersion(version),
           }),
         );

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -58,6 +58,8 @@ type PropsFromState = {
   nextFileIsLoading: boolean;
   nextFilePath: string | undefined;
   entryStatusMap: EntryStatusMap | undefined;
+  fileTreeComparedToVersionId: number | null;
+  fileTreeVersionId: number | undefined;
   path: string | undefined;
   version: Version | undefined | null;
   versionFile: VersionFile | undefined | null;
@@ -92,6 +94,8 @@ export class CompareBase extends React.Component<Props> {
       currentBaseVersionId,
       currentVersionId,
       entryStatusMap,
+      fileTreeComparedToVersionId,
+      fileTreeVersionId,
       dispatch,
       history,
       match,
@@ -131,10 +135,17 @@ export class CompareBase extends React.Component<Props> {
       );
     }
 
+    // Force-reload a version so the file tree rebuilds itself.
+    const forceReloadVersion = fileTreeVersionId
+      ? oldVersionId !== fileTreeComparedToVersionId ||
+        newVersionId !== fileTreeVersionId
+      : false;
+
     if (
       compareInfo === undefined ||
       version === undefined ||
-      entryStatusMap === undefined
+      entryStatusMap === undefined ||
+      forceReloadVersion
     ) {
       dispatch(
         _fetchDiff({
@@ -142,6 +153,7 @@ export class CompareBase extends React.Component<Props> {
           baseVersionId: oldVersionId,
           headVersionId: newVersionId,
           path: path || undefined,
+          forceReloadVersion,
         }),
       );
       return;
@@ -268,7 +280,7 @@ export const mapStateToProps = (
   ownProps: RouteComponentProps<PropsFromRouter>,
 ): PropsFromState => {
   const { history, match } = ownProps;
-  const { versions } = state;
+  const { fileTree, versions } = state;
   const addonId = parseInt(match.params.addonId, 10);
   const baseVersionId = parseInt(match.params.baseVersionId, 10);
   const headVersionId = parseInt(match.params.headVersionId, 10);
@@ -333,6 +345,8 @@ export const mapStateToProps = (
     currentBaseVersionId: state.versions.currentBaseVersionId,
     currentVersionId,
     entryStatusMap,
+    fileTreeComparedToVersionId: fileTree.comparedToVersionId,
+    fileTreeVersionId: fileTree.forVersionId,
     nextCompareInfo,
     nextFile: nextFilePath
       ? getVersionFile(state.versions, headVersionId, nextFilePath)

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -1787,6 +1787,7 @@ describe(__filename, () => {
     const _fetchDiff = ({
       addonId = 1,
       baseVersionId = 2,
+      forceReloadVersion = false,
       headVersionId = 3,
       store = configureStore(),
       version = fakeVersionWithDiff,
@@ -1800,6 +1801,7 @@ describe(__filename, () => {
             _getDiff,
             addonId,
             baseVersionId,
+            forceReloadVersion,
             headVersionId,
             path,
           }),
@@ -1904,6 +1906,34 @@ describe(__filename, () => {
       await thunk();
 
       expect(dispatch).not.toHaveBeenCalledWith(
+        actions.loadVersionInfo({
+          version,
+        }),
+      );
+    });
+
+    it('dispatches loadVersionInfo() when forceReloadVersion is true', async () => {
+      const store = configureStore();
+      const baseVersionId = nextUniqueId();
+      const headVersionId = baseVersionId + 1;
+      const version = { ...fakeVersionWithDiff, id: headVersionId };
+
+      store.dispatch(
+        actions.loadVersionInfo({
+          version,
+        }),
+      );
+
+      const { dispatch, thunk } = _fetchDiff({
+        baseVersionId,
+        forceReloadVersion: true,
+        headVersionId,
+        version,
+        store,
+      });
+      await thunk();
+
+      expect(dispatch).toHaveBeenCalledWith(
         actions.loadVersionInfo({
           version,
         }),

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -964,6 +964,7 @@ type FetchDiffParams = {
   _getDiff?: typeof getDiff;
   addonId: number;
   baseVersionId: number;
+  forceReloadVersion?: boolean;
   headVersionId: number;
   path?: string;
 };
@@ -1045,6 +1046,7 @@ export const fetchDiff = ({
   baseVersionId,
   headVersionId,
   path,
+  forceReloadVersion,
 }: FetchDiffParams): ThunkActionCreator => {
   return async (dispatch, getState) => {
     const { api: apiState, versions: versionsState } = getState();
@@ -1085,7 +1087,7 @@ export const fetchDiff = ({
       dispatch(actions.abortFetchVersion({ versionId: headVersionId }));
       dispatch(errorsActions.addError({ error: response.error }));
     } else {
-      if (!getVersionInfo(versionsState, response.id)) {
+      if (forceReloadVersion || !getVersionInfo(versionsState, response.id)) {
         dispatch(
           actions.loadVersionInfo({
             version: response,


### PR DESCRIPTION
Fixes #1261 
The idea is to force the page to fetch and reload a new `version`, then build the file tree again when changing the version number (either base version or head version). I do not like this approach, since it seems to make `FileTree` component less self-contained. But it may be a quick way to fix without disturbing too much.