### PR TITLE
Show global linter messages in overview

### DIFF
--- a/src/components/CodeOverview/index.spec.tsx
+++ b/src/components/CodeOverview/index.spec.tsx
@@ -554,8 +554,9 @@ describe(__filename, () => {
     expect(innerRoot.find(`.${styles.linterMessage}`)).toHaveLength(1);
   });
 
-  it('does not render global linter messages', () => {
+  it('renders global linter messages on the first line', () => {
     const { innerRoot } = renderWithMessages({
+      contentLines: generateFileLines({ count: 5 }),
       messages: [
         {
           description: 'This third party library is banned',
@@ -564,7 +565,13 @@ describe(__filename, () => {
       ],
     });
 
-    expect(innerRoot.find(`.${styles.linterMessage}`)).toHaveLength(0);
+    // Make sure only one linter message was added.
+    expect(innerRoot.find(`.${styles.linterMessage}`)).toHaveLength(1);
+
+    // Make sure only line 1 shows the global message.
+    const lines = innerRoot.find(`.${styles.line}`);
+    expect(lines.at(0).find(`.${styles.linterMessage}`)).toHaveLength(1);
+    expect(lines.at(1).find(`.${styles.linterMessage}`)).toHaveLength(0);
   });
 
   it('replaces CodeLineShapes with linter messages', () => {
@@ -622,6 +629,23 @@ describe(__filename, () => {
     expect(message).toHaveClassName(styles.linterError);
     expect(message).not.toHaveClassName(styles.linterNotice);
     expect(message).not.toHaveClassName(styles.linterWarning);
+  });
+
+  it('accounts for global messages when finding the most severe linter message type', () => {
+    const line = 1;
+    const { innerRoot } = renderWithMessages({
+      messages: [
+        { type: 'notice', line },
+        // This will be a global message.
+        { type: 'error', line: undefined },
+        { type: 'warning', line },
+      ],
+    });
+
+    const message = innerRoot.find(`.${styles.linterMessage}`);
+
+    expect(message).toHaveLength(1);
+    expect(message).toHaveClassName(styles.linterError);
   });
 
   it.each([

--- a/src/components/CodeOverview/index.tsx
+++ b/src/components/CodeOverview/index.tsx
@@ -157,11 +157,17 @@ export class CodeOverviewBase extends React.Component<Props, State> {
 
     const messages = selectedMessageMap
       ? groupOflineShapes.reduce((matches: LinterMessageType[], shape) => {
+          let allMatches = matches;
+          if (shape.line === 1 && selectedMessageMap.global.length) {
+            allMatches = allMatches.concat(selectedMessageMap.global);
+          }
           if (selectedMessageMap.byLine[shape.line]) {
-            return matches.concat(selectedMessageMap.byLine[shape.line]);
+            allMatches = allMatches.concat(
+              selectedMessageMap.byLine[shape.line],
+            );
           }
 
-          return matches;
+          return allMatches;
         }, [])
       : [];
 

--- a/src/components/CodeOverview/index.tsx
+++ b/src/components/CodeOverview/index.tsx
@@ -8,6 +8,7 @@ import debounce from 'lodash.debounce';
 import {
   getCodeLineAnchor as defaultCodeLineAnchorGetter,
   getLines,
+  GLOBAL_LINTER_ANCHOR_ID,
 } from '../CodeView/utils';
 import {
   LinterMessage as LinterMessageType,
@@ -231,10 +232,17 @@ export class CodeOverviewBase extends React.Component<Props, State> {
           linkableLine = firstMsg.line;
         }
       }
+      if (
+        line &&
+        line === 1 &&
+        selectedMessageMap &&
+        selectedMessageMap.global.length
+      ) {
+        linkableLine = GLOBAL_LINTER_ANCHOR_ID;
+      }
 
-      const codeLineAnchor = linkableLine
-        ? getCodeLineAnchor(linkableLine)
-        : null;
+      const codeLineAnchor =
+        linkableLine !== undefined ? getCodeLineAnchor(linkableLine) : null;
 
       const scrollToLine = () => {
         // Explicitly scroll to the linter message in case the user had

--- a/src/components/CodeView/index.spec.tsx
+++ b/src/components/CodeView/index.spec.tsx
@@ -12,7 +12,12 @@ import GlobalLinterMessages from '../GlobalLinterMessages';
 import SlowPageAlert from '../SlowPageAlert';
 import { ExternalLinterMessage, getMessageMap } from '../../reducers/linter';
 import { createInternalVersion } from '../../reducers/versions';
-import { getCodeLineAnchor, getCodeLineAnchorID, mapWithDepth } from './utils';
+import {
+  getCodeLineAnchor,
+  getCodeLineAnchorID,
+  mapWithDepth,
+  GLOBAL_LINTER_ANCHOR_ID,
+} from './utils';
 import { allowSlowPagesParam, getLanguageFromMimeType } from '../../utils';
 import {
   SimulateCommentListParams,
@@ -406,7 +411,7 @@ describe(__filename, () => {
   it('renders a containerRef at GlobalLinterMessages component, if line 0 is selected', () => {
     const firstUid = 'first-uid';
     const secondUid = 'second-uid';
-    const id = getCodeLineAnchorID(0);
+    const id = getCodeLineAnchorID(GLOBAL_LINTER_ANCHOR_ID);
     const location = createFakeLocation({ hash: `#${id}` });
 
     const { root } = renderWithMessages({

--- a/src/components/CodeView/index.tsx
+++ b/src/components/CodeView/index.tsx
@@ -12,6 +12,7 @@ import {
   getCodeLineAnchorID,
   getLines,
   mapWithDepth,
+  GLOBAL_LINTER_ANCHOR_ID,
 } from './utils';
 import refractor from '../../refractor';
 import {
@@ -124,7 +125,10 @@ export class CodeViewBase extends React.Component<Props> {
       <>
         <GlobalLinterMessages
           containerRef={
-            isLineSelected(getCodeLineAnchorID(0), location)
+            isLineSelected(
+              getCodeLineAnchorID(GLOBAL_LINTER_ANCHOR_ID),
+              location,
+            )
               ? _scrollToSelectedLine
               : undefined
           }

--- a/src/components/CodeView/utils.tsx
+++ b/src/components/CodeView/utils.tsx
@@ -37,6 +37,8 @@ export const getLines = (content: string) => {
   return content ? content.replace('\r\n', '\n').split('\n') : [];
 };
 
+export const GLOBAL_LINTER_ANCHOR_ID = 0;
+
 export const getCodeLineAnchorID = (line: number) => {
   return `I${line}`;
 };


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/677

I wanted to add a story for this but was blocked by https://github.com/mozilla/addons-code-manager/issues/1315