### PR TITLE
Only render the `VersionFileViewer` children when linter messages are loaded

### DIFF
--- a/src/components/VersionFileViewer/index.spec.tsx
+++ b/src/components/VersionFileViewer/index.spec.tsx
@@ -122,11 +122,38 @@ describe(__filename, () => {
       .filterWhere((c) => c.prop('title') === title);
   };
 
-  it('renders children', () => {
+  it('renders a loading message when linter messages are not loaded yet', () => {
     const childClass = 'ExampleClass';
-    const root = renderWithLinterProvider({
-      children: <div className={childClass} />,
-    });
+    const root = renderWithLinterProvider(
+      {
+        children: <div className={childClass} />,
+      },
+      {
+        messageMap: undefined,
+      },
+    );
+
+    expect(root.find(`.${childClass}`)).toHaveLength(0);
+    expect(root.find(Loading)).toHaveLength(1);
+    expect(root.find(Loading)).toHaveProp(
+      'message',
+      'Loading linter information...',
+    );
+  });
+
+  it('renders children when linter messages are loaded', () => {
+    const childClass = 'ExampleClass';
+    const messageMap = getMessageMap(
+      createFakeExternalLinterResult({ messages: [] }),
+    );
+    const root = renderWithLinterProvider(
+      {
+        children: <div className={childClass} />,
+      },
+      {
+        messageMap,
+      },
+    );
 
     expect(root.find(`.${childClass}`)).toHaveLength(1);
   });

--- a/src/components/VersionFileViewer/index.tsx
+++ b/src/components/VersionFileViewer/index.tsx
@@ -103,7 +103,11 @@ const VersionFileViewer = ({
           ) : null
         }
       >
-        {children}
+        {messageMap ? (
+          children
+        ) : (
+          <Loading message={gettext('Loading linter information...')} />
+        )}
       </ContentShell>
     );
   };


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/1334

---

This patch optimizes "cold starts" only because we only fetch the validation information once for a given version (if I am not mistaken). That being said, I can see huge performance boosts when cold loading a large file.