### PR TITLE
Fix VersionChooser story

### DIFF
--- a/src/components/VersionChooser/index.tsx
+++ b/src/components/VersionChooser/index.tsx
@@ -289,14 +289,6 @@ const mapStateToProps = (
 
 const ConnectedVersionChooser = connect(mapStateToProps)(VersionChooserBase);
 
-// We have to export this class to tell Storybook that it's okay to inject the
-// router props directly. That's because we want to by-pass the `withRouter()`
-// HOC, which requires a `Router` and a `Route` and we don't want that in
-// Storybook.
-export const VersionChooserWithoutRouter = ConnectedVersionChooser as React.ComponentType<
-  PublicProps & Partial<DefaultProps & RouterProps>
->;
-
 export default withRouter<PublicProps & Partial<DefaultProps> & RouterProps>(
   ConnectedVersionChooser,
 );

--- a/stories/VersionChooser.stories.tsx
+++ b/stories/VersionChooser.stories.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 
 import configureStore from '../src/configureStore';
 import { actions as popoverActions } from '../src/reducers/popover';
-import { VersionChooserWithoutRouter } from '../src/components/VersionChooser';
+import VersionChooser from '../src/components/VersionChooser';
 import { ExternalVersionsList, actions } from '../src/reducers/versions';
 import { fakeVersionsListItem } from '../src/test-helpers';
 import { renderWithStoreAndRouter } from './utils';
@@ -17,18 +17,9 @@ const render = ({
   store.dispatch(actions.setCurrentBaseVersionId({ versionId: baseVersionId }));
   store.dispatch(actions.setCurrentVersionId({ versionId: headVersionId }));
   store.dispatch(popoverActions.show('COMPARE_VERSIONS'));
-  return renderWithStoreAndRouter(
-    <VersionChooserWithoutRouter
-      addonId={addonId}
-      match={{
-        isExact: true,
-        path: 'some-path',
-        url: 'some-url',
-        params: { lang: 'fr' },
-      }}
-    />,
-    { store },
-  );
+  return renderWithStoreAndRouter(<VersionChooser addonId={addonId} />, {
+    store,
+  });
 };
 
 const listedVersions: ExternalVersionsList = [


### PR DESCRIPTION
Fixes #1359 

Since we already wrapped the `VersionChooser` component in `MemoryRouter`, I think we do not need `VersionChooserWithoutRouter` anymore.