### PR TITLE
Do not throw an error when clicking empty lines in code overview

### DIFF
--- a/src/components/CodeOverview/index.spec.tsx
+++ b/src/components/CodeOverview/index.spec.tsx
@@ -532,14 +532,16 @@ describe(__filename, () => {
   it('does not scroll when clicking an empty line', () => {
     const _document = { ...document, querySelector: jest.fn() };
     const root = renderWithFixedHeight({ _document, content: '' });
+    const event = { preventDefault: jest.fn() };
 
     // Click the first empty line.
     root
       .find(Link)
       .at(1)
-      .simulate('click');
+      .simulate('click', event);
 
     expect(_document.querySelector).not.toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalled();
   });
 
   it('handles empty content', () => {

--- a/src/components/CodeOverview/index.tsx
+++ b/src/components/CodeOverview/index.tsx
@@ -244,11 +244,14 @@ export class CodeOverviewBase extends React.Component<Props, State> {
       const codeLineAnchor =
         linkableLine !== undefined ? getCodeLineAnchor(linkableLine) : null;
 
-      const scrollToLine = () => {
+      const scrollToLine = (
+        event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
+      ) => {
         // Explicitly scroll to the linter message in case the user had
         // scrolled it out of view.
         // Example: https://github.com/mozilla/addons-code-manager/issues/682
         if (!codeLineAnchor) {
+          event.preventDefault();
           return;
         }
         const domLine = _document.querySelector(codeLineAnchor);


### PR DESCRIPTION
Fixes #1311 