### PR TITLE
Ensure file tree list auto-scrolls only when needed

### DIFF
--- a/src/components/FileTreeNode/index.tsx
+++ b/src/components/FileTreeNode/index.tsx
@@ -159,7 +159,10 @@ export class FileTreeNodeBase<TreeNodeType> extends React.Component<Props> {
 
     if (this.isSelected() && version.visibleSelectedPath !== node.id) {
       if (this.nodeRef && this.nodeRef.current) {
-        this.nodeRef.current.scrollIntoView();
+        this.nodeRef.current.scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest',
+        });
         dispatch(
           versionsActions.setVisibleSelectedPath({
             path: node.id,


### PR DESCRIPTION
Fixes #695 
it looks like an easy fix without using `react-intersection-observer`. The parameter [`scroolIntoViewOptions`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) is not supported well for all browsers, but at least it works well in Firefox and Chrome.

Using 'j' 'k' to change files
![icon_f](https://user-images.githubusercontent.com/4984681/72090022-6f481900-32ca-11ea-9b21-6a94c89b8fab.gif)
