### PR TITLE
Truncate file content based on number of characters in the Comp…

### DIFF
--- a/src/components/CodeView/index.tsx
+++ b/src/components/CodeView/index.tsx
@@ -16,6 +16,8 @@ import {
 } from './utils';
 import refractor from '../../refractor';
 import {
+  SLOW_LOADING_CHAR_COUNT,
+  TRIMMED_CHAR_COUNT,
   gettext,
   getLanguageFromMimeType,
   shouldAllowSlowPages,
@@ -24,10 +26,6 @@ import { Version } from '../../reducers/versions';
 import LinterProvider, { LinterProviderInfo } from '../LinterProvider';
 import GlobalLinterMessages from '../GlobalLinterMessages';
 import SlowPageAlert from '../SlowPageAlert';
-
-// This is how many characters of code it takes to slow down the UI.
-const SLOW_LOADING_CHAR_COUNT = 3000;
-const TRIMMED_CHAR_COUNT = 2000;
 
 // This function mimics what https://github.com/rexxars/react-refractor does,
 // but we need a different layout to inline comments so we cannot use this

--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -27,6 +27,7 @@ import LinterProvider, { LinterProviderInfo } from '../LinterProvider';
 import GlobalLinterMessages from '../GlobalLinterMessages';
 import SlowPageAlert from '../SlowPageAlert';
 import {
+  TRIMMED_CHAR_COUNT,
   allowSlowPagesParam,
   getLanguageFromMimeType,
   getAllHunkChanges,
@@ -963,6 +964,17 @@ describe(__filename, () => {
 
   describe('trimHunks', () => {
     const changeCharCount = 5;
+
+    it('returns the imput hunks if the content is not greater than the _trimmedCharCount', () => {
+      // TRIMMED_CHAR_COUNT is the default value used for _trimmedCharCount by trimHunks
+      const change = { content: 'a'.repeat(TRIMMED_CHAR_COUNT) };
+
+      const hunks = [createInternalHunkWithChanges([change])];
+
+      const trimmed = trimHunks({ hunks });
+      expect(getAllHunkChanges(trimmed)).toHaveLength(1);
+      expect(trimmed[0].changes[0].content).toEqual(change.content);
+    });
 
     describe('for a single hunk', () => {
       it('includes changes up to the _trimmedCharCount', () => {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -16,6 +16,11 @@ import {
 import { CompareInfo } from './reducers/versions';
 import { getCodeLineAnchor } from './components/CodeView/utils';
 
+// This is how many characters of code it takes to slow down the UI.
+export const SLOW_LOADING_CHAR_COUNT = 3000;
+// This is how many characters of code we will include in trimmed content.
+export const TRIMMED_CHAR_COUNT = 2000;
+
 // Querystring params used by the app.
 export const messageUidQueryParam = 'messageUid';
 export const pathQueryParam = 'path';


### PR DESCRIPTION
~~Depends on #1363~~
Fixes #1366 

This also removes the code that disables highlighting for trimmed files in compare view. Our hypothesis is that that won't be needed anymore after trimming.

This also addresses an issue that existed with multiple children without keys in the `extraMessages` array (which I noticed while running tests).
