### PR TITLE
Refactor to avoid hardcoding changeType

### DIFF
--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -3,7 +3,6 @@ import queryString from 'query-string';
 import React from 'react';
 import { Alert } from 'react-bootstrap';
 import {
-  ChangeType,
   Diff,
   HunkInfo,
   Hunks,
@@ -36,6 +35,7 @@ import {
   ExternalChange,
   ExternalHunk,
   ScrollTarget,
+  changeTypes,
   createInternalDiff,
   createInternalHunk,
   createInternalVersion,
@@ -671,30 +671,30 @@ describe(__filename, () => {
     );
   });
 
-  it.each(['delete-eofnl', 'insert-eofnl', 'normal-eofnl'])(
-    'does not render a widget for %s changes',
-    (type) => {
-      const changeType = type as ChangeType;
-      const line = nextUniqueId();
-      const externalMessages = [{ line, uid: 'first' }];
-      const version = createInternalVersion({
-        ...fakeVersion,
-        id: nextUniqueId(),
-      });
-      const diff = createDiffWithHunks([
-        createHunkWithChanges([{ type: changeType, new_line_number: line }]),
-      ]);
-      const widgets = renderAndGetWidgets({
-        diff,
-        selectedMessageMap: createFakeLinterMessagesByPath({
-          messages: externalMessages,
-        }),
-        version,
-      });
+  it.each([
+    changeTypes.deleteEofnl,
+    changeTypes.insertEofnl,
+    changeTypes.normalEofnl,
+  ])('does not render a widget for %s changes', (type) => {
+    const line = nextUniqueId();
+    const externalMessages = [{ line, uid: 'first' }];
+    const version = createInternalVersion({
+      ...fakeVersion,
+      id: nextUniqueId(),
+    });
+    const diff = createDiffWithHunks([
+      createHunkWithChanges([{ type, new_line_number: line }]),
+    ]);
+    const widgets = renderAndGetWidgets({
+      diff,
+      selectedMessageMap: createFakeLinterMessagesByPath({
+        messages: externalMessages,
+      }),
+      version,
+    });
 
-      expect(getWidgetNodes(widgets).length).toEqual(0);
-    },
-  );
+    expect(getWidgetNodes(widgets).length).toEqual(0);
+  });
 
   describe('comment list', () => {
     it('renders inline comments for commentable lines', () => {
@@ -1191,28 +1191,30 @@ describe(__filename, () => {
   });
 
   describe('changeCanBeCommentedUpon', () => {
-    it.each(['insert', 'normal'])(
+    it.each([changeTypes.insert, changeTypes.normal])(
       'returns true for a(n) %s change',
-      (changeType) => {
+      (type) => {
         const change = {
           ...fakeChangeInfo,
-          type: changeType as ChangeType,
+          type,
         };
 
         expect(changeCanBeCommentedUpon(change)).toEqual(true);
       },
     );
 
-    it.each(['delete', 'delete-eofnl', 'insert-eofnl', 'normal-eofnl'])(
-      'returns false for a(n) %s change',
-      (changeType) => {
-        const change = {
-          ...fakeChangeInfo,
-          type: changeType as ChangeType,
-        };
+    it.each([
+      changeTypes.delete,
+      changeTypes.deleteEofnl,
+      changeTypes.insertEofnl,
+      changeTypes.normalEofnl,
+    ])('returns false for a(n) %s change', (type) => {
+      const change = {
+        ...fakeChangeInfo,
+        type,
+      };
 
-        expect(changeCanBeCommentedUpon(change)).toEqual(false);
-      },
-    );
+      expect(changeCanBeCommentedUpon(change)).toEqual(false);
+    });
   });
 });

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -2,7 +2,6 @@ import queryString from 'query-string';
 import * as React from 'react';
 import {
   ChangeInfo,
-  ChangeType,
   Decoration,
   Diff,
   DiffInfo,
@@ -30,6 +29,7 @@ import refractor from '../../refractor';
 import {
   ScrollTarget,
   Version,
+  changeTypes,
   getDiffAnchors,
   getRelativeDiffAnchor,
 } from '../../reducers/versions';
@@ -84,8 +84,7 @@ export const trimHunks = ({
 };
 
 export const changeCanBeCommentedUpon = (change: ChangeInfo) => {
-  const types: ChangeType[] = ['insert', 'normal'];
-  return types.includes(change.type);
+  return [changeTypes.insert, changeTypes.normal].includes(change.type);
 };
 
 export type PublicProps = {

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -107,6 +107,15 @@ type PartialExternalVersion = {
   version: string;
 };
 
+export const changeTypes: Record<string, ChangeType> = Object.freeze({
+  delete: 'delete',
+  deleteEofnl: 'delete-eofnl',
+  insert: 'insert',
+  insertEofnl: 'insert-eofnl',
+  normal: 'normal',
+  normalEofnl: 'normal-eofnl',
+});
+
 export type ExternalChange = {
   content: string;
   new_line_number: number;

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -5,15 +5,9 @@ import purify from 'dompurify';
 import { History, Location } from 'history';
 import queryString from 'query-string';
 import log from 'loglevel';
-import {
-  Hunks,
-  ChangeInfo,
-  ChangeType,
-  DiffInfo,
-  getChangeKey,
-} from 'react-diff-view';
+import { Hunks, ChangeInfo, DiffInfo, getChangeKey } from 'react-diff-view';
 
-import { CompareInfo } from './reducers/versions';
+import { changeTypes, CompareInfo } from './reducers/versions';
 import { getCodeLineAnchor } from './components/CodeView/utils';
 
 // This is how many characters of code it takes to slow down the UI.
@@ -212,7 +206,11 @@ export class ForwardComparisonMap {
       );
     }
 
-    const relevantTypes: ChangeType[] = ['insert', 'normal', 'delete'];
+    const relevantTypes = [
+      changeTypes.insert,
+      changeTypes.normal,
+      changeTypes.delete,
+    ];
 
     // Sort changes per line, ordered by relevantTypes.
     Object.keys(this.changeMap).forEach((line) => {


### PR DESCRIPTION
Fixes #1322. I am sure if this approach is desirable.

I found it a bit tricky to use `enum` in this case, because `enum` defined in `@types/react-diff-view/index.d.ts` file [could not be used in other files](https://lukasbehal.com/2017-05-22-enums-in-declaration-files/). Finally I just defined a new `const` in `reducer/version.tsx`.