### PR TITLE
Update the file list when switching between Browse and Compare page

### DIFF
--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -987,6 +987,38 @@ describe(__filename, () => {
     );
   });
 
+  it('does not throw an error when the selected path is not in version.entries', () => {
+    const baseVersionId = nextUniqueId();
+    const headVersionId = baseVersionId + 1;
+    const version = createExternalVersionWithEntries([{ path: 'path1' }], {
+      id: headVersionId,
+      selected_file: 'a non-existant file',
+    });
+    const store = configureStore();
+
+    dispatchLoadVersionInfo({ store, version });
+    store.dispatch(
+      versionsActions.loadEntryStatusMap({
+        version,
+        comparedToVersionId: baseVersionId,
+      }),
+    );
+    store.dispatch(
+      fileTreeActions.buildTree({
+        comparedToVersionId: baseVersionId,
+        version: createInternalVersion(version),
+      }),
+    );
+
+    expect(() => {
+      render({
+        baseVersionId: String(baseVersionId),
+        headVersionId: String(headVersionId),
+        store,
+      });
+    }).not.toThrow();
+  });
+
   describe('forceReloadVersion', () => {
     const setUpFileTreeAndRender = ({
       baseVersionId = nextUniqueId(),

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -346,11 +346,16 @@ export const mapStateToProps = (
   }
 
   const tree = getTree(state.fileTree, headVersionId);
+  const paths = version ? version.entries.map((entry) => entry.path) : [];
 
   const nextFilePath =
-    version && tree && entryStatusMap
+    version &&
+    tree &&
+    entryStatusMap &&
+    selectedPath &&
+    paths.includes(selectedPath)
       ? findRelativePathWithDiff({
-          currentPath: version.selectedPath,
+          currentPath: selectedPath,
           pathList: tree.pathList,
           position: RelativePathPosition.next,
           version,


### PR DESCRIPTION
Fixes #1421 

The main idea of this patch is to call `fetchVersion` with `{path: undefined}` to get version info (including the file list), so that we can get the updated file tree, even though the selected path does not exist in the new version.