### PR TITLE
Use React.Profiler to send render timings to GA

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "type-coverage": "^2.0.0"
   },
   "scripts": {
-    "build": "react-scripts build",
+    "build": "react-scripts build --profile",
     "build-local-dev-config": "cat .env.dev .env.common-local > .env.local",
     "build-local-olympia-config": "cat .env.olympia > .env.local",
     "build-local-stage-config": "cat .env.stage .env.common-local > .env.local",

--- a/src/components/CodeView/index.spec.tsx
+++ b/src/components/CodeView/index.spec.tsx
@@ -382,39 +382,15 @@ describe(__filename, () => {
     const _sendPerfTiming = jest.fn();
     const root = render({ _sendPerfTiming });
     const instance = getInstance<CodeViewBase>(root);
-    const { onRenderCallback } = instance;
+    const { onRenderProfiler } = instance;
     const actualDuration = 19;
     const id = 'some-id';
     const phase = 'mount';
 
     const profiler = root.find('#CodeView-Render');
-    expect(profiler).toHaveProp('onRender', onRenderCallback);
+    expect(profiler).toHaveProp('onRender', onRenderProfiler);
 
-    onRenderCallback(id, phase, actualDuration);
-    expect(_sendPerfTiming).toHaveBeenCalledWith({ actualDuration, id, phase });
-  });
-
-  it('configures highlighting Profiler', () => {
-    const _sendPerfTiming = jest.fn();
-    const actualDuration = 19;
-    const id = 'some-id';
-    const phase = 'mount';
-
-    const content = '{ "foo": "bar" }';
-    const mimeType = 'application/json';
-    const { renderContent, root } = simulateCommentableLine({
-      _sendPerfTiming,
-      mimeType,
-      content,
-    });
-    const instance = getInstance<CodeViewBase>(root);
-    const { onRenderCallback } = instance;
-    const line = renderContent();
-
-    const profiler = line.find('#CodeView-Highlighting');
-    expect(profiler).toHaveProp('onRender', onRenderCallback);
-
-    onRenderCallback(id, phase, actualDuration);
+    onRenderProfiler(id, phase, actualDuration);
     expect(_sendPerfTiming).toHaveBeenCalledWith({ actualDuration, id, phase });
   });
 

--- a/src/components/CodeView/index.spec.tsx
+++ b/src/components/CodeView/index.spec.tsx
@@ -27,6 +27,7 @@ import {
   createFakeLocation,
   fakeExternalLinterMessage,
   fakeVersion,
+  getInstance,
   shallowUntilTarget,
   simulateCommentList,
   simulateCommentable,
@@ -98,10 +99,17 @@ describe(__filename, () => {
     ...props
   }: Pick<SimulateCommentableParams, 'addCommentButton'> &
     Partial<RenderWithLinterProviderParams> = {}) => {
-    const provider = renderWithLinterProvider(props);
+    const root = render(props);
+    const { messageMap, messagesAreLoading, selectedMessageMap } = props;
+    const provider = simulateLinterProvider(root, {
+      messageMap,
+      messagesAreLoading,
+      selectedMessageMap,
+    });
     return {
       ...simulateCommentable({ addCommentButton, root: provider }),
       provider,
+      root,
     };
   };
 
@@ -368,6 +376,46 @@ describe(__filename, () => {
     expect(provider).toHaveProp('versionId', version.id);
     expect(provider).toHaveProp('validationURL', version.validationURL);
     expect(provider).toHaveProp('selectedPath', version.selectedPath);
+  });
+
+  it('configures base Profiler', () => {
+    const _sendPerfTiming = jest.fn();
+    const root = render({ _sendPerfTiming });
+    const instance = getInstance<CodeViewBase>(root);
+    const { onRenderCallback } = instance;
+    const actualDuration = 19;
+    const id = 'some-id';
+    const phase = 'mount';
+
+    const profiler = root.find('#CodeView-Render');
+    expect(profiler).toHaveProp('onRender', onRenderCallback);
+
+    onRenderCallback(id, phase, actualDuration);
+    expect(_sendPerfTiming).toHaveBeenCalledWith({ actualDuration, id, phase });
+  });
+
+  it('configures highlighting Profiler', () => {
+    const _sendPerfTiming = jest.fn();
+    const actualDuration = 19;
+    const id = 'some-id';
+    const phase = 'mount';
+
+    const content = '{ "foo": "bar" }';
+    const mimeType = 'application/json';
+    const { renderContent, root } = simulateCommentableLine({
+      _sendPerfTiming,
+      mimeType,
+      content,
+    });
+    const instance = getInstance<CodeViewBase>(root);
+    const { onRenderCallback } = instance;
+    const line = renderContent();
+
+    const profiler = line.find('#CodeView-Highlighting');
+    expect(profiler).toHaveProp('onRender', onRenderCallback);
+
+    onRenderCallback(id, phase, actualDuration);
+    expect(_sendPerfTiming).toHaveBeenCalledWith({ actualDuration, id, phase });
   });
 
   it('renders a global LinterMessage', () => {

--- a/src/components/CodeView/index.tsx
+++ b/src/components/CodeView/index.tsx
@@ -29,8 +29,6 @@ import LinterProvider, { LinterProviderInfo } from '../LinterProvider';
 import GlobalLinterMessages from '../GlobalLinterMessages';
 import SlowPageAlert from '../SlowPageAlert';
 
-const { Profiler } = React;
-
 // This function mimics what https://github.com/rexxars/react-refractor does,
 // but we need a different layout to inline comments so we cannot use this
 // component.
@@ -91,7 +89,8 @@ export class CodeViewBase extends React.Component<Props> {
     enableCommenting: process.env.REACT_APP_ENABLE_COMMENTING === 'true',
   };
 
-  onRenderCallback = (id: string, phase: string, actualDuration: number) => {
+  // See https://github.com/reactjs/rfcs/blob/master/text/0051-profiler.md
+  onRenderProfiler = (id: string, phase: string, actualDuration: number) => {
     this.props._sendPerfTiming({ actualDuration, id, phase });
   };
 
@@ -205,18 +204,12 @@ export class CodeViewBase extends React.Component<Props> {
                               >{`${line}`}</Link>
                               {enableCommenting && addCommentButton}
                             </td>
-
-                            <Profiler
-                              id="CodeView-Highlighting"
-                              onRender={this.onRenderCallback}
-                            >
-                              <td className={styles.code}>
-                                {renderCode({
-                                  code,
-                                  language,
-                                })}
-                              </td>
-                            </Profiler>
+                            <td className={styles.code}>
+                              {renderCode({
+                                code,
+                                language,
+                              })}
+                            </td>
                           </>
                         )}
                       </Commentable>
@@ -270,7 +263,7 @@ export class CodeViewBase extends React.Component<Props> {
     const { version } = this.props;
 
     return (
-      <Profiler id="CodeView-Render" onRender={this.onRenderCallback}>
+      <React.Profiler id="CodeView-Render" onRender={this.onRenderProfiler}>
         <LinterProvider
           versionId={version.id}
           validationURL={version.validationURL}
@@ -281,7 +274,7 @@ export class CodeViewBase extends React.Component<Props> {
           // comments per line.
           (info: LinterProviderInfo) => this.renderWithLinterInfo(info)}
         </LinterProvider>
-      </Profiler>
+      </React.Profiler>
     );
   }
 }

--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -548,15 +548,15 @@ describe(__filename, () => {
     const _sendPerfTiming = jest.fn();
     const root = render({ _sendPerfTiming });
     const instance = getInstance<DiffViewBase>(root);
-    const { onRenderCallback } = instance;
+    const { onRenderProfiler } = instance;
     const actualDuration = 19;
     const id = 'some-id';
     const phase = 'mount';
 
     const profiler = root.find('#DiffView-Render');
-    expect(profiler).toHaveProp('onRender', onRenderCallback);
+    expect(profiler).toHaveProp('onRender', onRenderProfiler);
 
-    onRenderCallback(id, phase, actualDuration);
+    onRenderProfiler(id, phase, actualDuration);
     expect(_sendPerfTiming).toHaveBeenCalledWith({ actualDuration, id, phase });
   });
 

--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -48,6 +48,7 @@ import {
   fakeChangeInfo,
   fakeExternalDiff,
   fakeVersion,
+  getInstance,
   nextUniqueId,
   shallowUntilTarget,
   simulateCommentable,
@@ -541,6 +542,22 @@ describe(__filename, () => {
     expect(provider).toHaveProp('versionId', version.id);
     expect(provider).toHaveProp('validationURL', version.validationURL);
     expect(provider).toHaveProp('selectedPath', version.selectedPath);
+  });
+
+  it('configures base Profiler', () => {
+    const _sendPerfTiming = jest.fn();
+    const root = render({ _sendPerfTiming });
+    const instance = getInstance<DiffViewBase>(root);
+    const { onRenderCallback } = instance;
+    const actualDuration = 19;
+    const id = 'some-id';
+    const phase = 'mount';
+
+    const profiler = root.find('#DiffView-Render');
+    expect(profiler).toHaveProp('onRender', onRenderCallback);
+
+    onRenderCallback(id, phase, actualDuration);
+    expect(_sendPerfTiming).toHaveBeenCalledWith({ actualDuration, id, phase });
   });
 
   it('renders global messages', () => {

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -143,7 +143,8 @@ export class DiffViewBase extends React.Component<Props> {
     viewType: 'unified',
   };
 
-  onRenderCallback = (id: string, phase: string, actualDuration: number) => {
+  // See https://github.com/reactjs/rfcs/blob/master/text/0051-profiler.md
+  onRenderProfiler = (id: string, phase: string, actualDuration: number) => {
     this.props._sendPerfTiming({ actualDuration, id, phase });
   };
 
@@ -482,7 +483,7 @@ export class DiffViewBase extends React.Component<Props> {
     const { version } = this.props;
 
     return (
-      <Profiler id="DiffView-Render" onRender={this.onRenderCallback}>
+      <Profiler id="DiffView-Render" onRender={this.onRenderProfiler}>
         <LinterProvider
           versionId={version.id}
           validationURL={version.validationURL}

--- a/src/utils.spec.tsx
+++ b/src/utils.spec.tsx
@@ -26,6 +26,7 @@ import {
   makeReviewersURL,
   nl2br,
   sanitizeHTML,
+  sendPerfTiming,
   shouldAllowSlowPages,
 } from './utils';
 import {
@@ -724,6 +725,23 @@ describe('codeCanBeHighlighted', () => {
     it('returns true if isMinified is true', () => {
       expect(codeShouldBeTrimmed(1, 2, true)).toEqual(true);
       expect(codeShouldBeTrimmed(1, 1, false)).toEqual(true);
+    });
+  });
+
+  describe('sendPerfTiming', () => {
+    it('sends a renderPerf timing via tracking', () => {
+      const _tracking = { timing: jest.fn() };
+      const actualDuration = 19;
+      const id = 'some-id';
+      const phase = 'mount';
+
+      sendPerfTiming({ _tracking, actualDuration, id, phase });
+      expect(_tracking.timing).toHaveBeenCalledWith({
+        category: 'renderPerf',
+        label: phase,
+        value: actualDuration,
+        variable: id,
+      });
     });
   });
 });

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -9,6 +9,7 @@ import { Hunks, ChangeInfo, DiffInfo, getChangeKey } from 'react-diff-view';
 
 import { changeTypes, CompareInfo } from './reducers/versions';
 import { getCodeLineAnchor } from './components/CodeView/utils';
+import tracking from './tracking';
 
 // This is how many characters of code it takes to slow down the UI.
 export const SLOW_LOADING_CHAR_COUNT = 3000;
@@ -269,4 +270,23 @@ export const codeShouldBeTrimmed = (
   isMinified: boolean,
 ) => {
   return codeLength >= slowLoadingCharCount || isMinified;
+};
+
+export const sendPerfTiming = ({
+  _tracking = tracking,
+  actualDuration,
+  id,
+  phase,
+}: {
+  _tracking?: typeof tracking;
+  actualDuration: number;
+  id: string;
+  phase: string;
+}) => {
+  _tracking.timing({
+    category: 'renderPerf',
+    label: phase,
+    value: actualDuration,
+    variable: id,
+  });
 };


### PR DESCRIPTION
Fixes #1423 

This will send data on the performance of the render function for both `CodeView` and `DiffView` to GA for future analysis. There has been some discussion about how much highlighting affects the performance, so I built in a separate measure of just the highlighting piece for the `CodeView` component.