### PR TITLE
Change logic for trimming both minified and non-minified code

### DIFF
--- a/src/components/CodeView/index.spec.tsx
+++ b/src/components/CodeView/index.spec.tsx
@@ -18,7 +18,11 @@ import {
   mapWithDepth,
   GLOBAL_LINTER_ANCHOR_ID,
 } from './utils';
-import { allowSlowPagesParam, getLanguageFromMimeType } from '../../utils';
+import {
+  allowSlowPagesParam,
+  contentAddedByTrimmer,
+  getLanguageFromMimeType,
+} from '../../utils';
 import {
   SimulateCommentListParams,
   SimulateCommentableParams,
@@ -527,7 +531,7 @@ describe(__filename, () => {
       `${content.substring(
         0,
         _minifiedFileTrimmedCharCount,
-      )} /* truncated by code-manager */`,
+      )} ${contentAddedByTrimmer}`,
     );
   });
 

--- a/src/components/CodeView/index.tsx
+++ b/src/components/CodeView/index.tsx
@@ -19,6 +19,7 @@ import {
   MINIFIED_FILE_TRIMMED_CHAR_COUNT,
   SLOW_LOADING_LINE_COUNT,
   codeShouldBeTrimmed,
+  contentAddedByTrimmer,
   gettext,
   getLanguageFromMimeType,
   sendPerfTiming,
@@ -127,11 +128,11 @@ export class CodeViewBase extends React.Component<Props> {
             `${content.substring(
               0,
               _minifiedFileTrimmedCharCount,
-            )} /* truncated by code-manager */`,
+            )} ${contentAddedByTrimmer}`,
           );
         } else {
           codeLines = codeLines.slice(0, _slowLoadingLineCount);
-          codeLines.push('/* truncated by code-manager */');
+          codeLines.push(contentAddedByTrimmer);
         }
         codeWasTrimmed = true;
       }

--- a/src/components/CodeView/index.tsx
+++ b/src/components/CodeView/index.tsx
@@ -278,10 +278,12 @@ export class CodeViewBase extends React.Component<Props> {
           validationURL={version.validationURL}
           selectedPath={version.selectedPath}
         >
-          {// This needs to be an anonymous function (which defeats memoization)
-          // so that the component gets re-rendered in the case of adding
-          // comments per line.
-          (info: LinterProviderInfo) => this.renderWithLinterInfo(info)}
+          {
+            // This needs to be an anonymous function (which defeats memoization)
+            // so that the component gets re-rendered in the case of adding
+            // comments per line.
+            (info: LinterProviderInfo) => this.renderWithLinterInfo(info)
+          }
         </LinterProvider>
       </React.Profiler>
     );

--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -26,6 +26,8 @@ import LinterProvider, { LinterProviderInfo } from '../LinterProvider';
 import GlobalLinterMessages from '../GlobalLinterMessages';
 import SlowPageAlert from '../SlowPageAlert';
 import {
+  MINIFIED_FILE_TRIMMED_CHAR_COUNT,
+  SLOW_LOADING_LINE_COUNT,
   allowSlowPagesParam,
   getLanguageFromMimeType,
   getAllHunkChanges,
@@ -1033,6 +1035,19 @@ describe(__filename, () => {
   });
 
   describe('trimHunkLines', () => {
+    it('defaults _slowLoadingLineCount to SLOW_LOADING_LINE_COUNT', () => {
+      const changes = Array(SLOW_LOADING_LINE_COUNT + 10).fill({
+        content: '// example content',
+      });
+      const hunk = createInternalHunkWithChanges(changes);
+
+      // Add one to expected length for the message that gets added.
+      const expectedLength = SLOW_LOADING_LINE_COUNT + 1;
+
+      const trimmed = trimHunkLines({ hunks: [hunk] });
+      expect(trimmed[0].changes.length).toEqual(expectedLength);
+    });
+
     describe('for a single hunk', () => {
       it('does not trim when not necessary', () => {
         const hunks = [
@@ -1095,6 +1110,18 @@ describe(__filename, () => {
 
   describe('trimHunkChars', () => {
     const changeCharCount = 5;
+
+    it('defaults _trimmedCharCount to MINIFIED_FILE_TRIMMED_CHAR_COUNT', () => {
+      const change = {
+        content: 'a'.repeat(MINIFIED_FILE_TRIMMED_CHAR_COUNT + 10),
+      };
+      const hunk = createInternalHunkWithChanges([change]);
+
+      const trimmed = trimHunkChars({ hunks: [hunk] });
+      expect(trimmed[0].changes[0].content.length).toEqual(
+        MINIFIED_FILE_TRIMMED_CHAR_COUNT,
+      );
+    });
 
     describe('for a single hunk', () => {
       it('does not trim when not necessary', () => {

--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -26,7 +26,6 @@ import LinterProvider, { LinterProviderInfo } from '../LinterProvider';
 import GlobalLinterMessages from '../GlobalLinterMessages';
 import SlowPageAlert from '../SlowPageAlert';
 import {
-  TRIMMED_CHAR_COUNT,
   allowSlowPagesParam,
   getLanguageFromMimeType,
   getAllHunkChanges,
@@ -61,10 +60,11 @@ import DiffView, {
   DefaultProps,
   DiffViewBase,
   PublicProps,
-  changeContentAddedByTrimmer,
+  addedChange,
   changeCanBeCommentedUpon,
   getChangeCharCount,
-  trimHunks,
+  trimHunkChars,
+  trimHunkLines,
 } from '.';
 
 describe(__filename, () => {
@@ -862,128 +862,123 @@ describe(__filename, () => {
     expect(root.find(`.${styles.highlightingDisabled}`)).toHaveLength(0);
   });
 
-  it('lets you turn on diff trimming', () => {
-    const _slowLoadingCharCount = 10;
-    const _trimmedCharCount = _slowLoadingCharCount - 1;
-    const change1 = { content: 'a'.repeat(_slowLoadingCharCount / 2) };
-    const change2 = { content: 'b'.repeat(_slowLoadingCharCount / 2) };
+  it('checks whether code should be trimmed', () => {
+    const _codeShouldBeTrimmed = jest.fn();
+    const _minifiedFileTrimmedCharCount = 10;
+    const _slowLoadingLineCount = 10;
+
+    const changeLength = 5;
+    const change1 = { content: 'a'.repeat(changeLength) };
+    const change2 = { content: 'b'.repeat(changeLength) };
     const diff = createDiffWithHunks([
       createHunkWithChanges([change1, change2]),
     ]);
+
+    renderWithLinterProvider({
+      _codeShouldBeTrimmed,
+      _minifiedFileTrimmedCharCount,
+      _slowLoadingLineCount,
+      diff,
+      isMinified: true,
+    });
+
+    expect(_codeShouldBeTrimmed).toHaveBeenCalledWith({
+      codeCharLength: changeLength * 2,
+      codeLineLength: 2,
+      isMinified: true,
+      minifiedFileTrimmedCharCount: _minifiedFileTrimmedCharCount,
+      slowLoadingLineCount: _slowLoadingLineCount,
+    });
+  });
+
+  it('trims minified files by chars, when needed', () => {
+    const _codeShouldBeTrimmed = jest.fn().mockReturnValue(true);
+    const _trimHunkChars = jest
+      .fn()
+      .mockReturnValue([createHunkWithChanges([{}])]);
+
+    const root = renderWithLinterProvider({
+      _codeShouldBeTrimmed,
+      _trimHunkChars,
+      isMinified: true,
+    });
+
+    expect(_codeShouldBeTrimmed).toHaveBeenCalled();
+    expect(_trimHunkChars).toHaveBeenCalled();
+
+    const fadableShell = root.find(FadableContent);
+    expect(fadableShell).toHaveProp('fade', true);
+
+    const message = root.find(SlowPageAlert);
+    // There should be a warning at the top and bottom.
+    expect(message).toHaveLength(2);
+  });
+
+  it('trims non-minified files by lines, when needed', () => {
+    const _codeShouldBeTrimmed = jest.fn().mockReturnValue(true);
+    const _trimHunkLines = jest
+      .fn()
+      .mockReturnValue([createHunkWithChanges([{}])]);
+    // Non-minified files are not trimmed by default, so we need to force
+    // trimming via a URL param.
     const location = createFakeLocation({
       search: queryString.stringify({ [allowSlowPagesParam]: false }),
     });
 
     const root = renderWithLinterProvider({
-      diff,
+      _codeShouldBeTrimmed,
+      _trimHunkLines,
+      isMinified: false,
       location,
-      _slowLoadingCharCount,
-      _trimmedCharCount,
     });
+
+    expect(_codeShouldBeTrimmed).toHaveBeenCalled();
+    expect(_trimHunkLines).toHaveBeenCalled();
 
     const fadableShell = root.find(FadableContent);
     expect(fadableShell).toHaveProp('fade', true);
-
-    const diffView = fadableShell.find(Diff);
-    expect(diffView).toHaveProp(
-      'hunks',
-      createDiffWithHunks([
-        createHunkWithChanges([
-          change1,
-          {
-            ...change2,
-            content: change2.content.substring(
-              0,
-              _slowLoadingCharCount / 2 - 1,
-            ),
-          },
-          {
-            content: changeContentAddedByTrimmer,
-            new_line_number: undefined,
-            old_line_number: undefined,
-          },
-        ]),
-      ]).hunks,
-    );
 
     const message = root.find(SlowPageAlert);
     // There should be a warning at the top and bottom.
     expect(message).toHaveLength(2);
   });
 
-  it('trims minified files by default', () => {
-    const _slowLoadingCharCount = 10;
-    const _trimmedCharCount = 5;
-    const change1 = { content: 'a'.repeat(4) };
-    const change2 = { content: 'b'.repeat(4) };
-    const diff = createDiffWithHunks([
-      createHunkWithChanges([change1, change2]),
-    ]);
+  it('does not trim non-minified files by default', () => {
+    const _codeShouldBeTrimmed = jest.fn().mockReturnValue(true);
+    const _trimHunkLines = jest
+      .fn()
+      .mockReturnValue([createHunkWithChanges([{}])]);
+    // Non-minified files are not trimmed by default, so we need to force
+    // trimming via a URL param.
 
     const root = renderWithLinterProvider({
-      diff,
-      isMinified: true,
-      _slowLoadingCharCount,
-      _trimmedCharCount,
+      _codeShouldBeTrimmed,
+      _trimHunkLines,
+      isMinified: false,
     });
 
-    const fadableShell = root.find(FadableContent);
-    expect(fadableShell).toHaveProp('fade', true);
-
-    const diffView = fadableShell.find(Diff);
-    expect(diffView).toHaveProp(
-      'hunks',
-      createDiffWithHunks([
-        createHunkWithChanges([
-          change1,
-          {
-            ...change2,
-            content: change2.content.substring(0, 1),
-          },
-          {
-            content: changeContentAddedByTrimmer,
-            new_line_number: undefined,
-            old_line_number: undefined,
-          },
-        ]),
-      ]).hunks,
-    );
-
-    const message = root.find(SlowPageAlert);
-    // There should be a warning at the top and bottom.
-    expect(message).toHaveLength(2);
-  });
-
-  it('disables diff trimming for non-minified files by default', () => {
-    const _slowLoadingCharCount = 5;
-    const change = { content: 'a'.repeat(_slowLoadingCharCount + 1) };
-    const diff = createDiffWithHunks([createHunkWithChanges([change])]);
-
-    const root = renderWithLinterProvider({
-      diff,
-      _slowLoadingCharCount,
-    });
+    expect(_codeShouldBeTrimmed).toHaveBeenCalled();
+    expect(_trimHunkLines).not.toHaveBeenCalled();
 
     expect(root.find(FadableContent)).toHaveProp('fade', false);
 
-    const diffView = root.find(Diff);
-    expect(diffView).toHaveProp('hunks', diff.hunks);
-
     const message = root.find(SlowPageAlert);
-    // There should only be one warning at the top.
+    // There should only be a warning at the top (which enables trimming).
     expect(message).toHaveLength(1);
   });
 
   it('configures SlowPageAlert', () => {
-    const _slowLoadingCharCount = 5;
-    const change = { content: 'a'.repeat(_slowLoadingCharCount + 1) };
-    const diff = createDiffWithHunks([createHunkWithChanges([change])]);
+    const _codeShouldBeTrimmed = jest.fn().mockReturnValue(true);
+    const _trimHunkLines = jest
+      .fn()
+      .mockReturnValue([createHunkWithChanges([{}])]);
     const location = createFakeLocation();
 
     const root = renderWithLinterProvider({
-      diff,
+      _codeShouldBeTrimmed,
+      _trimHunkLines,
+      isMinified: false,
       location,
-      _slowLoadingCharCount,
     });
 
     const message = root.find(SlowPageAlert).at(0);
@@ -999,7 +994,7 @@ describe(__filename, () => {
 
     // Pass in allowSlowPages=true|false to test messaging.
 
-    expect(getMessage(true)).toEqual('This diff will load slowly.');
+    expect(getMessage(true)).toEqual('This diff may load slowly.');
     expect(getMessage(false)).toEqual(
       'This diff was shortened to load faster.',
     );
@@ -1037,145 +1032,136 @@ describe(__filename, () => {
     });
   });
 
-  describe('trimHunks', () => {
-    const changeCharCount = 5;
-
-    it('returns the input hunks if the content is not greater than the _trimmedCharCount', () => {
-      // TRIMMED_CHAR_COUNT is the default value used for _trimmedCharCount by trimHunks
-      const change = { content: 'a'.repeat(TRIMMED_CHAR_COUNT) };
-
-      const hunks = [createInternalHunkWithChanges([change])];
-
-      const trimmed = trimHunks({ hunks });
-      expect(getAllHunkChanges(trimmed)).toHaveLength(1);
-      expect(trimmed[0].changes[0].content).toEqual(change.content);
-    });
-
+  describe('trimHunkLines', () => {
     describe('for a single hunk', () => {
-      it('includes changes up to the _trimmedCharCount', () => {
-        const change1 = { content: 'a'.repeat(changeCharCount) };
-        const change2 = { content: 'b'.repeat(changeCharCount) };
-        const change3 = { content: 'c'.repeat(changeCharCount) };
-
+      it('does not trim when not necessary', () => {
         const hunks = [
-          createInternalHunkWithChanges([change1, change2, change3]),
+          createInternalHunkWithChanges([
+            { content: '// example content 1' },
+            { content: '// example content 2' },
+          ]),
         ];
 
-        const trimmed = trimHunks({
+        expect(trimHunkLines({ _slowLoadingLineCount: 2, hunks })).toEqual(
           hunks,
-          _trimmedCharCount: changeCharCount * 2,
-        });
-        expect(getAllHunkChanges(trimmed)).toHaveLength(3);
-        expect(trimmed[0].changes[0].content).toEqual(change1.content);
-        expect(trimmed[0].changes[1].content).toEqual(change2.content);
-        expect(trimmed[0].changes[2].content).toEqual(
-          changeContentAddedByTrimmer,
         );
       });
 
-      it('excludes content that exceeds the _trimmedCharCount', () => {
-        const change1 = { content: 'a'.repeat(changeCharCount) };
-        const change2 = { content: 'b'.repeat(changeCharCount + 1) };
+      it('trims lines when there are too many', () => {
+        const hunk = createInternalHunkWithChanges([
+          { content: '// example content 1' },
+          { content: '// example content 2' },
+          { content: '// example content 3' },
+        ]);
 
-        const hunks = [createInternalHunkWithChanges([change1, change2])];
-
-        const trimmed = trimHunks({
-          hunks,
-          _trimmedCharCount: changeCharCount * 2,
-        });
-        expect(getAllHunkChanges(trimmed)).toHaveLength(3);
-        expect(trimmed[0].changes[0].content).toEqual(change1.content);
-        expect(trimmed[0].changes[1].content).toEqual(
-          change2.content.substring(0, changeCharCount),
-        );
-      });
-
-      it('adds a change with a message about content being trimmed', () => {
-        const change1 = { content: 'a'.repeat(changeCharCount) };
-        const change2 = { content: 'b'.repeat(changeCharCount + 1) };
-
-        const hunks = [createInternalHunkWithChanges([change1, change2])];
-
-        const trimmed = trimHunks({
-          hunks,
-          _trimmedCharCount: changeCharCount * 2,
-        });
-        expect(getAllHunkChanges(trimmed)).toHaveLength(3);
-        expect(trimmed[0].changes[2].content).toEqual(
-          changeContentAddedByTrimmer,
-        );
-        expect(trimmed[0].changes[2].lineNumber).toEqual(undefined);
-        expect(trimmed[0].changes[2].newLineNumber).toEqual(undefined);
-        expect(trimmed[0].changes[2].oldLineNumber).toEqual(undefined);
+        expect(
+          trimHunkLines({ _slowLoadingLineCount: 2, hunks: [hunk] }),
+        ).toEqual([
+          { ...hunk, changes: [hunk.changes[0], hunk.changes[1], addedChange] },
+        ]);
       });
     });
 
     describe('for multiple hunks', () => {
-      it('includes changes up to the _trimmedCharCount', () => {
-        const change1 = { content: 'a'.repeat(changeCharCount) };
-        const change2 = { content: 'b'.repeat(changeCharCount) };
-        const change3 = { content: 'c'.repeat(changeCharCount) };
-
+      it('does not trim when not necessary', () => {
         const hunks = [
-          createInternalHunkWithChanges([change1]),
-          createInternalHunkWithChanges([change2, change3]),
+          createInternalHunkWithChanges([{ content: '// example content 1' }]),
+          createInternalHunkWithChanges([{ content: '// example content 2' }]),
         ];
 
-        const trimmed = trimHunks({
+        expect(trimHunkLines({ _slowLoadingLineCount: 2, hunks })).toEqual(
           hunks,
-          _trimmedCharCount: changeCharCount * 2,
-        });
-        expect(getAllHunkChanges(trimmed)).toHaveLength(3);
-        expect(trimmed[0].changes[0].content).toEqual(change1.content);
-        expect(trimmed[1].changes[0].content).toEqual(change2.content);
-        expect(trimmed[1].changes[1].content).toEqual(
-          changeContentAddedByTrimmer,
         );
       });
 
-      it('excludes content that exceeds the _trimmedCharCount', () => {
-        const change1 = { content: 'a'.repeat(changeCharCount) };
-        const change2 = { content: 'b'.repeat(changeCharCount + 1) };
+      it('trims lines when there are too many', () => {
+        const hunk1 = createInternalHunkWithChanges([
+          { content: '// example content 1' },
+        ]);
+        const hunk2 = createInternalHunkWithChanges([
+          { content: '// example content 2' },
+          { content: '// example content 3' },
+        ]);
 
+        expect(
+          trimHunkLines({ _slowLoadingLineCount: 2, hunks: [hunk1, hunk2] }),
+        ).toEqual([
+          hunk1,
+          { ...hunk2, changes: [hunk2.changes[0], addedChange] },
+        ]);
+      });
+    });
+  });
+
+  describe('trimHunkChars', () => {
+    const changeCharCount = 5;
+
+    describe('for a single hunk', () => {
+      it('does not trim when not necessary', () => {
         const hunks = [
-          createInternalHunkWithChanges([change1]),
-          createInternalHunkWithChanges([change2]),
+          createInternalHunkWithChanges([
+            { content: 'a'.repeat(changeCharCount) },
+          ]),
         ];
 
-        const trimmed = trimHunks({
-          hunks,
-          _trimmedCharCount: changeCharCount * 2,
-        });
-        expect(getAllHunkChanges(trimmed)).toHaveLength(3);
-        expect(trimmed[0].changes[0].content).toEqual(change1.content);
-        expect(trimmed[1].changes[0].content).toEqual(
-          change2.content.substring(0, changeCharCount),
-        );
-        expect(trimmed[1].changes[1].content).toEqual(
-          changeContentAddedByTrimmer,
-        );
+        expect(
+          trimHunkChars({ _trimmedCharCount: changeCharCount, hunks }),
+        ).toEqual(hunks);
       });
 
-      it('adds a change with a message about content being trimmed', () => {
-        const change1 = { content: 'a'.repeat(changeCharCount) };
-        const change2 = { content: 'b'.repeat(changeCharCount + 1) };
+      it('trims chars when there are too many', () => {
+        const hunk = createInternalHunkWithChanges([
+          { content: 'a'.repeat(changeCharCount * 2) },
+        ]);
 
+        const trimmed = trimHunkChars({
+          hunks: [hunk],
+          _trimmedCharCount: changeCharCount,
+        });
+        expect(getAllHunkChanges(trimmed)).toHaveLength(2);
+        expect(trimmed[0].changes[0]).toEqual({
+          ...hunk.changes[0],
+          content: hunk.changes[0].content.substring(0, changeCharCount),
+        });
+        expect(trimmed[0].changes[1]).toEqual(addedChange);
+      });
+    });
+
+    describe('for multiple hunks', () => {
+      it('does not trim when not necessary', () => {
         const hunks = [
-          createInternalHunkWithChanges([change1]),
-          createInternalHunkWithChanges([change2]),
+          createInternalHunkWithChanges([
+            { content: 'a'.repeat(changeCharCount) },
+          ]),
+          createInternalHunkWithChanges([
+            { content: 'b'.repeat(changeCharCount) },
+          ]),
         ];
 
-        const trimmed = trimHunks({
-          hunks,
+        expect(
+          trimHunkChars({ _trimmedCharCount: changeCharCount * 2, hunks }),
+        ).toEqual(hunks);
+      });
+
+      it('trims chars when there are too many', () => {
+        const hunk1 = createInternalHunkWithChanges([
+          { content: 'a'.repeat(changeCharCount) },
+        ]);
+        const hunk2 = createInternalHunkWithChanges([
+          { content: 'b'.repeat(changeCharCount * 2) },
+        ]);
+
+        const trimmed = trimHunkChars({
+          hunks: [hunk1, hunk2],
           _trimmedCharCount: changeCharCount * 2,
         });
         expect(getAllHunkChanges(trimmed)).toHaveLength(3);
-        expect(trimmed[1].changes[1].content).toEqual(
-          changeContentAddedByTrimmer,
-        );
-        expect(trimmed[1].changes[1].lineNumber).toEqual(undefined);
-        expect(trimmed[1].changes[1].newLineNumber).toEqual(undefined);
-        expect(trimmed[1].changes[1].oldLineNumber).toEqual(undefined);
+        expect(trimmed[0].changes[0]).toEqual(hunk1.changes[0]);
+        expect(trimmed[1].changes[0]).toEqual({
+          ...hunk1.changes[0],
+          content: hunk2.changes[0].content.substring(0, changeCharCount),
+        });
+        expect(trimmed[1].changes[1]).toEqual(addedChange);
       });
     });
   });

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -38,6 +38,7 @@ import {
   SLOW_LOADING_LINE_COUNT,
   codeCanBeHighlighted,
   codeShouldBeTrimmed,
+  contentAddedByTrimmer,
   getAllHunkChanges,
   getLanguageFromMimeType,
   gettext,
@@ -49,11 +50,8 @@ import 'react-diff-view/style/index.css';
 
 const { Profiler } = React;
 
-export const changeContentAddedByTrimmer =
-  '/* diff truncated by code-manager */';
-
 export const addedChange: ChangeInfo = {
-  content: changeContentAddedByTrimmer,
+  content: contentAddedByTrimmer,
   isDelete: false,
   isInsert: false,
   isNormal: true,

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -15,6 +15,7 @@ import tracking from './tracking';
 export const SLOW_LOADING_LINE_COUNT = 2000;
 // This is how many characters we will include in trimmed minfied file content.
 export const MINIFIED_FILE_TRIMMED_CHAR_COUNT = 2000;
+export const contentAddedByTrimmer = '/* truncated by code-manager */';
 
 // Querystring params used by the app.
 export const messageUidQueryParam = 'messageUid';

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -11,10 +11,10 @@ import { changeTypes, CompareInfo } from './reducers/versions';
 import { getCodeLineAnchor } from './components/CodeView/utils';
 import tracking from './tracking';
 
-// This is how many characters of code it takes to slow down the UI.
-export const SLOW_LOADING_CHAR_COUNT = 3000;
-// This is how many characters of code we will include in trimmed content.
-export const TRIMMED_CHAR_COUNT = 2000;
+// This is how many lines of code it takes to slow down the UI.
+export const SLOW_LOADING_LINE_COUNT = 2000;
+// This is how many characters we will include in trimmed minfied file content.
+export const MINIFIED_FILE_TRIMMED_CHAR_COUNT = 2000;
 
 // Querystring params used by the app.
 export const messageUidQueryParam = 'messageUid';
@@ -264,12 +264,23 @@ export const createCodeLineAnchorGetter = ({
   return getCodeLineAnchor;
 };
 
-export const codeShouldBeTrimmed = (
-  codeLength: number,
-  slowLoadingCharCount: number,
-  isMinified: boolean,
-) => {
-  return codeLength >= slowLoadingCharCount || isMinified;
+export const codeShouldBeTrimmed = ({
+  codeCharLength,
+  codeLineLength,
+  isMinified,
+  minifiedFileTrimmedCharCount,
+  slowLoadingLineCount,
+}: {
+  codeCharLength: number;
+  codeLineLength: number;
+  isMinified: boolean;
+  minifiedFileTrimmedCharCount: number;
+  slowLoadingLineCount: number;
+}) => {
+  return (
+    codeLineLength >= slowLoadingLineCount ||
+    (isMinified && codeCharLength > minifiedFileTrimmedCharCount)
+  );
 };
 
 export const sendPerfTiming = ({


### PR DESCRIPTION
Fixes #1507 

Also makes some changes to the way that trimming works, specifically:
- For non-minified files, trimming is based on number of lines, not number of characters.
- For minified files, trimming is based on number of characters.
