### PR TITLE
Turn off debug mode for Google Analytics

### DIFF
--- a/.env
+++ b/.env
@@ -32,3 +32,6 @@ REACT_APP_ENABLE_COMMENTING=true
 REACT_APP_ANALYTICS_HOST=https://www.google-analytics.com
 REACT_APP_TRACKING_ENABLED=true
 REACT_APP_TRACKING_ID=UA-77033033-29
+
+# This is used for local development to toggle debug mode for Google Analytics
+REACT_APP_GA_DEBUG_MODE=false

--- a/.env.common-local
+++ b/.env.common-local
@@ -26,3 +26,6 @@ PUBLIC_URL=/
 # Variables for Google Analytics
 REACT_APP_TRACKING_ENABLED=false
 REACT_APP_TRACKING_ID=UA-77033033-31
+
+# This is used for local development to toggle debug mode for Google Analytics
+REACT_APP_GA_DEBUG_MODE=false

--- a/src/tracking.spec.tsx
+++ b/src/tracking.spec.tsx
@@ -77,7 +77,7 @@ describe(__filename, () => {
       createTracking({ _reactGA, trackingId });
       expect(_reactGA.initialize).toHaveBeenCalledWith(
         trackingId,
-        expect.objectContaining({ debug: true }),
+        expect.objectContaining({ debug: false }),
       );
       expect(_reactGA.set).toHaveBeenCalledWith({ transport: 'beacon' });
     });

--- a/src/tracking.tsx
+++ b/src/tracking.tsx
@@ -46,7 +46,7 @@ export class Tracking {
   constructor({
     _isDoNotTrackEnabled = isDoNotTrackEnabled,
     _reactGA = ReactGA,
-    trackingEnabled = Boolean(process.env.REACT_APP_TRACKING_ENABLED),
+    trackingEnabled = process.env.REACT_APP_TRACKING_ENABLED === 'true',
     trackingId = process.env.REACT_APP_TRACKING_ID,
     // We need to set useMock to true in the tests in order to use a provided
     // mock, because of the check below for
@@ -80,7 +80,9 @@ export class Tracking {
     if (this.trackingEnabled && trackingId) {
       this._reactGA = _reactGA;
       this._reactGA.initialize(trackingId, {
-        debug: process.env.NODE_ENV !== 'production',
+        debug:
+          process.env.NODE_ENV !== 'production' &&
+          process.env.REACT_APP_GA_DEBUG_MODE === 'true',
         titleCase: false,
         gaOptions: {
           siteSpeedSampleRate: 100,


### PR DESCRIPTION
Fixes #1569 

I also found a bug in the way we were handling boolean values from `env` files in `tracking.tsx` which I fixed.