### PR TITLE
LinterMessage link open externally

### DIFF
--- a/src/components/LinterMessage/index.tsx
+++ b/src/components/LinterMessage/index.tsx
@@ -45,7 +45,12 @@ const renderDescription = (description: LinterMessage['description']) => {
         .reduce((allParts: React.ReactNode[], part) => {
           if (urlPattern.test(part)) {
             allParts.push(
-              <Alert.Link key={`link:${part}`} href={part}>
+              <Alert.Link
+                key={`link:${part}`}
+                href={part}
+                rel="noreferrer noopener"
+                target="_blank"
+              >
                 {part}
               </Alert.Link>,
             );


### PR DESCRIPTION
Fixes #328 
- [x] This PR relates to an existing open issue and there are no existing PRs open for the same issue.
- [x] Add a description of the changes introduced in this PR.
- [x] The change has been successfully run locally.

LinterMessage components now open in a new tab using attributes `target="_blank"` and `rel="noreferrer noopener"`.
