### PR TITLE
Remove references to `oldRevision` and `newRevision` from the code

### DIFF
--- a/src/@types/react-diff-view/index.d.ts
+++ b/src/@types/react-diff-view/index.d.ts
@@ -41,8 +41,6 @@ declare module 'react-diff-view' {
     hunks: Hunks;
     oldEndingNewLine: boolean;
     newEndingNewLine: boolean;
-    oldRevision: string;
-    newRevision: string;
     newMode: string;
     oldMode: string;
     type: DiffInfoType;

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -363,9 +363,10 @@ export class DiffViewBase extends React.Component<Props> {
       _trimHunkChars,
       diff,
       isMinified,
-      mimeType,
-      viewType,
       location,
+      mimeType,
+      version,
+      viewType,
     } = this.props;
 
     const options = {
@@ -480,7 +481,7 @@ export class DiffViewBase extends React.Component<Props> {
         {extraMessages.length ? this.renderExtraMessages(extraMessages) : null}
 
         {diff && hunks && (
-          <React.Fragment key={`${diff.oldRevision}-${diff.newRevision}`}>
+          <React.Fragment key={version.id}>
             {this.renderHeader(diff)}
             <FadableContent fade={diffWasTrimmed}>
               <Diff

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -1603,8 +1603,6 @@ describe(__filename, () => {
         version,
       });
 
-      expect(diff).toHaveProperty('oldRevision', String(baseVersionId));
-      expect(diff).toHaveProperty('newRevision', String(headVersionId));
       expect(diff).toHaveProperty('oldMode', externalDiff.mode);
       expect(diff).toHaveProperty('newMode', externalDiff.mode);
       expect(diff).toHaveProperty('oldPath', externalDiff.old_path);

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -979,8 +979,6 @@ export const createInternalHunk = (hunk: ExternalHunk): HunkInfo => {
 };
 
 export const createInternalDiff = ({
-  baseVersionId,
-  headVersionId,
   version,
 }: CreateInternalDiffParams): DiffInfo | null => {
   const GIT_STATUS_TO_TYPE: { [status: string]: DiffInfoType } = {
@@ -994,8 +992,6 @@ export const createInternalDiff = ({
   const { diff } = version.file;
   if (diff) {
     return {
-      newRevision: String(headVersionId),
-      oldRevision: String(baseVersionId),
       hunks: diff.hunks.map(createInternalHunk),
       type: GIT_STATUS_TO_TYPE[diff.mode] || GIT_STATUS_TO_TYPE.M,
       newEndingNewLine: diff.new_ending_new_line,


### PR DESCRIPTION
Fixes #1633 
