### PR TITLE
Introduce different types for external files with content vs diffs

### DIFF
--- a/src/components/CodeOverview/index.spec.tsx
+++ b/src/components/CodeOverview/index.spec.tsx
@@ -15,7 +15,7 @@ import {
   createFakeExternalLinterResult,
   createFakeLocation,
   createFakeRef,
-  fakeVersion,
+  fakeVersionWithContent,
   getInstance,
   shallowUntilTarget,
   simulateLinterProvider,
@@ -47,7 +47,7 @@ describe(__filename, () => {
       _debounce,
       _window: createFakeWindow(),
       content: 'example code content',
-      version: createInternalVersion(fakeVersion),
+      version: createInternalVersion(fakeVersionWithContent),
       ...otherProps,
     };
   };
@@ -159,7 +159,7 @@ describe(__filename, () => {
   };
 
   it('configures LinterProvider', () => {
-    const version = createInternalVersion(fakeVersion);
+    const version = createInternalVersion(fakeVersionWithContent);
     const root = render({ version });
 
     const provider = root.find(LinterProvider);

--- a/src/components/CodeView/index.spec.tsx
+++ b/src/components/CodeView/index.spec.tsx
@@ -31,7 +31,7 @@ import {
   createFakeExternalLinterResult,
   createFakeLocation,
   fakeExternalLinterMessage,
-  fakeVersion,
+  fakeVersionWithContent,
   getInstance,
   shallowUntilTarget,
   simulateCommentList,
@@ -74,7 +74,7 @@ describe(__filename, () => {
       isMinified: false,
       linterMessagesByLine: undefined,
       mimeType: 'mime/type',
-      version: createInternalVersion(fakeVersion),
+      version: createInternalVersion(fakeVersionWithContent),
       ...otherProps,
     };
     return shallowUntilTarget(<CodeView {...props} />, CodeViewBase, {
@@ -377,7 +377,7 @@ describe(__filename, () => {
   });
 
   it('configures LinterProvider', () => {
-    const version = createInternalVersion(fakeVersion);
+    const version = createInternalVersion(fakeVersionWithContent);
     const root = render({ version });
 
     const provider = root.find(LinterProvider);
@@ -602,7 +602,7 @@ describe(__filename, () => {
 
   describe('comment list', () => {
     it('renders a comment list', () => {
-      const version = createInternalVersion(fakeVersion);
+      const version = createInternalVersion(fakeVersionWithContent);
       const { shell } = simulateInlineCommentList({
         content: 'single line of code',
         enableCommenting: true,

--- a/src/components/Comment/index.spec.tsx
+++ b/src/components/Comment/index.spec.tsx
@@ -420,20 +420,24 @@ describe(__filename, () => {
 
     it('does not add/remove listeners with an undefined ref', () => {
       // Make sure this doesn't throw an error.
-      const { root } = setUpStoreAndRender({
-        beginEdit: true,
-        createTextareaRef: () => undefined,
-      });
-      root.unmount();
+      expect(() => {
+        const { root } = setUpStoreAndRender({
+          beginEdit: true,
+          createTextareaRef: () => undefined,
+        });
+        root.unmount();
+      }).not.toThrow();
     });
 
     it('does not add/remove listeners with a null DOM node', () => {
       // Make sure this doesn't throw an error.
-      const { root } = setUpStoreAndRender({
-        beginEdit: true,
-        createTextareaRef: () => React.createRef(),
-      });
-      root.unmount();
+      expect(() => {
+        const { root } = setUpStoreAndRender({
+          beginEdit: true,
+          createTextareaRef: () => React.createRef(),
+        });
+        root.unmount();
+      }).not.toThrow();
     });
   });
 

--- a/src/components/CommentSummary/index.spec.tsx
+++ b/src/components/CommentSummary/index.spec.tsx
@@ -6,7 +6,10 @@ import {
   ExternalComment,
   createInternalComment,
 } from '../../reducers/comments';
-import { createFakeExternalComment, fakeVersion } from '../../test-helpers';
+import {
+  createFakeExternalComment,
+  fakeVersionWithContent,
+} from '../../test-helpers';
 
 import CommentSummary, { PublicProps } from '.';
 
@@ -33,7 +36,7 @@ describe(__filename, () => {
     return {
       filename: null,
       lineno: null,
-      version: fakeVersion,
+      version: fakeVersionWithContent,
       ...props,
     };
   };

--- a/src/components/DiffView/fixtures/largeDiff.tsx
+++ b/src/components/DiffView/fixtures/largeDiff.tsx
@@ -156,7 +156,7 @@ index ba61d34..0000000
 -};
 -
 -// This is how we store file information, but the getVersionFile selector
--// returns more info, which is defined in VersionFile, below.
+-// returns more info, which is defined in VersionFileWithContent, below.
 -type InternalVersionFile = {
 -  content: string;
 -  created: string;
@@ -165,7 +165,7 @@ index ba61d34..0000000
 -  size: number;
 -};
 -
--export type VersionFile = {
+-export type VersionFileWithContent = {
 -  content: string;
 -  created: string;
 -  downloadURL: string | null;
@@ -485,7 +485,7 @@ index ba61d34..0000000
 -  versionId: number,
 -  path: string,
 -  { _log = log } = {},
--): VersionFile | void | null => {
+-): VersionFileWithContent | void | null => {
 -  const version = getVersionInfo(versions, versionId);
 -  const filesForVersion = getVersionFiles(versions, versionId);
 -

--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -38,7 +38,7 @@ import {
   fakeChangeInfo,
   fakeExternalDiff,
   fakeTokens,
-  fakeVersion,
+  fakeVersionWithContent,
   getInstance,
   nextUniqueId,
   shallowUntilTarget,
@@ -79,7 +79,7 @@ describe(__filename, () => {
         enableCommenting={enableCommenting}
         isMinified={false}
         mimeType="text/plain"
-        version={createInternalVersion(fakeVersion)}
+        version={createInternalVersion(fakeVersionWithContent)}
         {...props}
       />,
       DiffViewBase,
@@ -166,10 +166,10 @@ describe(__filename, () => {
     const baseVersionId = 1;
     const headVersionId = 2;
     const version = {
-      ...fakeVersion,
+      ...fakeVersionWithContent,
       id: headVersionId,
       file: {
-        ...fakeVersion.file,
+        ...fakeVersionWithContent.file,
         base_file: {
           id: nextUniqueId(),
         },
@@ -608,8 +608,8 @@ describe(__filename, () => {
 
   it('configures LinterProvider', () => {
     const version = createInternalVersion({
-      ...fakeVersion,
-      id: fakeVersion.id + 1,
+      ...fakeVersionWithContent,
+      id: fakeVersionWithContent.id + 1,
     });
     const root = render({ version });
 
@@ -703,7 +703,7 @@ describe(__filename, () => {
       { line: secondLine, uid: 'second' },
     ];
     const version = createInternalVersion({
-      ...fakeVersion,
+      ...fakeVersionWithContent,
       id: nextUniqueId(),
     });
     const diff = createDiffWithHunks([
@@ -775,7 +775,7 @@ describe(__filename, () => {
     const line = nextUniqueId();
     const externalMessages = [{ line, uid: 'first' }];
     const version = createInternalVersion({
-      ...fakeVersion,
+      ...fakeVersionWithContent,
       id: nextUniqueId(),
     });
     const diff = createDiffWithHunks([
@@ -797,7 +797,7 @@ describe(__filename, () => {
       const CommentListResult = () => <div />;
       const lineNumber = nextUniqueId();
       const version = createInternalVersion({
-        ...fakeVersion,
+        ...fakeVersionWithContent,
         id: nextUniqueId(),
       });
       const diff = createDiffWithHunks([
@@ -854,7 +854,7 @@ describe(__filename, () => {
       const _changeCanBeCommentedUpon = jest.fn().mockReturnValue(false);
       const lineNumber = nextUniqueId();
       const version = createInternalVersion({
-        ...fakeVersion,
+        ...fakeVersionWithContent,
         id: nextUniqueId(),
       });
       const diff = createDiffWithHunks([
@@ -875,7 +875,7 @@ describe(__filename, () => {
     it('does not render inline comments when the feature is disabled', () => {
       const line = nextUniqueId();
       const version = createInternalVersion({
-        ...fakeVersion,
+        ...fakeVersionWithContent,
         id: nextUniqueId(),
       });
       const diff = createDiffWithHunks([
@@ -1162,7 +1162,7 @@ describe(__filename, () => {
       enableCommenting = true,
       renderDefault = jest.fn(),
       side = 'new',
-      version = createInternalVersion(fakeVersion),
+      version = createInternalVersion(fakeVersionWithContent),
       wrapInAnchor = jest.fn().mockReturnValue(defaultGutter),
     }: Partial<ReactDiffView.RenderGutterParams> &
       RenderParams & {
@@ -1197,7 +1197,7 @@ describe(__filename, () => {
       const className = 'test-class';
       const defaultGutter = <div className={className} />;
       const renderDefault = jest.fn();
-      const version = createInternalVersion(fakeVersion);
+      const version = createInternalVersion(fakeVersionWithContent);
       const wrapInAnchor = jest.fn().mockReturnValue(defaultGutter);
       const gutter = _renderGutter({
         change,

--- a/src/components/FileMetadata/index.spec.tsx
+++ b/src/components/FileMetadata/index.spec.tsx
@@ -4,9 +4,12 @@ import { shallow } from 'enzyme';
 import {
   actions as versionActions,
   getVersionFile,
-  VersionFile,
+  VersionFileWithContent,
 } from '../../reducers/versions';
-import { fakeVersion, createStoreWithVersion } from '../../test-helpers';
+import {
+  fakeVersionWithContent,
+  createStoreWithVersion,
+} from '../../test-helpers';
 import styles from './styles.module.scss';
 import { formatFilesize } from '../../utils';
 import { makeApiURL } from '../../api';
@@ -15,7 +18,7 @@ import FileMetadata from '.';
 
 describe(__filename, () => {
   const _getVersionFile = (props = {}) => {
-    const version = fakeVersion;
+    const version = fakeVersionWithContent;
     const store = createStoreWithVersion({ version });
     store.dispatch(
       versionActions.loadVersionFile({
@@ -29,16 +32,19 @@ describe(__filename, () => {
         store.getState().versions,
         version.id,
         version.file.selected_file,
-      ) as VersionFile),
+      ) as VersionFileWithContent),
       ...props,
     };
   };
 
   it('renders metadata for a file', () => {
     const file = _getVersionFile();
-    const root = shallow(<FileMetadata file={file} />);
+    const versionString = '1.2';
+    const root = shallow(
+      <FileMetadata file={file} versionString={versionString} />,
+    );
 
-    expect(root.find(`.${styles.version}`)).toHaveText(file.versionString);
+    expect(root.find(`.${styles.version}`)).toHaveText(versionString);
     expect(root.find(`.${styles.sha256}`)).toHaveText(file.sha256);
 
     const downloadLink = root.find(`.${styles.downloadURL}`).find('a');
@@ -54,7 +60,7 @@ describe(__filename, () => {
   it('renders a formatted filesize', () => {
     const size = 12345;
     const file = _getVersionFile({ size });
-    const root = shallow(<FileMetadata file={file} />);
+    const root = shallow(<FileMetadata file={file} versionString="1.2" />);
 
     expect(root.find(`.${styles.size}`)).toHaveText(formatFilesize(size));
   });

--- a/src/components/FileMetadata/index.tsx
+++ b/src/components/FileMetadata/index.tsx
@@ -1,20 +1,21 @@
 import * as React from 'react';
 
-import { VersionFile } from '../../reducers/versions';
+import { VersionFileWithContent } from '../../reducers/versions';
 import styles from './styles.module.scss';
 import { formatFilesize, gettext } from '../../utils';
 import { makeApiURL } from '../../api';
 
 type PublicProps = {
-  file: VersionFile;
+  file: VersionFileWithContent;
+  versionString: string;
 };
 
-const FileMetadataBase = ({ file }: PublicProps) => {
+const FileMetadataBase = ({ file, versionString }: PublicProps) => {
   return (
     <div className={styles.FileMetadata}>
       <dl>
         <dt>{gettext('Version')}</dt>
-        <dd className={styles.version}>{file.versionString}</dd>
+        <dd className={styles.version}>{versionString}</dd>
         <dt>{gettext('Size')}</dt>
         <dd className={styles.size}>{formatFilesize(file.size)}</dd>
         <dt>{gettext('SHA256 hash')}</dt>

--- a/src/components/FileTree/index.spec.tsx
+++ b/src/components/FileTree/index.spec.tsx
@@ -17,7 +17,7 @@ import {
 import {
   createFakeLogger,
   dispatchLoadVersionInfo,
-  fakeVersion,
+  fakeVersionWithContent,
   getInstance,
   shallowUntilTarget,
   spyOn,
@@ -32,7 +32,7 @@ describe(__filename, () => {
   describe('FileTree', () => {
     const getVersion = ({
       store = configureStore(),
-      version = fakeVersion,
+      version = fakeVersionWithContent,
     }): Version => {
       dispatchLoadVersionInfo({ store, version });
 

--- a/src/components/FileTreeNode/index.spec.tsx
+++ b/src/components/FileTreeNode/index.spec.tsx
@@ -23,7 +23,7 @@ import {
   createFakeRef,
   createStoreWithVersion,
   fakeExternalLinterMessage,
-  fakeVersion,
+  fakeVersionWithContent,
   shallowUntilTarget,
   simulateLinterProvider,
   spyOn,
@@ -86,7 +86,7 @@ describe(__filename, () => {
     versionId = 12349876,
     comparedToVersionId = 123,
     store = createStoreWithVersion({
-      version: { ...fakeVersion, id: versionId },
+      version: { ...fakeVersionWithContent, id: versionId },
     }),
     ...props
   }: RenderParams = {}) => {
@@ -135,7 +135,7 @@ describe(__filename, () => {
     messages = [fakeExternalLinterMessage],
     treefoldRenderProps = {},
   }) => {
-    const externalVersion = fakeVersion;
+    const externalVersion = fakeVersionWithContent;
     const comparedToVersionId = 22;
     const store = createStoreWithVersion({ version: externalVersion });
     store.dispatch(
@@ -238,9 +238,9 @@ describe(__filename, () => {
 
   it('requires a loaded version', () => {
     const store = configureStore();
-    expect(() => render({ store, versionId: fakeVersion.id + 1 })).toThrow(
-      /No version exists/,
-    );
+    expect(() =>
+      render({ store, versionId: fakeVersionWithContent.id + 1 }),
+    ).toThrow(/No version exists/);
   });
 
   it('renders a simple directory node', () => {
@@ -373,7 +373,7 @@ describe(__filename, () => {
   });
 
   it('marks a file node as selected', () => {
-    const externalVersion = fakeVersion;
+    const externalVersion = fakeVersionWithContent;
     const store = createStoreWithVersion({ version: externalVersion });
 
     const root = renderWithLinterProvider({
@@ -815,7 +815,7 @@ describe(__filename, () => {
   });
 
   it('configures LinterProvider', () => {
-    const externalVersion = fakeVersion;
+    const externalVersion = fakeVersionWithContent;
     const store = createStoreWithVersion({ version: externalVersion });
     const root = render({ store, versionId: externalVersion.id });
 
@@ -850,7 +850,7 @@ describe(__filename, () => {
   });
 
   it('focuses a node when selected and not already in focus', () => {
-    const externalVersion = fakeVersion;
+    const externalVersion = fakeVersionWithContent;
     const nodeId = externalVersion.file.selected_file;
 
     const store = createStoreWithVersion({ version: externalVersion });
@@ -885,7 +885,7 @@ describe(__filename, () => {
   it('does not focus a node when not selected', () => {
     const versionId = 8765;
     const store = createStoreWithVersion({
-      version: { ...fakeVersion, id: versionId },
+      version: { ...fakeVersionWithContent, id: versionId },
     });
     // Make sure the path is not in focus.
     store.dispatch(
@@ -906,7 +906,7 @@ describe(__filename, () => {
   });
 
   it('does not focus a node when selected and already in focus', () => {
-    const externalVersion = fakeVersion;
+    const externalVersion = fakeVersionWithContent;
     const store = createStoreWithVersion({ version: externalVersion });
     const nodeId = externalVersion.file.selected_file;
 

--- a/src/components/KeyboardShortcuts/index.spec.tsx
+++ b/src/components/KeyboardShortcuts/index.spec.tsx
@@ -25,7 +25,7 @@ import {
   createStoreWithVersion,
   fakeAction,
   fakeExternalLinterMessage,
-  fakeVersion,
+  fakeVersionWithContent,
   fakeVersionEntry,
   fakeVersionWithDiff,
   getInstance,
@@ -52,10 +52,10 @@ describe(__filename, () => {
     pathList = ['file1.js'],
     versionId = 321,
     externalVersion = {
-      ...fakeVersion,
+      ...fakeVersionWithContent,
       id: versionId,
       file: {
-        ...fakeVersion.file,
+        ...fakeVersionWithContent.file,
       },
       // eslint-disable-next-line @typescript-eslint/camelcase
       file_entries: pathList.reduce((pathMap, path: string) => {
@@ -73,7 +73,7 @@ describe(__filename, () => {
   }: {
     pathList?: string[];
     versionId?: number;
-    externalVersion?: typeof fakeVersion;
+    externalVersion?: typeof fakeVersionWithContent;
     store?: Store;
   } = {}) => {
     store.dispatch(

--- a/src/components/LinterProvider/index.spec.tsx
+++ b/src/components/LinterProvider/index.spec.tsx
@@ -13,9 +13,9 @@ import {
   createContextWithFakeRouter,
   createFakeExternalLinterResult,
   createFakeThunk,
-  fakeVersion,
+  fakeVersionWithContent,
   fakeVersionEntry,
-  fakeVersionFile,
+  fakeVersionFileWithContent,
   shallowUntilTarget,
   spyOn,
 } from '../../test-helpers';
@@ -36,7 +36,7 @@ describe(__filename, () => {
 
   const render = ({
     children = jest.fn(),
-    version = createInternalVersion(fakeVersion),
+    version = createInternalVersion(fakeVersionWithContent),
     store = configureStore(),
     ...moreProps
   }: RenderParams = {}) => {
@@ -89,9 +89,9 @@ describe(__filename, () => {
     store: Store;
   }) => {
     const version = createInternalVersion({
-      ...fakeVersion,
+      ...fakeVersionWithContent,
       file: {
-        ...fakeVersionFile,
+        ...fakeVersionFileWithContent,
         selected_file: path,
       },
       file_entries: { [path]: { ...fakeVersionEntry, path } },
@@ -136,8 +136,8 @@ describe(__filename, () => {
   it('dispatches fetchLinterMessagesIfNeeded when linterMessages is undefined', () => {
     const url = '/path/to/validation.json';
     const version = createInternalVersion({
-      ...fakeVersion,
-      id: fakeVersion.id + 1,
+      ...fakeVersionWithContent,
+      id: fakeVersionWithContent.id + 1,
       validation_url_json: url,
     });
 
@@ -176,9 +176,9 @@ describe(__filename, () => {
 
     // Create a version where the manifestPath is selected.
     const version = createInternalVersion({
-      ...fakeVersion,
+      ...fakeVersionWithContent,
       file: {
-        ...fakeVersionFile,
+        ...fakeVersionFileWithContent,
         selected_file: manifestPath,
       },
       file_entries: {
@@ -260,9 +260,9 @@ describe(__filename, () => {
 
     // Create a version with manifestPath selected.
     const version = createInternalVersion({
-      ...fakeVersion,
+      ...fakeVersionWithContent,
       file: {
-        ...fakeVersionFile,
+        ...fakeVersionFileWithContent,
         selected_file: manifestPath,
       },
       file_entries: {
@@ -298,7 +298,7 @@ describe(__filename, () => {
     const children = jest.fn();
     const store = configureStore();
 
-    const version = createInternalVersion(fakeVersion);
+    const version = createInternalVersion(fakeVersionWithContent);
     store.dispatch(
       linterActions.beginFetchLinterResult({ versionId: version.id }),
     );

--- a/src/components/Navbar/index.spec.tsx
+++ b/src/components/Navbar/index.spec.tsx
@@ -18,7 +18,7 @@ import {
   createStoreWithVersionComments,
   dispatchLoadVersionInfo,
   fakeUser,
-  fakeVersion,
+  fakeVersionWithContent,
   fakeVersionAddon,
   nextUniqueId,
   shallowUntilTarget,
@@ -85,10 +85,10 @@ describe(__filename, () => {
   } = {}) => {
     return createStoreWithVersion({
       version: {
-        ...fakeVersion,
+        ...fakeVersionWithContent,
         id,
         version: versionString,
-        addon: { ...fakeVersion.addon, id: addonId },
+        addon: { ...fakeVersionWithContent.addon, id: addonId },
       },
       makeCurrent: true,
     });
@@ -99,7 +99,7 @@ describe(__filename, () => {
       const addonName = 'addon name example';
       const store = createStoreWithVersion({
         version: {
-          ...fakeVersion,
+          ...fakeVersionWithContent,
           addon: { ...fakeVersionAddon, name: { 'en-US': addonName } },
         },
         makeCurrent: true,
@@ -114,7 +114,7 @@ describe(__filename, () => {
       const slug = 'some-slug';
       const store = createStoreWithVersion({
         version: {
-          ...fakeVersion,
+          ...fakeVersionWithContent,
           addon: { ...fakeVersionAddon, slug },
         },
         makeCurrent: true,
@@ -385,7 +385,7 @@ describe(__filename, () => {
       const currentBaseVersionId = nextUniqueId();
       dispatchLoadVersionInfo({
         store,
-        version: { ...fakeVersion, id: currentBaseVersionId },
+        version: { ...fakeVersionWithContent, id: currentBaseVersionId },
       });
       store.dispatch(
         versionsActions.setCurrentBaseVersionId({
@@ -426,7 +426,11 @@ describe(__filename, () => {
       id?: number;
       versionString?: string;
     }) => {
-      const baseVersion = { ...fakeVersion, id, version: versionString };
+      const baseVersion = {
+        ...fakeVersionWithContent,
+        id,
+        version: versionString,
+      };
       dispatchLoadVersionInfo({ store, version: baseVersion });
       store.dispatch(
         versionsActions.setCurrentBaseVersionId({ versionId: baseVersion.id }),

--- a/src/components/VersionChooser/index.spec.tsx
+++ b/src/components/VersionChooser/index.spec.tsx
@@ -22,7 +22,7 @@ import {
   createFakeHistory,
   createFakeThunk,
   createStoreWithVersion,
-  fakeVersion,
+  fakeVersionWithContent,
   fakeVersionsList,
   fakeVersionsListItem,
   nextUniqueId,
@@ -533,7 +533,7 @@ describe(__filename, () => {
     const headVersionId = nextUniqueId();
 
     const store = createStoreWithVersion({
-      version: { ...fakeVersion, id: headVersionId },
+      version: { ...fakeVersionWithContent, id: headVersionId },
     });
     const { addonId } = _loadVersionsList({ store });
 

--- a/src/components/VersionFileViewer/index.spec.tsx
+++ b/src/components/VersionFileViewer/index.spec.tsx
@@ -28,11 +28,11 @@ import {
   createFakeExternalLinterResult,
   dispatchLoadVersionInfo,
   fakeExternalLinterMessage,
-  fakeVersion,
+  fakeVersionWithContent,
   fakeVersionEntry,
   getContentShellPanel,
   simulateLinterProvider,
-  fakeVersionFile,
+  fakeVersionFileWithContent,
 } from '../../test-helpers';
 import { flattenDiffChanges } from '../../utils';
 import styles from './styles.module.scss';
@@ -62,9 +62,9 @@ describe(__filename, () => {
     //   file: createInternalVersionFile(...),
     // };
     const version = {
-      ...fakeVersion,
+      ...fakeVersionWithContent,
       file: {
-        ...fakeVersion.file,
+        ...fakeVersionWithContent.file,
         content: fileContent,
         // eslint-disable-next-line @typescript-eslint/camelcase
         selected_file: path,
@@ -72,7 +72,7 @@ describe(__filename, () => {
       },
       // eslint-disable-next-line @typescript-eslint/camelcase
       file_entries: {
-        ...fakeVersion.file_entries,
+        ...fakeVersionWithContent.file_entries,
         [path]: entry || { ...fakeVersionEntry, filename: path, path },
       },
     };
@@ -216,9 +216,13 @@ describe(__filename, () => {
   it('renders a message in the information panel for the deleted file', () => {
     const filename = 'someFileName.js';
     const version = createInternalVersion({
-      ...fakeVersion,
+      ...fakeVersionWithContent,
       // eslint-disable-next-line @typescript-eslint/camelcase
-      file: { ...fakeVersionFile, filename, selected_file: filename },
+      file: {
+        ...fakeVersionFileWithContent,
+        filename,
+        selected_file: filename,
+      },
     });
     const entryStatusMap: EntryStatusMap = {
       [filename]: 'D',

--- a/src/components/VersionFileViewer/index.spec.tsx
+++ b/src/components/VersionFileViewer/index.spec.tsx
@@ -217,10 +217,10 @@ describe(__filename, () => {
     const filename = 'someFileName.js';
     const version = createInternalVersion({
       ...fakeVersionWithContent,
-      // eslint-disable-next-line @typescript-eslint/camelcase
       file: {
         ...fakeVersionFileWithContent,
         filename,
+        // eslint-disable-next-line @typescript-eslint/camelcase
         selected_file: filename,
       },
     });

--- a/src/components/VersionFileViewer/index.tsx
+++ b/src/components/VersionFileViewer/index.tsx
@@ -14,7 +14,7 @@ import {
   CompareInfo,
   EntryStatusMap,
   Version,
-  VersionFile,
+  VersionFileWithContent,
   getInsertedLines,
 } from '../../reducers/versions';
 import { AnyReactNode } from '../../typeUtils';
@@ -33,7 +33,7 @@ export type PublicProps = {
   comparedToVersionId: number | null;
   compareInfo?: CompareInfo | null | undefined;
   entryStatusMap?: EntryStatusMap;
-  file: VersionFile | null | undefined;
+  file: VersionFileWithContent | null | undefined;
   getCodeLineAnchor?: GetCodeLineAnchor;
   onSelectFile: FileTreeProps['onSelect'];
   version: Version | undefined | null;
@@ -81,7 +81,7 @@ const VersionFileViewer = ({
 
     const renderFileInfo = () => {
       if (file) {
-        return <FileMetadata file={file} />;
+        return <FileMetadata file={file} versionString={versionString} />;
       }
 
       if (entryStatusMap && entryStatusMap[selectedPath] === 'D') {

--- a/src/pages/Browse/index.spec.tsx
+++ b/src/pages/Browse/index.spec.tsx
@@ -11,9 +11,9 @@ import {
   createFakeThunk,
   dispatchLoadVersionInfo,
   externallyLocalizedString,
-  fakeVersion,
+  fakeVersionWithContent,
   fakeVersionEntry,
-  fakeVersionFile,
+  fakeVersionFileWithContent,
   shallowUntilTarget,
   spyOn,
   nextUniqueId,
@@ -92,7 +92,7 @@ describe(__filename, () => {
 
   const _loadVersionAndFile = ({
     store = configureStore(),
-    version = { ...fakeVersion, id: nextUniqueId() },
+    version = { ...fakeVersionWithContent, id: nextUniqueId() },
     setCurrentVersionId = true,
     loadVersionFile = true,
   }) => {
@@ -123,14 +123,14 @@ describe(__filename, () => {
     versionId = nextUniqueId(),
   } = {}) => {
     const version = {
-      ...fakeVersion,
+      ...fakeVersionWithContent,
       id: versionId,
       file: {
-        ...fakeVersion.file,
+        ...fakeVersionWithContent.file,
         selected_file: initialPath,
       },
       file_entries: {
-        ...fakeVersion.file_entries,
+        ...fakeVersionWithContent.file_entries,
         ...extraFileEntries,
       },
     };
@@ -234,7 +234,7 @@ describe(__filename, () => {
   it('dispatches setCurrentVersionId when switching versions', () => {
     const newVersionId = 789;
     const oldVersionId = 987;
-    const version = { ...fakeVersion, id: newVersionId };
+    const version = { ...fakeVersionWithContent, id: newVersionId };
     const store = configureStore();
     store.dispatch(
       versionsActions.setCurrentVersionId({ versionId: oldVersionId }),
@@ -251,10 +251,10 @@ describe(__filename, () => {
 
   it('renders a VersionFileViewer', () => {
     const version = {
-      ...fakeVersion,
+      ...fakeVersionWithContent,
       id: 87652,
       file: {
-        ...fakeVersion.file,
+        ...fakeVersionWithContent.file,
         id: 991234,
       },
     };
@@ -279,9 +279,9 @@ describe(__filename, () => {
     const path = 'image.png';
     const downloadUrl = '/some/download/url/';
     const version = {
-      ...fakeVersion,
+      ...fakeVersionWithContent,
       file: {
-        ...fakeVersionFile,
+        ...fakeVersionFileWithContent,
         download_url: downloadUrl,
         mime_category: 'image' as VersionEntryType,
         selected_file: path,
@@ -299,7 +299,7 @@ describe(__filename, () => {
   });
 
   it('renders a loading message when we do not have the content of a file yet', () => {
-    const version = fakeVersion;
+    const version = fakeVersionWithContent;
 
     const store = configureStore();
     _loadVersionAndFile({ store, version });
@@ -322,7 +322,7 @@ describe(__filename, () => {
 
   it('dispatches viewVersionFile without preserving the URL hash when a file is selected', () => {
     const addonId = 123456;
-    const version = { ...fakeVersion, id: 98765 };
+    const version = { ...fakeVersionWithContent, id: 98765 };
     const path = 'some-path';
 
     const store = configureStore();
@@ -503,7 +503,7 @@ describe(__filename, () => {
   });
 
   it('does not dispatch fetchVersion on mount if a version is already loaded', () => {
-    const version = fakeVersion;
+    const version = fakeVersionWithContent;
 
     const store = configureStore();
     _loadVersionAndFile({ store, version });
@@ -540,7 +540,7 @@ describe(__filename, () => {
   });
 
   it('does not dispatch anything on update when an API error has occured', () => {
-    const version = fakeVersion;
+    const version = fakeVersionWithContent;
     const store = configureStore();
     _loadVersionAndFile({ store, version });
 
@@ -593,10 +593,10 @@ describe(__filename, () => {
     const name = 'AdBlockPlus';
     const versionString = '1.0-beta';
     const version = {
-      ...fakeVersion,
-      id: fakeVersion.id + 1,
+      ...fakeVersionWithContent,
+      id: fakeVersionWithContent.id + 1,
       addon: {
-        ...fakeVersion.addon,
+        ...fakeVersionWithContent.addon,
         name: externallyLocalizedString(name),
       },
       version: versionString,
@@ -709,8 +709,8 @@ describe(__filename, () => {
     const addonId = nextUniqueId();
     const versionId = nextUniqueId();
     const version = {
-      ...fakeVersion,
-      addon: { ...fakeVersion.addon, id: addonId },
+      ...fakeVersionWithContent,
+      addon: { ...fakeVersionWithContent.addon, id: addonId },
       id: versionId,
     };
     const store = configureStore();
@@ -750,8 +750,8 @@ describe(__filename, () => {
     const addonId = nextUniqueId();
     const versionId = nextUniqueId();
     const version = {
-      ...fakeVersion,
-      addon: { ...fakeVersion.addon, id: addonId },
+      ...fakeVersionWithContent,
+      addon: { ...fakeVersionWithContent.addon, id: addonId },
       id: versionId,
     };
     const store = configureStore();

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -10,7 +10,7 @@ import { ApiState } from '../../reducers/api';
 import VersionFileViewer from '../../components/VersionFileViewer';
 import {
   Version,
-  VersionFile,
+  VersionFileWithContent,
   fetchVersion,
   fetchVersionFile,
   getVersionFile,
@@ -50,12 +50,12 @@ type PropsFromRouter = {
 
 type PropsFromState = {
   apiState: ApiState;
-  file: VersionFile | null | undefined;
+  file: VersionFileWithContent | null | undefined;
   fileIsLoading: boolean;
   fileTreeComparedToVersionId: number | null;
   fileTreeVersionId: number | undefined;
   nextFilePath: string | undefined;
-  nextFile: VersionFile | null | undefined;
+  nextFile: VersionFileWithContent | null | undefined;
   nextFileIsLoading: boolean;
   version: Version | undefined | null;
   currentBaseVersionId: number | null | undefined | false;

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -12,7 +12,7 @@ import {
   createStoreWithVersion,
   dispatchLoadVersionInfo,
   externallyLocalizedString,
-  fakeVersion,
+  fakeVersionWithContent,
   fakeVersionWithDiff,
   shallowUntilTarget,
   spyOn,
@@ -159,10 +159,10 @@ describe(__filename, () => {
           // Make a version with file content out of the given version
           // diff response.
           version: {
-            ...fakeVersion,
+            ...fakeVersionWithContent,
             id: version.id,
             file: {
-              ...fakeVersion.file,
+              ...fakeVersionWithContent.file,
               ...version.file,
             },
           },
@@ -1027,7 +1027,7 @@ describe(__filename, () => {
       store.dispatch(
         fileTreeActions.buildTree({
           version: createInternalVersion({
-            ...fakeVersion,
+            ...fakeVersionWithContent,
             id: forVersionId,
           }),
           comparedToVersionId,
@@ -1330,7 +1330,7 @@ describe(__filename, () => {
       const store = configureStore();
       dispatchLoadVersionInfo({
         store,
-        version: { ...fakeVersion, id: headVersionId },
+        version: { ...fakeVersionWithContent, id: headVersionId },
       });
       store.dispatch(
         versionsActions.loadDiff({

--- a/src/pages/Compare/index.tsx
+++ b/src/pages/Compare/index.tsx
@@ -12,7 +12,7 @@ import {
   CompareInfo,
   EntryStatusMap,
   Version,
-  VersionFile,
+  VersionFileWithContent,
   fetchDiff,
   fetchVersionFile,
   isFileLoading,
@@ -54,7 +54,7 @@ type PropsFromState = {
   currentBaseVersionId: number | null | undefined | false;
   currentVersionId: number | null | undefined | false;
   nextCompareInfo: CompareInfo | null | undefined;
-  nextFile: VersionFile | null | undefined;
+  nextFile: VersionFileWithContent | null | undefined;
   nextFileIsLoading: boolean;
   nextFilePath: string | undefined;
   entryStatusMap: EntryStatusMap | undefined;
@@ -63,7 +63,7 @@ type PropsFromState = {
   path: string | undefined;
   selectedPath: string | null;
   version: Version | undefined | null;
-  versionFile: VersionFile | undefined | null;
+  versionFile: VersionFileWithContent | undefined | null;
   versionFileIsLoading: boolean;
 };
 

--- a/src/pages/Index/index.spec.tsx
+++ b/src/pages/Index/index.spec.tsx
@@ -64,9 +64,11 @@ describe(__filename, () => {
   });
 
   it('will not throw an error when simulation is not allowed', () => {
-    const root = render({ allowErrorSimulation: false });
+    expect(() => {
+      const root = render({ allowErrorSimulation: false });
 
-    getInstance<IndexBase>(root).throwAnError();
+      getInstance<IndexBase>(root).throwAnError();
+    }).not.toThrow();
   });
 
   it('logs a simulated error', () => {
@@ -79,10 +81,12 @@ describe(__filename, () => {
   });
 
   it('logs a simulated error with console', () => {
-    const root = render({ allowErrorSimulation: true });
+    expect(() => {
+      const root = render({ allowErrorSimulation: true });
 
-    // Make sure this doesn't throw an error.
-    root.find(`.${styles.logAnErrorWithConsoleButton}`).simulate('click');
+      // Make sure this doesn't throw an error.
+      root.find(`.${styles.logAnErrorWithConsoleButton}`).simulate('click');
+    }).not.toThrow();
   });
 
   it('will not log an error when simulation is not allowed', () => {

--- a/src/reducers/fileTree.spec.tsx
+++ b/src/reducers/fileTree.spec.tsx
@@ -31,7 +31,7 @@ import {
   createFakeLocation,
   createFakeThunk,
   createVersionWithInternalEntries,
-  fakeVersion,
+  fakeVersionWithContent,
   fakeVersionEntry,
   getFakeVersionAndPathList,
   nextUniqueId,
@@ -42,7 +42,7 @@ import { getLocalizedString } from '../utils';
 describe(__filename, () => {
   describe('reducer', () => {
     it('builds and loads a tree', () => {
-      const version = createInternalVersion(fakeVersion);
+      const version = createInternalVersion(fakeVersionWithContent);
       const comparedToVersionId = nextUniqueId();
       const state = reducer(
         undefined,
@@ -62,14 +62,14 @@ describe(__filename, () => {
         undefined,
         actions.buildTree({
           comparedToVersionId: null,
-          version: createInternalVersion(fakeVersion),
+          version: createInternalVersion(fakeVersionWithContent),
         }),
       );
       state = reducer(
         state,
         versionsActions.loadVersionInfo({
           updatePathInfo: true,
-          version: fakeVersion,
+          version: fakeVersionWithContent,
         }),
       );
 
@@ -87,14 +87,17 @@ describe(__filename, () => {
         undefined,
         actions.buildTree({
           comparedToVersionId: null,
-          version: createInternalVersion({ ...fakeVersion, id: oldVerisonId }),
+          version: createInternalVersion({
+            ...fakeVersionWithContent,
+            id: oldVerisonId,
+          }),
         }),
       );
       state = reducer(
         state,
         versionsActions.loadVersionInfo({
           updatePathInfo: true,
-          version: { ...fakeVersion, id: newVersionId },
+          version: { ...fakeVersionWithContent, id: newVersionId },
         }),
       );
 
@@ -108,7 +111,7 @@ describe(__filename, () => {
 
   describe('getTree', () => {
     it('returns a tree', () => {
-      const version = createInternalVersion(fakeVersion);
+      const version = createInternalVersion(fakeVersionWithContent);
       const state = reducer(
         undefined,
         actions.buildTree({ comparedToVersionId: null, version }),
@@ -118,15 +121,21 @@ describe(__filename, () => {
     });
 
     it('returns undefined if there is no tree loaded', () => {
-      const version = createInternalVersion(fakeVersion);
+      const version = createInternalVersion(fakeVersionWithContent);
       const state = initialState;
 
       expect(getTree(state, version.id)).toEqual(undefined);
     });
 
     it('returns undefined if a version is requested that has not been loaded', () => {
-      const version1 = createInternalVersion({ ...fakeVersion, id: 1 });
-      const version2 = createInternalVersion({ ...fakeVersion, id: 2 });
+      const version1 = createInternalVersion({
+        ...fakeVersionWithContent,
+        id: 1,
+      });
+      const version2 = createInternalVersion({
+        ...fakeVersionWithContent,
+        id: 2,
+      });
       const state = reducer(
         undefined,
         actions.buildTree({ comparedToVersionId: null, version: version2 }),

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -72,7 +72,6 @@ import {
   fakeVersionAddon,
   fakeVersionEntry,
   fakeVersionFileWithContent,
-  fakeVersionFileWithDiff,
   fakeVersionWithDiff,
   fakeVersionsList,
   fakeVersionsListItem,

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -51,7 +51,7 @@ export type ExternalVersionEntry = {
   status?: VersionEntryStatus;
 };
 
-type PartialExternalVersionFile = {
+export type PartialExternalVersionFile = {
   download_url: string | null;
   filename: string;
   id: number;
@@ -70,7 +70,7 @@ export type ExternalVersionAddon = {
   slug: string;
 };
 
-type PartialExternalVersion = {
+export type PartialExternalVersion = {
   addon: ExternalVersionAddon;
   channel: string;
   has_been_validated: boolean;
@@ -154,34 +154,19 @@ export type ExternalVersionWithDiffFileOnly = {
   file: ExternalVersionFileWithDiff;
 };
 
-// This is how we store file information, but the getVersionFile selector
-// returns more info, which is defined in VersionFile, below.
-type InternalVersionFile = {
-  content: string;
+type PartialVersionFile = {
   downloadURL: string | null;
   filename: string;
+  fileType: VersionEntryType;
   id: number;
   isMinified: boolean;
   mimeType: string;
   sha256: string;
   size: number;
-  fileType: VersionEntryType;
 };
 
-export type VersionFile = {
+export type VersionFileWithContent = PartialVersionFile & {
   content: string;
-  downloadURL: string | null;
-  // This is the basename of the file.
-  filename: string;
-  id: number;
-  isMinified: boolean;
-  mimeType: string;
-  // This is the relative path to the file, including directories.
-  path: string;
-  sha256: string;
-  size: number;
-  fileType: VersionEntryType;
-  versionString: string;
 };
 
 export type VersionEntry = {
@@ -401,7 +386,7 @@ export type VersionsState = {
   versionFiles: {
     [versionId: number]: {
       [path: string]:
-        | InternalVersionFile // data successfully loaded
+        | VersionFileWithContent // data successfully loaded
         | null // an error has occured
         | undefined; // data not fetched yet
     };
@@ -446,7 +431,7 @@ export const getParentFolders = (path: string): string[] => {
 
 export const createInternalVersionFile = (
   file: ExternalVersionFileWithContent,
-): InternalVersionFile => {
+): VersionFileWithContent => {
   return {
     content: file.content,
     downloadURL: file.download_url,
@@ -611,7 +596,7 @@ export const getVersionFile = (
   versions: VersionsState,
   versionId: number,
   path: string,
-): VersionFile | undefined | null => {
+): VersionFileWithContent | undefined | null => {
   const version = getVersionInfo(versions, versionId);
   const filesForVersion = getVersionFiles(versions, versionId);
 
@@ -625,11 +610,7 @@ export const getVersionFile = (
     }
 
     if (file) {
-      return {
-        ...file,
-        path,
-        versionString: version.versionString,
-      };
+      return file;
     }
   }
 

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -37,10 +37,13 @@ import {
   ExternalVersionAddon,
   ExternalVersionEntry,
   ExternalVersionFileWithContent,
+  ExternalVersionFileWithDiff,
   ExternalVersionWithContent,
   ExternalVersionWithDiff,
   ExternalVersionsList,
   ExternalVersionsListItem,
+  PartialExternalVersion,
+  PartialExternalVersionFile,
   Version,
   VersionEntryType,
   actions as versionsActions,
@@ -95,50 +98,24 @@ export const createFakeEntry = (
   };
 };
 
-export const fakeVersionFile: ExternalVersionFileWithContent = Object.freeze({
-  content: 'some file content',
-  created: '2017-08-15T12:01:13Z',
+const partialFakeVersionFile: PartialExternalVersionFile = {
   download_url: 'https://example.org/download/manifest.json',
   filename: 'manifest.json',
-  hash: 'some-hash',
   id: 789,
-  is_mozilla_signed_extension: true,
-  is_restart_required: false,
-  is_webextension: true,
   mime_category: 'text',
   mimetype: 'application/json',
-  permissions: [],
-  platform: 'all',
   selected_file: 'manifest.json',
   sha256: 'some-sha',
   size: 123,
-  status: 'public',
-  url: 'http://example.com/edit/',
   uses_unknown_minified_code: false,
-});
+};
 
-export const fakeVersionAddon: ExternalVersionAddon = Object.freeze({
-  icon_url: 'some-icon-url',
-  id: 111,
-  name: { 'en-US': 'addon name' },
-  slug: 'addon-slug',
-});
-
-export const fakeVersion: ExternalVersionWithContent = Object.freeze({
-  addon: fakeVersionAddon,
-  channel: 'some channel',
-  file: fakeVersionFile,
-  file_entries: {
-    'manifest.json': fakeVersionEntry,
+export const fakeVersionFileWithContent: ExternalVersionFileWithContent = Object.freeze(
+  {
+    ...partialFakeVersionFile,
+    content: 'some file content',
   },
-  has_been_validated: true,
-  id: 123,
-  reviewed: '2017-08-15T12:01:13Z',
-  url: 'http://example.com/',
-  validation_url: 'http://example.com/validation/',
-  validation_url_json: 'http://example.com/validation/json/',
-  version: '1.0',
-});
+);
 
 export const fakeExternalDiff = Object.freeze({
   path: 'manifest.json',
@@ -214,23 +191,65 @@ export const fakeExternalDiff = Object.freeze({
   new_ending_new_line: false,
 });
 
+export const fakeVersionFileWithDiff: ExternalVersionFileWithDiff = Object.freeze(
+  {
+    ...partialFakeVersionFile,
+    base_file: {
+      id: nextUniqueId(),
+    },
+    diff: fakeExternalDiff,
+  },
+);
+
+export const fakeVersionAddon: ExternalVersionAddon = Object.freeze({
+  icon_url: 'some-icon-url',
+  id: 111,
+  name: { 'en-US': 'addon name' },
+  slug: 'addon-slug',
+});
+
+export const partialFakeVersion: PartialExternalVersion = {
+  addon: fakeVersionAddon,
+  channel: 'some channel',
+  file_entries: {
+    'manifest.json': fakeVersionEntry,
+  },
+  has_been_validated: true,
+  id: 123,
+  reviewed: '2017-08-15T12:01:13Z',
+  url: 'http://example.com/',
+  validation_url: 'http://example.com/validation/',
+  validation_url_json: 'http://example.com/validation/json/',
+  version: '1.0',
+};
+
+export const fakeVersionWithContent: ExternalVersionWithContent = Object.freeze(
+  {
+    ...partialFakeVersion,
+    file: fakeVersionFileWithContent,
+  },
+);
+
 export const createExternalVersionWithEntries = (
   partialEntries: ({ path: string } & Partial<ExternalVersionEntry>)[],
   {
+    addonId = nextUniqueId(),
     diff = null,
-    id = fakeVersion.id,
-    selected_file = fakeVersion.file.selected_file,
+    id = fakeVersionWithContent.id,
+    selected_file = fakeVersionWithContent.file.selected_file,
   }: {
+    addonId?: number;
     diff?: typeof fakeExternalDiff | null;
-    id?: typeof fakeVersion.id;
-    selected_file?: typeof fakeVersion.file.selected_file;
+    id?: typeof fakeVersionWithContent.id;
+    selected_file?: typeof fakeVersionWithContent.file.selected_file;
   } = {},
 ) => {
   return {
-    ...fakeVersion,
+    ...fakeVersionWithContent,
     id,
+    addon: { ...fakeVersionAddon, id: addonId },
     file: {
-      ...fakeVersion.file,
+      ...fakeVersionWithContent.file,
       base_file: {
         id: nextUniqueId(),
       },
@@ -257,7 +276,7 @@ export const createVersionWithInternalEntries = (
   entries: Version['entries'],
 ): Version => {
   return {
-    ...createInternalVersion(fakeVersion),
+    ...createInternalVersion(fakeVersionWithContent),
     id: nextUniqueId(),
     entries,
   };
@@ -360,16 +379,10 @@ export const fakeExternalLinterResult = Object.freeze({
 
 /* eslint-enable @typescript-eslint/camelcase */
 
-export const fakeVersionWithDiff: ExternalVersionWithDiff = {
-  ...fakeVersion,
-  file: {
-    ...fakeVersion.file,
-    diff: fakeExternalDiff,
-    base_file: {
-      id: nextUniqueId(),
-    },
-  },
-};
+export const fakeVersionWithDiff: ExternalVersionWithDiff = Object.freeze({
+  ...partialFakeVersion,
+  file: fakeVersionFileWithDiff,
+});
 
 export const fakeVersionsListItem: ExternalVersionsListItem = {
   id: nextUniqueId(),
@@ -853,7 +866,7 @@ export const dispatchLoadVersionInfo = ({
 export const createStoreWithVersion = (
   /* istanbul ignore next */
   {
-    version = fakeVersion,
+    version = fakeVersionWithContent,
     makeCurrent = false,
   }: {
     version?: ExternalVersionWithDiff | ExternalVersionWithContent;
@@ -943,7 +956,7 @@ export const createStoreWithVersionComments = ({
   versionId = 1,
   comments = [createFakeExternalComment()],
 } = {}) => {
-  const version = { ...fakeVersion, id: versionId };
+  const version = { ...fakeVersionWithContent, id: versionId };
   const store = createStoreWithVersion({ version, makeCurrent: true });
 
   dispatchComments({ versionId, store, comments });

--- a/src/utils.spec.tsx
+++ b/src/utils.spec.tsx
@@ -548,7 +548,7 @@ describe('ForwardComparisonMap', () => {
     changes?: ExternalChange[];
     hunks?: ExternalHunk[];
   } = {}) => {
-    const fakeVersion = {
+    const version = {
       ...fakeVersionWithDiff,
       file: {
         ...fakeVersionWithDiff.file,
@@ -562,7 +562,7 @@ describe('ForwardComparisonMap', () => {
     const diffInfo = createInternalDiff({
       baseVersionId: 1,
       headVersionId: 2,
-      version: fakeVersion,
+      version,
     });
     if (!diffInfo) {
       throw new Error('diffInfo was unexpectedly empty');

--- a/stories/CodeOverview.stories.tsx
+++ b/stories/CodeOverview.stories.tsx
@@ -14,8 +14,8 @@ import { JS_SAMPLE } from './CodeView.stories';
 import { createInternalVersion } from '../src/reducers/versions';
 import {
   createFakeExternalLinterResult,
-  fakeVersion,
-  fakeVersionFile,
+  fakeVersionWithContent,
+  fakeVersionFileWithContent,
   fakeVersionEntry,
 } from '../src/test-helpers';
 import {
@@ -35,9 +35,9 @@ const render = ({
 } = {}) => {
   const path = 'background.js';
   const version = createInternalVersion({
-    ...fakeVersion,
+    ...fakeVersionWithContent,
     file: {
-      ...fakeVersionFile,
+      ...fakeVersionFileWithContent,
       selected_file: path,
     },
     file_entries: { [path]: { ...fakeVersionEntry, path } },

--- a/stories/CodeView.stories.tsx
+++ b/stories/CodeView.stories.tsx
@@ -20,9 +20,9 @@ import {
 } from './utils';
 import {
   createFakeExternalLinterResult,
-  fakeVersion,
+  fakeVersionWithContent,
   fakeVersionEntry,
-  fakeVersionFile,
+  fakeVersionFileWithContent,
 } from '../src/test-helpers';
 
 const getParams = () => rootAttributeParams({ fullscreen: true });
@@ -70,7 +70,7 @@ const render = ({
     content,
     isMinified: false,
     mimeType: 'application/javascript',
-    version: createInternalVersion(fakeVersion),
+    version: createInternalVersion(fakeVersionWithContent),
     ...moreProps,
   };
   return renderWithStoreAndRouter(
@@ -94,9 +94,9 @@ const renderJSWithMessages = (
 ) => {
   const path = 'lib/some-file.js';
   const version = createInternalVersion({
-    ...fakeVersion,
+    ...fakeVersionWithContent,
     file: {
-      ...fakeVersionFile,
+      ...fakeVersionFileWithContent,
       selected_file: path,
     },
     file_entries: { [path]: { ...fakeVersionEntry, path } },

--- a/stories/DiffView.stories.tsx
+++ b/stories/DiffView.stories.tsx
@@ -20,9 +20,9 @@ import { createInternalVersion } from '../src/reducers/versions';
 import {
   createFakeExternalLinterResult,
   createFakeLocation,
-  fakeVersion,
+  fakeVersionWithContent,
   fakeVersionEntry,
-  fakeVersionFile,
+  fakeVersionFileWithContent,
 } from '../src/test-helpers';
 import { allowSlowPagesParam } from '../src/utils';
 import longUnbrokenMinifiedDiff from './fixtures/long-unbroken-minified-diff';
@@ -44,7 +44,7 @@ const render = (
     diff: parseDiff(basicDiff)[0],
     isMinified: false,
     mimeType: 'application/javascript',
-    version: createInternalVersion(fakeVersion),
+    version: createInternalVersion(fakeVersionWithContent),
     ...remainingProps,
   };
 
@@ -72,9 +72,9 @@ const renderWithMessages = (
 
   const store = configureStore();
   const version = createInternalVersion({
-    ...fakeVersion,
+    ...fakeVersionWithContent,
     file: {
-      ...fakeVersionFile,
+      ...fakeVersionFileWithContent,
       selected_file: path,
     },
     file_entries: { [path]: { ...fakeVersionEntry, path } },

--- a/stories/FadableContent.stories.tsx
+++ b/stories/FadableContent.stories.tsx
@@ -5,7 +5,7 @@ import configureStore from '../src/configureStore';
 import CodeView from '../src/components/CodeView';
 import FadableContent from '../src/components/FadableContent';
 import { createInternalVersion } from '../src/reducers/versions';
-import { fakeVersion } from '../src/test-helpers';
+import { fakeVersionWithContent } from '../src/test-helpers';
 import { JS_SAMPLE } from './CodeView.stories';
 import { generateParagraphs, renderWithStoreAndRouter } from './utils';
 
@@ -25,7 +25,7 @@ storiesOf('FadableContent', module)
         content={JS_SAMPLE}
         isMinified={false}
         mimeType="application/javascript"
-        version={createInternalVersion(fakeVersion)}
+        version={createInternalVersion(fakeVersionWithContent)}
       />,
     );
   })

--- a/stories/FileMetadata.stories.tsx
+++ b/stories/FileMetadata.stories.tsx
@@ -6,15 +6,15 @@ import FileMetadata from '../src/components/FileMetadata';
 import {
   actions as versionActions,
   getVersionFile,
-  VersionFile,
+  VersionFileWithContent,
 } from '../src/reducers/versions';
 import {
   createStoreWithVersion,
-  fakeVersion,
+  fakeVersionWithContent,
   fakeVersionEntry,
 } from '../src/test-helpers';
 
-const loadVersionFile = (version = fakeVersion) => {
+const loadVersionFile = (version = fakeVersionWithContent) => {
   const store = createStoreWithVersion({ version });
   store.dispatch(
     versionActions.loadVersionFile({
@@ -27,7 +27,7 @@ const loadVersionFile = (version = fakeVersion) => {
     store.getState().versions,
     version.id,
     version.file.selected_file,
-  ) as VersionFile;
+  ) as VersionFileWithContent;
   return versionFile;
 };
 
@@ -40,7 +40,7 @@ storiesOf('FileMetadata', module).addWithChapters('all variants', {
           sectionFn: () => {
             const versionFile = loadVersionFile();
 
-            return <FileMetadata file={versionFile} />;
+            return <FileMetadata file={versionFile} versionString="1.2" />;
           },
         },
         {
@@ -48,9 +48,9 @@ storiesOf('FileMetadata', module).addWithChapters('all variants', {
           sectionFn: () => {
             const path = 'very-long-file-name.json';
             const version = {
-              ...fakeVersion,
+              ...fakeVersionWithContent,
               file: {
-                ...fakeVersion.file,
+                ...fakeVersionWithContent.file,
                 entries: {
                   [path]: {
                     ...fakeVersionEntry,
@@ -68,7 +68,7 @@ storiesOf('FileMetadata', module).addWithChapters('all variants', {
 
             return (
               <div style={{ width: '200px' }}>
-                <FileMetadata file={versionFile} />
+                <FileMetadata file={versionFile} versionString="1.2" />
               </div>
             );
           },

--- a/stories/FileTree.stories.tsx
+++ b/stories/FileTree.stories.tsx
@@ -20,7 +20,7 @@ import {
   createFakeExternalLinterResult,
   dispatchComments,
   fakeExternalLinterMessage,
-  fakeVersion,
+  fakeVersionWithContent,
   fakeVersionEntry,
 } from '../src/test-helpers';
 import { renderWithStoreAndRouter } from './utils';
@@ -31,10 +31,10 @@ const fakeDirectoryEntry = {
 };
 
 const defaultVersion = {
-  ...fakeVersion,
+  ...fakeVersionWithContent,
   id: 456,
   file: {
-    ...fakeVersion.file,
+    ...fakeVersionWithContent.file,
     entries: {
       'manifest.json': {
         ...fakeVersionEntry,

--- a/stories/FileTreeNode.stories.tsx
+++ b/stories/FileTreeNode.stories.tsx
@@ -3,7 +3,10 @@ import { Store } from 'redux';
 import { storiesOf } from '@storybook/react';
 
 import FileTreeNode, { PublicProps } from '../src/components/FileTreeNode';
-import { createStoreWithVersion, fakeVersion } from '../src/test-helpers';
+import {
+  createStoreWithVersion,
+  fakeVersionWithContent,
+} from '../src/test-helpers';
 import { renderWithStoreAndRouter } from './utils';
 
 type GetPropsParams = {
@@ -19,7 +22,7 @@ const getProps = ({
   nodeName = 'node name',
   nodeId = 'node-id',
   renderChildNodes = () => ({}),
-  versionId = fakeVersion.id,
+  versionId = fakeVersionWithContent.id,
 }: GetPropsParams = {}) => {
   return {
     getToggleProps: () => ({
@@ -46,7 +49,7 @@ const getProps = ({
 const render = ({
   versionId = 543219,
   store = createStoreWithVersion({
-    version: { ...fakeVersion, id: versionId },
+    version: { ...fakeVersionWithContent, id: versionId },
   }),
   ...props
 }: { store?: Store } & GetPropsParams = {}) => {
@@ -86,7 +89,7 @@ storiesOf('FileTreeNode', module).addWithChapters('all variants', {
             const versionId = 921;
             const store = createStoreWithVersion({
               version: {
-                ...fakeVersion,
+                ...fakeVersionWithContent,
                 id: versionId,
               },
             });
@@ -115,7 +118,7 @@ storiesOf('FileTreeNode', module).addWithChapters('all variants', {
         {
           title: 'selected node',
           sectionFn: () => {
-            const externalVersion = fakeVersion;
+            const externalVersion = fakeVersionWithContent;
             const store = createStoreWithVersion({ version: externalVersion });
 
             return render({

--- a/stories/Navbar.stories.tsx
+++ b/stories/Navbar.stories.tsx
@@ -12,7 +12,7 @@ import {
   createStoreWithVersionComments,
   dispatchLoadVersionInfo,
   fakeUser,
-  fakeVersion,
+  fakeVersionWithContent,
   fakeVersionAddon,
   nextUniqueId,
 } from '../src/test-helpers';
@@ -44,7 +44,7 @@ const dispatchBaseVersion = ({
   store: Store;
   versionString?: string;
 }) => {
-  const baseVersion = { ...fakeVersion, id, version: versionString };
+  const baseVersion = { ...fakeVersionWithContent, id, version: versionString };
   dispatchLoadVersionInfo({ store, version: baseVersion });
   store.dispatch(
     versionsActions.setCurrentBaseVersionId({ versionId: baseVersion.id }),
@@ -61,7 +61,7 @@ storiesOf('Navbar', module)
   })
   .add('with current version', () => {
     const version = {
-      ...fakeVersion,
+      ...fakeVersionWithContent,
       addon: { ...fakeVersionAddon, name: { 'en-US': 'uBlock Origin' } },
     };
     const store = createStoreWithVersion({ version, makeCurrent: true });
@@ -69,7 +69,7 @@ storiesOf('Navbar', module)
   })
   .add('with base version, current version', () => {
     const version = {
-      ...fakeVersion,
+      ...fakeVersionWithContent,
       id: nextUniqueId(),
       version: '2.0',
       addon: { ...fakeVersionAddon, name: { 'en-US': 'uBlock Origin' } },
@@ -81,7 +81,7 @@ storiesOf('Navbar', module)
   })
   .add('with new base version loading', () => {
     const version = {
-      ...fakeVersion,
+      ...fakeVersionWithContent,
       version: '2.0',
       addon: { ...fakeVersionAddon, name: { 'en-US': 'uBlock Origin' } },
     };


### PR DESCRIPTION
Fixes #1635 

Most of these changes are just replacing the `Version` type with `VersionWithContent` and the `VersionFile` type with `VersionFileWithConent`. The new `VersionWithContent` and `VersionFileWithConent` types are also defined, and a change was made to remove `versionString` from the `VersionFileWithConent` type because it should be able to be created from just a `file`, which doesn't have the `versionString`.

A future patch will introduce the `VersionWithDiff` and `VersionFileWithDiff` types, including functions to allow differentiating between them. This patch is mostly just groundwork that needs to be done and will reduce the size of future patches.
