### PR TITLE
Only retrieve file info when that's all we need, in the Compare view

### DIFF
--- a/src/components/FileMetadata/index.spec.tsx
+++ b/src/components/FileMetadata/index.spec.tsx
@@ -1,14 +1,10 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 
+import { createInternalVersionFile } from '../../reducers/versions';
 import {
-  actions as versionActions,
-  getVersionFile,
-  VersionFileWithContent,
-} from '../../reducers/versions';
-import {
-  fakeVersionWithContent,
-  createStoreWithVersion,
+  fakeVersionFileWithContent,
+  fakeVersionFileWithDiff,
 } from '../../test-helpers';
 import styles from './styles.module.scss';
 import { formatFilesize } from '../../utils';
@@ -17,28 +13,8 @@ import { makeApiURL } from '../../api';
 import FileMetadata from '.';
 
 describe(__filename, () => {
-  const _getVersionFile = (props = {}) => {
-    const version = fakeVersionWithContent;
-    const store = createStoreWithVersion({ version });
-    store.dispatch(
-      versionActions.loadVersionFile({
-        path: version.file.selected_file,
-        version,
-      }),
-    );
-
-    return {
-      ...(getVersionFile(
-        store.getState().versions,
-        version.id,
-        version.file.selected_file,
-      ) as VersionFileWithContent),
-      ...props,
-    };
-  };
-
-  it('renders metadata for a file', () => {
-    const file = _getVersionFile();
+  it('renders metadata for a file with content', () => {
+    const file = createInternalVersionFile(fakeVersionFileWithContent);
     const versionString = '1.2';
     const root = shallow(
       <FileMetadata file={file} versionString={versionString} />,
@@ -57,9 +33,22 @@ describe(__filename, () => {
     );
   });
 
+  it('can render for a file with a diff', () => {
+    const file = createInternalVersionFile(fakeVersionFileWithDiff);
+    const versionString = '1.2';
+    const root = shallow(
+      <FileMetadata file={file} versionString={versionString} />,
+    );
+
+    expect(root.find(`.${styles.version}`)).toHaveText(versionString);
+  });
+
   it('renders a formatted filesize', () => {
     const size = 12345;
-    const file = _getVersionFile({ size });
+    const file = createInternalVersionFile({
+      ...fakeVersionFileWithContent,
+      size,
+    });
     const root = shallow(<FileMetadata file={file} versionString="1.2" />);
 
     expect(root.find(`.${styles.size}`)).toHaveText(formatFilesize(size));

--- a/src/components/FileMetadata/index.tsx
+++ b/src/components/FileMetadata/index.tsx
@@ -1,12 +1,15 @@
 import * as React from 'react';
 
-import { VersionFileWithContent } from '../../reducers/versions';
+import {
+  VersionFileWithContent,
+  VersionFileWithDiff,
+} from '../../reducers/versions';
 import styles from './styles.module.scss';
 import { formatFilesize, gettext } from '../../utils';
 import { makeApiURL } from '../../api';
 
 type PublicProps = {
-  file: VersionFileWithContent;
+  file: VersionFileWithContent | VersionFileWithDiff;
   versionString: string;
 };
 

--- a/src/components/KeyboardShortcuts/index.spec.tsx
+++ b/src/components/KeyboardShortcuts/index.spec.tsx
@@ -172,9 +172,7 @@ describe(__filename, () => {
 
   it('renders one line descriptions for keys "p"/"n" and "k"/"j" in Browse', () => {
     const root = render({
-      file: createInternalVersionFile(
-        fakeVersionFileWithContent,
-      ) as VersionFileWithContent,
+      file: createInternalVersionFile(fakeVersionFileWithContent),
     });
 
     expect(root.find(`dt.${styles.hasAlias}`)).toHaveLength(2);
@@ -210,9 +208,7 @@ describe(__filename, () => {
   });
 
   it('generates a getCodeLineAnchor function using _createCodeLineAnchorGetter', () => {
-    const file = createInternalVersionFile(
-      fakeVersionFileWithContent,
-    ) as VersionFileWithContent;
+    const file = createInternalVersionFile(fakeVersionFileWithContent);
 
     const _createCodeLineAnchorGetter = jest.fn();
 
@@ -331,9 +327,7 @@ describe(__filename, () => {
         { key: key as string },
         {
           _goToRelativeFile,
-          file: createInternalVersionFile(
-            fakeVersionFileWithContent,
-          ) as VersionFileWithContent,
+          file: createInternalVersionFile(fakeVersionFileWithContent),
           currentPath,
           store,
           versionId,

--- a/src/components/KeyboardShortcuts/index.spec.tsx
+++ b/src/components/KeyboardShortcuts/index.spec.tsx
@@ -13,7 +13,6 @@ import {
   actions as versionsActions,
   createInternalVersion,
   createInternalVersionFile,
-  VersionFileWithContent,
   VersionFileWithDiff,
 } from '../../reducers/versions';
 import { actions as fullscreenGridActions } from '../../reducers/fullscreenGrid';

--- a/src/components/KeyboardShortcuts/index.tsx
+++ b/src/components/KeyboardShortcuts/index.tsx
@@ -16,9 +16,12 @@ import {
 } from '../../reducers/fileTree';
 import { LinterMessage } from '../../reducers/linter';
 import {
-  CompareInfo,
+  VersionFileWithContent,
+  VersionFileWithDiff,
   actions as versionsActions,
   goToRelativeDiff,
+  isFileWithContent,
+  isFileWithDiff,
 } from '../../reducers/versions';
 import { actions as fullscreenGridActions } from '../../reducers/fullscreenGrid';
 import styles from './styles.module.scss';
@@ -51,7 +54,7 @@ const mapKeyInBrowse = (key: string) => {
 };
 
 export type PublicProps = {
-  compareInfo: CompareInfo | null | undefined;
+  file: VersionFileWithContent | VersionFileWithDiff | null | undefined;
   comparedToVersionId: number | null;
   currentPath: string;
   messageMap: LinterProviderInfo['messageMap'];
@@ -88,7 +91,9 @@ export class KeyboardShortcutsBase extends React.Component<Props> {
   };
 
   isInBrowseMode = () => {
-    return !this.props.compareInfo;
+    const { file } = this.props;
+
+    return file && isFileWithContent(file);
   };
 
   getKey = (key: string) => {
@@ -101,11 +106,11 @@ export class KeyboardShortcutsBase extends React.Component<Props> {
       _goToRelativeDiff,
       _goToRelativeFile,
       _goToRelativeMessage,
-      compareInfo,
       comparedToVersionId,
       currentAnchor,
       currentPath,
       dispatch,
+      file,
       messageMap,
       messageUid,
       pathList,
@@ -126,7 +131,7 @@ export class KeyboardShortcutsBase extends React.Component<Props> {
     ) {
       event.preventDefault();
 
-      const getCodeLineAnchor = _createCodeLineAnchorGetter({ compareInfo });
+      const getCodeLineAnchor = _createCodeLineAnchorGetter(file);
 
       switch (this.getKey(event.key)) {
         case 'k':
@@ -167,12 +172,12 @@ export class KeyboardShortcutsBase extends React.Component<Props> {
           );
           break;
         case 'n':
-          if (compareInfo) {
+          if (file && isFileWithDiff(file)) {
             dispatch(
               _goToRelativeDiff({
                 currentAnchor,
                 comparedToVersionId,
-                diff: compareInfo.diff,
+                diff: file.diff,
                 pathList,
                 position: RelativePathPosition.next,
                 versionId,
@@ -181,12 +186,12 @@ export class KeyboardShortcutsBase extends React.Component<Props> {
           }
           break;
         case 'p':
-          if (compareInfo) {
+          if (file && isFileWithDiff(file)) {
             dispatch(
               _goToRelativeDiff({
                 currentAnchor,
                 comparedToVersionId,
-                diff: compareInfo.diff,
+                diff: file.diff,
                 pathList,
                 position: RelativePathPosition.previous,
                 versionId,

--- a/src/components/VersionFileViewer/index.spec.tsx
+++ b/src/components/VersionFileViewer/index.spec.tsx
@@ -41,30 +41,35 @@ import styles from './styles.module.scss';
 import VersionFileViewer, { ItemTitles, PublicProps } from '.';
 
 describe(__filename, () => {
+  enum ContentOrDiff {
+    content,
+    diff,
+  }
+
   const getInternalVersionAndFile = ({
-    contentOrDiff = 'content',
+    contentOrDiff = ContentOrDiff.content,
     entry,
     fileProps = {},
     path = 'background.js',
   }: {
-    contentOrDiff?: string;
+    contentOrDiff?: ContentOrDiff;
     entry?: ExternalVersionEntry;
     fileContent?: string;
     fileProps?: Partial<ExternalVersionFileWithContent>;
     path?: string;
   } = {}) => {
     const baseFile =
-      contentOrDiff === 'content'
+      contentOrDiff === ContentOrDiff.content
         ? fakeVersionFileWithContent
         : fakeVersionFileWithDiff;
     const externalFile = { ...baseFile, ...fileProps };
     const file =
-      contentOrDiff === 'content'
+      contentOrDiff === ContentOrDiff.content
         ? (createInternalVersionFile(externalFile) as VersionFileWithContent)
         : (createInternalVersionFile(externalFile) as VersionFileWithDiff);
 
     const version =
-      contentOrDiff === 'content'
+      contentOrDiff === ContentOrDiff.content
         ? ({
             ...fakeVersionWithContent,
             file_entries: {
@@ -318,7 +323,7 @@ describe(__filename, () => {
     const insertedLines = [1, 2];
     const _getInsertedLines = jest.fn().mockReturnValue(insertedLines);
     const fileAndVersion = getInternalVersionAndFile({
-      contentOrDiff: 'diff',
+      contentOrDiff: ContentOrDiff.diff,
     });
     const file = fileAndVersion.file as VersionFileWithDiff;
     const { version } = fileAndVersion;
@@ -335,7 +340,7 @@ describe(__filename, () => {
   it('does not call getInsertedLines if no diff exists', () => {
     const _getInsertedLines = jest.fn();
     const { file, version } = getInternalVersionAndFile({
-      contentOrDiff: 'content',
+      contentOrDiff: ContentOrDiff.content,
     });
 
     const root = renderPanel(
@@ -349,7 +354,7 @@ describe(__filename, () => {
 
   it('passes the content of a diff to CodeOverview', () => {
     const fileAndVersion = getInternalVersionAndFile({
-      contentOrDiff: 'diff',
+      contentOrDiff: ContentOrDiff.diff,
     });
     const file = fileAndVersion.file as VersionFileWithDiff;
     const { version } = fileAndVersion;

--- a/src/components/VersionFileViewer/index.tsx
+++ b/src/components/VersionFileViewer/index.tsx
@@ -11,11 +11,13 @@ import KeyboardShortcuts from '../KeyboardShortcuts';
 import LinterProvider, { LinterProviderInfo } from '../LinterProvider';
 import Loading from '../Loading';
 import {
-  CompareInfo,
   EntryStatusMap,
   Version,
   VersionFileWithContent,
+  VersionFileWithDiff,
   getInsertedLines,
+  isFileWithContent,
+  isFileWithDiff,
 } from '../../reducers/versions';
 import { AnyReactNode } from '../../typeUtils';
 import { flattenDiffChanges, gettext } from '../../utils';
@@ -31,9 +33,8 @@ export type PublicProps = {
   _getInsertedLines?: typeof getInsertedLines;
   children: AnyReactNode;
   comparedToVersionId: number | null;
-  compareInfo?: CompareInfo | null | undefined;
   entryStatusMap?: EntryStatusMap;
-  file: VersionFileWithContent | null | undefined;
+  file: VersionFileWithContent | VersionFileWithDiff | null | undefined;
   getCodeLineAnchor?: GetCodeLineAnchor;
   onSelectFile: FileTreeProps['onSelect'];
   version: Version | undefined | null;
@@ -43,7 +44,6 @@ const VersionFileViewer = ({
   _getInsertedLines = getInsertedLines,
   children,
   comparedToVersionId,
-  compareInfo,
   entryStatusMap,
   file,
   getCodeLineAnchor,
@@ -73,8 +73,8 @@ const VersionFileViewer = ({
         : null;
 
     const insertedLines =
-      compareInfo && compareInfo.diff
-        ? _getInsertedLines(compareInfo.diff)
+      file && isFileWithDiff(file) && file.diff
+        ? _getInsertedLines(file.diff)
         : [];
 
     const { versionString, selectedPath } = version;
@@ -99,9 +99,9 @@ const VersionFileViewer = ({
 
     let overviewContent = '';
     if (file) {
-      if (compareInfo && compareInfo.diff) {
-        overviewContent = flattenDiffChanges(compareInfo.diff);
-      } else if (file.fileType !== 'image') {
+      if (isFileWithDiff(file) && file.diff) {
+        overviewContent = flattenDiffChanges(file.diff);
+      } else if (isFileWithContent(file) && file.fileType !== 'image') {
         overviewContent = file.content;
       }
     }
@@ -125,8 +125,8 @@ const VersionFileViewer = ({
             <AccordionItem title={ItemTitles.Shortcuts}>
               <KeyboardShortcuts
                 comparedToVersionId={comparedToVersionId}
-                compareInfo={compareInfo}
                 currentPath={version.selectedPath}
+                file={file}
                 messageMap={messageMap}
                 versionId={version.id}
               />

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -24,7 +24,6 @@ import { actions as fileTreeActions } from '../../reducers/fileTree';
 import {
   ExternalVersionWithDiff,
   VersionEntryStatus,
-  VersionFileWithDiff,
   actions as versionsActions,
   createEntryStatusMap,
   createInternalDiff,

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -12,6 +12,7 @@ import {
   createStoreWithVersion,
   dispatchLoadVersionInfo,
   externallyLocalizedString,
+  fakeVersionAddon,
   fakeVersionWithContent,
   fakeVersionWithDiff,
   shallowUntilTarget,
@@ -23,19 +24,18 @@ import { actions as fileTreeActions } from '../../reducers/fileTree';
 import {
   ExternalVersionWithDiff,
   VersionEntryStatus,
+  VersionFileWithDiff,
   actions as versionsActions,
   createEntryStatusMap,
   createInternalDiff,
   createInternalVersion,
-  getCompareInfo,
+  getVersionDiff,
+  createInternalVersionFile,
 } from '../../reducers/versions';
 import DiffView from '../../components/DiffView';
 import Loading from '../../components/Loading';
 import VersionFileViewer from '../../components/VersionFileViewer';
-import {
-  createCodeLineAnchorGetter,
-  getPathFromQueryString,
-} from '../../utils';
+import { createCodeLineAnchorGetter } from '../../utils';
 
 import Compare, { CompareBase, PublicProps, mapStateToProps } from '.';
 
@@ -78,8 +78,8 @@ describe(__filename, () => {
   };
 
   type RenderParams = {
-    _fetchDiff?: PublicProps['_fetchDiff'];
-    _fetchVersionFile?: PublicProps['_fetchVersionFile'];
+    _fetchVersionWithDiff?: PublicProps['_fetchVersionWithDiff'];
+    _fetchDiffFile?: PublicProps['_fetchDiffFile'];
     _viewVersionFile?: PublicProps['_viewVersionFile'];
     addonId?: string;
     baseVersionId?: string;
@@ -90,8 +90,8 @@ describe(__filename, () => {
   };
 
   const render = ({
-    _fetchDiff,
-    _fetchVersionFile,
+    _fetchVersionWithDiff,
+    _fetchDiffFile,
     _viewVersionFile,
     addonId = '999',
     baseVersionId = '1',
@@ -105,8 +105,8 @@ describe(__filename, () => {
         history,
         params: { lang, addonId, baseVersionId, headVersionId },
       }),
-      _fetchDiff,
-      _fetchVersionFile,
+      _fetchVersionWithDiff,
+      _fetchDiffFile,
       _viewVersionFile,
     };
 
@@ -122,20 +122,20 @@ describe(__filename, () => {
     baseVersionId = nextUniqueId(),
     headVersionId = baseVersionId + 1,
     store = configureStore(),
-    version = { ...fakeVersionWithDiff, id: headVersionId },
+    version = {
+      ...fakeVersionWithDiff,
+      addon: { ...fakeVersionAddon, id: addonId },
+      id: headVersionId,
+    },
     setCurrentVersionId = true,
     loadDiff = true,
     loadEntryStatusMap = true,
-    loadVersionFile = true,
-    path,
   }: {
     addonId?: number;
     baseVersionId?: number;
     headVersionId?: number;
     loadDiff?: boolean;
     loadEntryStatusMap?: boolean;
-    loadVersionFile?: boolean;
-    path?: string;
     setCurrentVersionId?: boolean;
     store?: Store;
     version?: typeof fakeVersionWithDiff;
@@ -152,30 +152,12 @@ describe(__filename, () => {
         }),
       );
     }
-    if (loadVersionFile) {
-      store.dispatch(
-        versionsActions.loadVersionFile({
-          path: version.file.selected_file,
-          // Make a version with file content out of the given version
-          // diff response.
-          version: {
-            ...fakeVersionWithContent,
-            id: version.id,
-            file: {
-              ...fakeVersionWithContent.file,
-              ...version.file,
-            },
-          },
-        }),
-      );
-    }
     if (loadDiff) {
       store.dispatch(
-        versionsActions.loadDiff({
-          addonId,
+        versionsActions.loadDiffFileFromVersion({
           baseVersionId,
           headVersionId,
-          path,
+          path: version.file.selected_file,
           version,
         }),
       );
@@ -205,14 +187,14 @@ describe(__filename, () => {
     headVersionId = baseVersionId + 1,
     lastSelectedPath,
     loadDiff = true,
-    loadVersionFile = true,
     version = {
       ...fakeVersionWithDiff,
-      id: headVersionId,
+      addon: { ...fakeVersionAddon, id: addonId },
       file: {
         ...fakeVersionWithDiff.file,
         selected_file,
       },
+      id: headVersionId,
     },
   }: {
     history?: History;
@@ -223,13 +205,12 @@ describe(__filename, () => {
     headVersionId?: number;
     lastSelectedPath?: string;
     loadDiff?: boolean;
-    loadVersionFile?: boolean;
     selected_file?: string;
     version?: ExternalVersionWithDiff;
   } = {}) => {
     const fakeThunk = createFakeThunk();
-    const _fetchDiff = createFakeThunk().createThunk;
-    const _fetchVersionFile = createFakeThunk().createThunk;
+    const _fetchVersionWithDiff = createFakeThunk().createThunk;
+    const _fetchDiffFile = createFakeThunk().createThunk;
     const _viewVersionFile = createFakeThunk().createThunk;
 
     _loadDiff({
@@ -237,8 +218,6 @@ describe(__filename, () => {
       baseVersionId,
       headVersionId,
       loadDiff,
-      loadVersionFile,
-      path: getPathFromQueryString(history) || undefined,
       store,
       version,
     });
@@ -264,8 +243,8 @@ describe(__filename, () => {
     const dispatchSpy = spyOn(store, 'dispatch');
 
     const root = render({
-      _fetchDiff,
-      _fetchVersionFile,
+      _fetchVersionWithDiff,
+      _fetchDiffFile,
       _viewVersionFile,
       addonId: String(addonId),
       baseVersionId: String(baseVersionId),
@@ -275,8 +254,8 @@ describe(__filename, () => {
     });
 
     return {
-      _fetchDiff,
-      _fetchVersionFile,
+      _fetchVersionWithDiff,
+      _fetchDiffFile,
       _viewVersionFile,
       addonId,
       baseVersionId,
@@ -284,6 +263,7 @@ describe(__filename, () => {
       fakeThunk,
       headVersionId,
       params: getRouteParams({ addonId, baseVersionId, headVersionId }),
+      path: version.file.selected_file,
       root,
       store,
       version,
@@ -305,33 +285,39 @@ describe(__filename, () => {
       addonId,
       baseVersionId,
       headVersionId,
+      path,
       root,
       store,
       version,
     } = loadDiffAndRender();
 
-    const compareInfo = getCompareInfo(
-      store.getState().versions,
+    const versionDiff = getVersionDiff({
       addonId,
       baseVersionId,
       headVersionId,
-    );
+      path,
+      versions: store.getState().versions,
+    }) as VersionFileWithDiff;
 
     const viewer = root.find(VersionFileViewer);
     expect(viewer).toHaveLength(1);
-    expect(viewer).toHaveProp('compareInfo', compareInfo);
+    expect(viewer).toHaveProp('file', versionDiff);
     expect(viewer).toHaveProp('comparedToVersionId', baseVersionId);
     expect(viewer).toHaveProp('version', createInternalVersion(version));
   });
 
   it('renders a DiffView', () => {
-    const addonId = 999;
+    const addonId = nextUniqueId();
     const baseVersionId = 1;
     const path = 'manifest.json';
     const mimeType = 'mime/type';
 
     const version = {
       ...fakeVersionWithDiff,
+      addon: {
+        ...fakeVersionAddon,
+        id: addonId,
+      },
       id: baseVersionId + 1,
       file: {
         ...fakeVersionWithDiff.file,
@@ -351,6 +337,7 @@ describe(__filename, () => {
 
     const root = render({
       store,
+      addonId: String(addonId),
       baseVersionId: String(baseVersionId),
       headVersionId: String(version.id),
     });
@@ -368,15 +355,16 @@ describe(__filename, () => {
     const headVersionId = baseVersionId + 1;
 
     const store = configureStore();
+
     store.dispatch(
-      versionsActions.beginFetchDiff({
+      versionsActions.beginFetchVersionWithDiff({
         addonId,
         baseVersionId,
         headVersionId,
       }),
     );
     store.dispatch(
-      versionsActions.abortFetchDiff({
+      versionsActions.abortFetchVersionWithDiff({
         addonId,
         baseVersionId,
         headVersionId,
@@ -397,7 +385,7 @@ describe(__filename, () => {
     );
   });
 
-  it('dispatches fetchDiff() on mount', () => {
+  it('dispatches fetchVersionWithDiff() on mount', () => {
     const addonId = 9999;
     const baseVersionId = 1;
     const headVersionId = baseVersionId + 1;
@@ -405,57 +393,21 @@ describe(__filename, () => {
     const store = configureStore();
     const dispatch = spyOn(store, 'dispatch');
     const fakeThunk = createFakeThunk();
-    const _fetchDiff = fakeThunk.createThunk;
+    const _fetchVersionWithDiff = fakeThunk.createThunk;
 
     render({
       ...getRouteParams({ addonId, baseVersionId, headVersionId }),
-      _fetchDiff,
+      _fetchVersionWithDiff,
       store,
     });
 
     expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(_fetchDiff).toHaveBeenCalledWith({
+    expect(_fetchVersionWithDiff).toHaveBeenCalledWith({
       addonId,
       baseVersionId,
       forceReloadVersion: false,
       headVersionId,
     });
-  });
-
-  it('dispatches fetchVersionFile() on mount', () => {
-    const {
-      addonId,
-      dispatchSpy,
-      fakeThunk,
-      version,
-      _fetchVersionFile,
-    } = loadDiffAndRender({ buildTree: true, loadVersionFile: false });
-
-    expect(dispatchSpy).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(_fetchVersionFile).toHaveBeenCalledWith({
-      addonId,
-      versionId: version.id,
-      path: version.file.selected_file,
-    });
-  });
-
-  it('does not dispatch fetchVersionFile() if the selected file was deleted', () => {
-    const baseVersionId = nextUniqueId();
-    const headVersionId = baseVersionId + 1;
-    const path = 'path.js';
-    const version = createExternalVersionWithEntries([{ path, status: 'D' }], {
-      selected_file: path,
-      id: headVersionId,
-    });
-    const { _fetchVersionFile } = loadDiffAndRender({
-      baseVersionId,
-      buildTree: true,
-      headVersionId,
-      loadVersionFile: false,
-      version,
-    });
-
-    expect(_fetchVersionFile).not.toHaveBeenCalled();
   });
 
   it('dispatches an action to set current version id if currentVersionId is unset', () => {
@@ -589,78 +541,6 @@ describe(__filename, () => {
     );
   });
 
-  it('does not dispatch fetchVersionFile() when a file is loading', () => {
-    const addonId = 9999;
-    const baseVersionId = 1;
-    const headVersionId = baseVersionId + 1;
-    const version = { ...fakeVersionWithDiff, id: headVersionId };
-    const store = configureStore();
-
-    dispatchLoadVersionInfo({ store, version });
-
-    store.dispatch(
-      versionsActions.loadEntryStatusMap({
-        version,
-        comparedToVersionId: baseVersionId,
-      }),
-    );
-
-    store.dispatch(
-      versionsActions.loadDiff({
-        addonId,
-        baseVersionId,
-        headVersionId,
-        version,
-      }),
-    );
-
-    store.dispatch(
-      versionsActions.setCurrentVersionId({
-        versionId: headVersionId,
-      }),
-    );
-
-    store.dispatch(
-      versionsActions.beginFetchVersionFile({
-        path: version.file.selected_file,
-        versionId: version.id,
-      }),
-    );
-
-    const dispatch = spyOn(store, 'dispatch');
-    const fakeThunk = createFakeThunk();
-    const _fetchVersionFile = fakeThunk.createThunk;
-
-    render({
-      ...getRouteParams({ addonId, baseVersionId, headVersionId }),
-      _fetchVersionFile,
-      store,
-    });
-
-    expect(dispatch).not.toHaveBeenCalledWith(fakeThunk.thunk);
-  });
-
-  it('does not dispatch fetchVersionFile() when the file is already loaded', () => {
-    const addonId = 999;
-    const baseVersionId = 1;
-    const version = { ...fakeVersionWithDiff, id: baseVersionId + 1 };
-    const headVersionId = version.id;
-    const fakeThunk = createFakeThunk();
-    const _fetchVersionFile = fakeThunk.createThunk;
-
-    const store = configureStore();
-    _loadDiff({ addonId, baseVersionId, headVersionId, store, version });
-    const dispatch = spyOn(store, 'dispatch');
-
-    render({
-      ...getRouteParams({ addonId, baseVersionId, headVersionId }),
-      _fetchVersionFile,
-      store,
-    });
-
-    expect(dispatch).not.toHaveBeenCalledWith(fakeThunk.thunk);
-  });
-
   it('redirects to a new compare url when the "old" version is newer than the "new" version', () => {
     const addonId = 123456;
     const baseVersionId = 2;
@@ -670,13 +550,13 @@ describe(__filename, () => {
     const store = configureStore();
     const dispatch = spyOn(store, 'dispatch');
     const fakeThunk = createFakeThunk();
-    const _fetchDiff = fakeThunk.createThunk;
+    const _fetchVersionWithDiff = fakeThunk.createThunk;
     const history = createFakeHistory();
     const push = spyOn(history, 'push');
 
     render({
       ...getRouteParams({ addonId, baseVersionId, headVersionId }),
-      _fetchDiff,
+      _fetchVersionWithDiff,
       history,
       lang,
       store,
@@ -696,9 +576,9 @@ describe(__filename, () => {
     expect(dispatchSpy).not.toHaveBeenCalledWith(fakeThunk.thunk);
   });
 
-  it('dispatches fetchDiff() on update when baseVersionId changes', () => {
+  it('dispatches fetchVersionWithDiff() on update when baseVersionId changes', () => {
     const {
-      _fetchDiff,
+      _fetchVersionWithDiff,
       addonId,
       baseVersionId,
       dispatchSpy,
@@ -728,14 +608,14 @@ describe(__filename, () => {
     });
 
     expect(dispatchSpy).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(_fetchDiff).toHaveBeenCalledWith(
+    expect(_fetchVersionWithDiff).toHaveBeenCalledWith(
       expect.objectContaining({ baseVersionId: newBaseVersionId }),
     );
   });
 
-  it('dispatches fetchDiff() on update when headVersionId changes', () => {
+  it('dispatches fetchVersionWithDiff() on update when headVersionId changes', () => {
     const {
-      _fetchDiff,
+      _fetchVersionWithDiff,
       addonId,
       baseVersionId,
       dispatchSpy,
@@ -765,90 +645,12 @@ describe(__filename, () => {
     });
 
     expect(dispatchSpy).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(_fetchDiff).toHaveBeenCalledWith(
+    expect(_fetchVersionWithDiff).toHaveBeenCalledWith(
       expect.objectContaining({ headVersionId: newHeadVersionId }),
     );
   });
 
-  it('dispatches fetchDiff() on update when addonId changes', () => {
-    const {
-      _fetchDiff,
-      addonId,
-      baseVersionId,
-      dispatchSpy,
-      fakeThunk,
-      headVersionId,
-      root,
-      store,
-    } = loadDiffAndRender();
-
-    const newAddonId = addonId + 1;
-    const routerProps = {
-      ...createFakeRouteComponentProps({
-        params: getRouteParams({
-          addonId: newAddonId,
-          baseVersionId,
-          headVersionId,
-        }),
-      }),
-    };
-
-    root.setProps({
-      ...routerProps,
-      ...mapStateToProps(store.getState(), {
-        ...root.instance().props,
-        ...routerProps,
-      }),
-    });
-
-    expect(dispatchSpy).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(_fetchDiff).toHaveBeenCalledWith(
-      expect.objectContaining({ addonId: newAddonId }),
-    );
-  });
-
-  it('dispatches fetchDiff() on update when path changes', () => {
-    const {
-      _fetchDiff,
-      addonId,
-      baseVersionId,
-      dispatchSpy,
-      fakeThunk,
-      headVersionId,
-      root,
-      store,
-    } = loadDiffAndRender();
-
-    const path = 'some-new-path';
-    const history = createFakeHistory({
-      location: createFakeLocation({
-        search: queryString.stringify({ path }),
-      }),
-    });
-    const routerProps = {
-      ...createFakeRouteComponentProps({
-        history,
-        params: getRouteParams({
-          addonId,
-          baseVersionId,
-          headVersionId,
-        }),
-      }),
-    };
-
-    root.setProps({
-      ...routerProps,
-      ...mapStateToProps(store.getState(), {
-        ...root.instance().props,
-        ...routerProps,
-      }),
-    });
-
-    expect(dispatchSpy).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(_fetchDiff).toHaveBeenCalledWith(expect.objectContaining({ path }));
-  });
-
-  it('dispatches fetchDiff() when entryStatusMap has not been loaded', () => {
+  it('dispatches fetchVersionWithDiff() when entryStatusMap has not been loaded', () => {
     const addonId = 10;
     const headVersionId = 222;
     const baseVersionId = 31;
@@ -863,12 +665,12 @@ describe(__filename, () => {
       loadEntryStatusMap: false,
     });
     const fakeThunk = createFakeThunk();
-    const _fetchDiff = fakeThunk.createThunk;
+    const _fetchVersionWithDiff = fakeThunk.createThunk;
 
     const dispatchSpy = spyOn(store, 'dispatch');
 
     render({
-      _fetchDiff,
+      _fetchVersionWithDiff,
       addonId: String(addonId),
       baseVersionId: String(baseVersionId),
       headVersionId: String(headVersionId),
@@ -909,13 +711,13 @@ describe(__filename, () => {
     });
   });
 
-  it('does not dispatch fetchDiff() when the diff is already loaded', () => {
+  it('does not dispatch fetchVersionWithDiff() when the diff is already loaded', () => {
     const { dispatchSpy, fakeThunk } = loadDiffAndRender();
 
     expect(dispatchSpy).not.toHaveBeenCalledWith(fakeThunk.thunk);
   });
 
-  it('does not dispatch fetchDiff() when path remains the same on update', () => {
+  it('does not dispatch fetchVersionWithDiff() when path remains the same on update', () => {
     const path = 'manifest.json';
     const { dispatchSpy, fakeThunk, root } = loadDiffAndRender({
       selected_file: path,
@@ -927,7 +729,7 @@ describe(__filename, () => {
     expect(dispatchSpy).not.toHaveBeenCalledWith(fakeThunk.thunk);
   });
 
-  it('does not dispatch fetchDiff() when path is the default file on update', () => {
+  it('does not dispatch fetchVersionWithDiff() when path is the default file on update', () => {
     const { dispatchSpy, fakeThunk, root, version } = loadDiffAndRender();
 
     // Once the default file is loaded (without `path` defined), there is an
@@ -937,7 +739,7 @@ describe(__filename, () => {
     expect(dispatchSpy).not.toHaveBeenCalledWith(fakeThunk.thunk);
   });
 
-  it('dispatches fetchDiff() with the path specified in the URL on mount', () => {
+  it('dispatches fetchVersionWithDiff() with the path specified in the URL on mount', () => {
     const addonId = 9999;
     const baseVersionId = 1;
     const headVersionId = baseVersionId + 1;
@@ -951,17 +753,17 @@ describe(__filename, () => {
     const store = configureStore();
     const dispatch = spyOn(store, 'dispatch');
     const fakeThunk = createFakeThunk();
-    const _fetchDiff = fakeThunk.createThunk;
+    const _fetchVersionWithDiff = fakeThunk.createThunk;
 
     render({
       ...getRouteParams({ addonId, baseVersionId, headVersionId }),
-      _fetchDiff,
+      _fetchVersionWithDiff,
       history,
       store,
     });
 
     expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
-    expect(_fetchDiff).toHaveBeenCalledWith(
+    expect(_fetchVersionWithDiff).toHaveBeenCalledWith(
       expect.objectContaining({
         addonId,
         baseVersionId,
@@ -1028,44 +830,52 @@ describe(__filename, () => {
       );
       const dispatch = spyOn(store, 'dispatch');
       const fakeThunk = createFakeThunk();
-      const _fetchDiff = fakeThunk.createThunk;
+      const _fetchVersionWithDiff = fakeThunk.createThunk;
 
       render({
         ...getRouteParams({ addonId, baseVersionId, headVersionId }),
-        _fetchDiff,
+        _fetchVersionWithDiff,
         store,
       });
-      return { dispatch, fakeThunk, store, _fetchDiff };
+      return { dispatch, fakeThunk, store, _fetchVersionWithDiff };
     };
 
-    it('dispatches fetchDiff() with forceReloadVersion set when the file tree has obsolete forVersionId', () => {
+    it('dispatches fetchVersionWithDiff() with forceReloadVersion set when the file tree has obsolete forVersionId', () => {
       const baseVersionId = nextUniqueId();
       const headVersionId = baseVersionId + 10;
-      const { dispatch, fakeThunk, _fetchDiff } = setUpFileTreeAndRender({
+      const {
+        dispatch,
+        fakeThunk,
+        _fetchVersionWithDiff,
+      } = setUpFileTreeAndRender({
         baseVersionId,
         forVersionId: headVersionId + 1,
         headVersionId,
       });
 
       expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
-      expect(_fetchDiff).toHaveBeenCalledWith(
+      expect(_fetchVersionWithDiff).toHaveBeenCalledWith(
         expect.objectContaining({
           forceReloadVersion: true,
         }),
       );
     });
 
-    it('dispatches fetchDiff() with forceReloadVersion set when the file tree has obsolete comparedToVersionId', () => {
+    it('dispatches fetchVersionWithDiff() with forceReloadVersion set when the file tree has obsolete comparedToVersionId', () => {
       const baseVersionId = nextUniqueId();
       const headVersionId = baseVersionId + 10;
-      const { dispatch, fakeThunk, _fetchDiff } = setUpFileTreeAndRender({
+      const {
+        dispatch,
+        fakeThunk,
+        _fetchVersionWithDiff,
+      } = setUpFileTreeAndRender({
         baseVersionId,
         comparedToVersionId: baseVersionId + 1,
         headVersionId,
       });
 
       expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
-      expect(_fetchDiff).toHaveBeenCalledWith(
+      expect(_fetchVersionWithDiff).toHaveBeenCalledWith(
         expect.objectContaining({
           forceReloadVersion: true,
         }),
@@ -1080,7 +890,7 @@ describe(__filename, () => {
 
     const store = configureStore();
     store.dispatch(
-      versionsActions.beginFetchDiff({
+      versionsActions.beginFetchVersionWithDiff({
         addonId,
         baseVersionId,
         headVersionId,
@@ -1088,7 +898,7 @@ describe(__filename, () => {
     );
     // Simulate an API error.
     store.dispatch(
-      versionsActions.abortFetchDiff({
+      versionsActions.abortFetchVersionWithDiff({
         addonId,
         baseVersionId,
         headVersionId,
@@ -1130,8 +940,8 @@ describe(__filename, () => {
         { id: headVersionId, selected_file: currentFile },
       );
       const {
-        _fetchDiff,
-        _fetchVersionFile,
+        _fetchVersionWithDiff,
+        _fetchDiffFile,
         dispatchSpy,
         fakeThunk,
       } = loadDiffAndRender({
@@ -1141,22 +951,21 @@ describe(__filename, () => {
         ...params,
       });
       return {
-        _fetchDiff,
-        _fetchVersionFile,
+        _fetchVersionWithDiff,
+        _fetchDiffFile,
         dispatchSpy,
         fakeThunk,
       };
     };
 
-    it('dispatches fetchDiff and fetchVersionFile for the next file with diff', () => {
+    it('dispatches fetchDiffFile for the next file with diff', () => {
       const addonId = 10;
       const baseVersionId = 44;
       const headVersionId = 55;
       const currentFile = 'current.json';
       const nextModifiedFile = 'modified.json';
       const {
-        _fetchDiff,
-        _fetchVersionFile,
+        _fetchDiffFile,
         dispatchSpy,
         fakeThunk,
       } = setUpForPreloadAndRender({
@@ -1168,28 +977,22 @@ describe(__filename, () => {
       });
 
       expect(dispatchSpy).toHaveBeenCalledWith(fakeThunk.thunk);
-      expect(_fetchDiff).toHaveBeenCalledWith({
+      expect(_fetchDiffFile).toHaveBeenCalledWith({
         addonId,
         baseVersionId,
         headVersionId,
         path: nextModifiedFile,
       });
-      expect(_fetchVersionFile).toHaveBeenCalledWith({
-        addonId,
-        versionId: headVersionId,
-        path: nextModifiedFile,
-      });
     });
 
-    it('dispatches fetchDiff and fetchVersionFile for the next file when the current file was deleted', () => {
+    it('dispatches fetchDiffFile for the next file when the current file was deleted', () => {
       const addonId = nextUniqueId();
       const baseVersionId = nextUniqueId();
       const headVersionId = baseVersionId + 1;
       const currentFile = 'current.json';
       const nextModifiedFile = 'modified.json';
       const {
-        _fetchDiff,
-        _fetchVersionFile,
+        _fetchDiffFile,
         dispatchSpy,
         fakeThunk,
       } = setUpForPreloadAndRender({
@@ -1197,43 +1000,32 @@ describe(__filename, () => {
         baseVersionId,
         currentFile,
         currentFileStatus: 'D',
-        loadVersionFile: false,
         headVersionId,
         nextModifiedFile,
         nextModifiedFileStatus: 'M',
       });
 
       expect(dispatchSpy).toHaveBeenCalledWith(fakeThunk.thunk);
-      expect(_fetchDiff).toHaveBeenCalledWith({
+      expect(_fetchDiffFile).toHaveBeenCalledWith({
         addonId,
         baseVersionId,
         headVersionId,
         path: nextModifiedFile,
       });
-      expect(_fetchVersionFile).toHaveBeenCalledWith({
-        addonId,
-        versionId: headVersionId,
-        path: nextModifiedFile,
-      });
     });
 
-    it.each([['buildTree'], ['loadVersionFile'], ['loadDiff']])(
-      'does not dispatch fetchDiff or fetchVersionFile for the next file before %s is dispatched',
+    it.each([['buildTree'], ['loadDiff']])(
+      'does not dispatch fetchDiffFile for the next file before %s is dispatched',
       (action) => {
         const currentFile = 'current.json';
         const nextModifiedFile = 'next.json';
-        const { _fetchDiff, _fetchVersionFile } = setUpForPreloadAndRender({
+        const { _fetchDiffFile } = setUpForPreloadAndRender({
           currentFile,
           nextModifiedFile,
           [action]: false,
         });
 
-        expect(_fetchDiff).not.toHaveBeenCalledWith(
-          expect.objectContaining({
-            path: nextModifiedFile,
-          }),
-        );
-        expect(_fetchVersionFile).not.toHaveBeenCalledWith(
+        expect(_fetchDiffFile).not.toHaveBeenCalledWith(
           expect.objectContaining({
             path: nextModifiedFile,
           }),
@@ -1241,92 +1033,15 @@ describe(__filename, () => {
       },
     );
 
-    it('does not dispatch fetchVersionFile for the next file if it is loading', () => {
-      const headVersionId = 2222;
-      const baseVersionId = 11;
-      const currentFile = 'current.json';
-      const nextModifiedFile = 'next.json';
-      const store = configureStore();
-      store.dispatch(
-        versionsActions.beginFetchVersionFile({
-          path: nextModifiedFile,
-          versionId: headVersionId,
-        }),
-      );
-      const { _fetchVersionFile } = setUpForPreloadAndRender({
-        baseVersionId,
-        currentFile,
-        headVersionId,
-        nextModifiedFile,
-        store,
-      });
-
-      expect(_fetchVersionFile).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          versionId: headVersionId,
-          path: nextModifiedFile,
-        }),
-      );
-    });
-
-    it('does not dispatch fetchVersionFile for the next file when it is already loaded', () => {
-      const headVersionId = 2222;
-      const baseVersionId = 11;
-      const currentFile = 'current.json';
-      const nextModifiedFile = 'next.json';
-      const store = configureStore();
-      store.dispatch(
-        versionsActions.loadVersionFile({
-          path: nextModifiedFile,
-          version: createExternalVersionWithEntries(
-            [{ path: nextModifiedFile }],
-            { id: headVersionId },
-          ),
-        }),
-      );
-      const { _fetchVersionFile } = setUpForPreloadAndRender({
-        baseVersionId,
-        currentFile,
-        headVersionId,
-        nextModifiedFile,
-        store,
-      });
-
-      expect(_fetchVersionFile).not.toHaveBeenCalled();
-    });
-
-    it('does not dispatch fetchVersionFile for the next file which has been deleted in the new version', () => {
-      const baseVersionId = nextUniqueId();
-      const headVersionId = baseVersionId + 1;
-      const currentFile = 'current.json';
-      const nextModifiedFile = 'next.json';
-      const store = configureStore();
-
-      const { _fetchVersionFile } = setUpForPreloadAndRender({
-        baseVersionId,
-        currentFile,
-        headVersionId,
-        nextModifiedFile,
-        nextModifiedFileStatus: 'D',
-        store,
-      });
-
-      expect(_fetchVersionFile).not.toHaveBeenCalled();
-    });
-
-    it('does not dispatch fetchDiff for the next diff when it is already loaded', () => {
+    it('does not dispatch fetchDiffFile for the next diff when it is already loaded', () => {
       const addonId = 2;
       const headVersionId = 2222;
       const baseVersionId = 11;
       const currentFile = 'current.json';
       const nextModifiedFile = 'next.json';
       const store = configureStore();
-      dispatchLoadVersionInfo({
-        store,
-        version: { ...fakeVersionWithContent, id: headVersionId },
-      });
       store.dispatch(
-        versionsActions.loadDiff({
+        versionsActions.loadDiffFile({
           addonId,
           baseVersionId,
           headVersionId,
@@ -1334,7 +1049,8 @@ describe(__filename, () => {
           path: nextModifiedFile,
         }),
       );
-      const { _fetchDiff } = setUpForPreloadAndRender({
+
+      const { _fetchDiffFile } = setUpForPreloadAndRender({
         addonId,
         baseVersionId,
         currentFile,
@@ -1343,43 +1059,45 @@ describe(__filename, () => {
         store,
       });
 
-      expect(_fetchDiff).not.toHaveBeenCalled();
+      expect(_fetchDiffFile).not.toHaveBeenCalled();
     });
   });
 
   it('configures VersionFileViewer with a file', () => {
-    const addonId = 1;
-    const baseVersionId = 1;
-    const version = { ...fakeVersionWithDiff, id: baseVersionId + 1 };
+    const addonId = nextUniqueId();
+    const baseVersionId = nextUniqueId();
+    const version = {
+      ...fakeVersionWithDiff,
+      addon: { ...fakeVersionAddon, id: addonId },
+      id: baseVersionId + 1,
+    };
     const entryStatusMap = createEntryStatusMap(version);
     const headVersionId = version.id;
 
-    const { store, root } = loadDiffAndRender({
+    const { root } = loadDiffAndRender({
       addonId,
       baseVersionId,
       headVersionId,
       version,
     });
 
+    const expectedFile = createInternalVersionFile(
+      version.file,
+    ) as VersionFileWithDiff;
+
     const viewer = root.find(VersionFileViewer);
     expect(viewer).toHaveProp('getCodeLineAnchor');
     expect(viewer).toHaveProp(
       'file',
-      expect.objectContaining({
-        id: version.file.id,
-        size: version.file.size,
-      }),
+      // expect.objectContaining({
+      //   id: version.file.id,
+      //   size: version.file.size,
+      // }),
+      expectedFile,
     );
     expect(viewer).toHaveProp('entryStatusMap', entryStatusMap);
 
-    const getterFromFactory = createCodeLineAnchorGetter({
-      compareInfo: getCompareInfo(
-        store.getState().versions,
-        addonId,
-        baseVersionId,
-        headVersionId,
-      ),
-    });
+    const getterFromFactory = createCodeLineAnchorGetter(expectedFile);
 
     const getCodeLineAnchor = viewer.prop('getCodeLineAnchor');
     if (!getCodeLineAnchor) {
@@ -1392,13 +1110,17 @@ describe(__filename, () => {
   });
 
   it('configures VersionFileViewer with a file even for empty diffs', () => {
+    const addonId = nextUniqueId();
+    const baseVersionId = nextUniqueId();
     const fileId = fakeVersionWithDiff.file.id + 1;
-    const headVersionId = 2;
+    const headVersionId = baseVersionId + 1;
     const { root } = loadDiffAndRender({
-      baseVersionId: headVersionId - 1,
+      addonId,
+      baseVersionId,
       headVersionId,
       version: {
         ...fakeVersionWithDiff,
+        addon: { ...fakeVersionAddon, id: addonId },
         id: headVersionId,
         file: {
           ...fakeVersionWithDiff.file,
@@ -1464,14 +1186,16 @@ describe(__filename, () => {
       location: Location;
       pathList: string[];
     }) => {
+      const addonId = nextUniqueId();
       const baseVersionId = headVersionId - 1;
       const history = createFakeHistory({ location });
       const version = createExternalVersionWithEntries(
         pathList.map((path) => ({ path })),
-        { id: headVersionId, selected_file: initialPath },
+        { addonId, id: headVersionId, selected_file: initialPath },
       );
 
       return loadDiffAndRender({
+        addonId,
         baseVersionId,
         headVersionId,
         history,

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -297,7 +297,7 @@ describe(__filename, () => {
       headVersionId,
       path,
       versions: store.getState().versions,
-    }) as VersionFileWithDiff;
+    });
 
     const viewer = root.find(VersionFileViewer);
     expect(viewer).toHaveLength(1);
@@ -1124,9 +1124,7 @@ describe(__filename, () => {
       version,
     });
 
-    const expectedFile = createInternalVersionFile(
-      version.file,
-    ) as VersionFileWithDiff;
+    const expectedFile = createInternalVersionFile(version.file);
 
     const viewer = root.find(VersionFileViewer);
     expect(viewer).toHaveProp('getCodeLineAnchor');

--- a/src/pages/Compare/index.spec.tsx
+++ b/src/pages/Compare/index.spec.tsx
@@ -717,6 +717,49 @@ describe(__filename, () => {
     expect(dispatchSpy).not.toHaveBeenCalledWith(fakeThunk.thunk);
   });
 
+  it('dispatches fetchDiffFile() when the version, but not the specific diff is already loaded', () => {
+    const addonId = nextUniqueId();
+    const baseVersionId = nextUniqueId();
+    const headVersionId = baseVersionId + 1;
+    const path = 'a/different/file.js';
+    const history = createFakeHistory({
+      location: createFakeLocation({
+        search: queryString.stringify({ path }),
+      }),
+    });
+    const version = {
+      ...fakeVersionWithDiff,
+      id: headVersionId,
+    };
+
+    const fakeThunk = createFakeThunk();
+    const _fetchDiffFile = createFakeThunk().createThunk;
+
+    const store = configureStore();
+    _loadDiff({ baseVersionId, headVersionId, store, version });
+
+    const dispatchSpy = spyOn(store, 'dispatch');
+
+    render({
+      _fetchDiffFile,
+      addonId: String(addonId),
+      baseVersionId: String(baseVersionId),
+      headVersionId: String(headVersionId),
+      history,
+      store,
+    });
+
+    expect(dispatchSpy).toHaveBeenCalledWith(fakeThunk.thunk);
+    expect(_fetchDiffFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        addonId,
+        baseVersionId,
+        headVersionId,
+        path,
+      }),
+    );
+  });
+
   it('does not dispatch fetchVersionWithDiff() when path remains the same on update', () => {
     const path = 'manifest.json';
     const { dispatchSpy, fakeThunk, root } = loadDiffAndRender({

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -3357,7 +3357,7 @@ describe(__filename, () => {
       const path = undefined;
 
       expect(
-        isDiffFileLoading(
+        isDiffLoading(
           initialState,
           addonId,
           baseVersionId,

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -27,14 +27,12 @@ import reducer, {
   createInternalVersionsListItem,
   createReducer,
   createVersionsMap,
-  fetchDiff,
+  fetchVersionWithDiff,
   fetchDiffFile,
   fetchVersion,
   fetchVersionFile,
   fetchVersionsList,
   getInsertedLines,
-  getCompareInfo,
-  getCompareInfoKey,
   getDiffAnchors,
   getDiffKey,
   getEntryStatusMapKey,
@@ -51,8 +49,7 @@ import reducer, {
   getVersionInfo,
   goToRelativeDiff,
   initialState,
-  isCompareInfoLoading,
-  isDiffFileLoading,
+  isDiffLoading,
   isFileLoading,
   isFileWithContent,
   isFileWithDiff,
@@ -710,68 +707,6 @@ describe(__filename, () => {
       expect(state.byAddonId[addonId]).toEqual(createVersionsMap(versions));
     });
 
-    it('sets the compare info to `null` and the loading flag to `false` on abortFetchDiff()', () => {
-      const addonId = 1;
-      const baseVersionId = 2;
-      const headVersionId = 2;
-
-      let versionsState = reducer(
-        undefined,
-        actions.beginFetchDiff({
-          addonId,
-          baseVersionId,
-          headVersionId,
-        }),
-      );
-      versionsState = reducer(
-        versionsState,
-        actions.abortFetchDiff({
-          addonId,
-          baseVersionId,
-          headVersionId,
-        }),
-      );
-
-      expect(
-        getCompareInfo(versionsState, addonId, baseVersionId, headVersionId),
-      ).toEqual(null);
-      expect(
-        isCompareInfoLoading(
-          versionsState,
-          addonId,
-          baseVersionId,
-          headVersionId,
-        ),
-      ).toEqual(false);
-    });
-
-    it('resets the compare info and sets the loading flag to `true` on beginFetchDiff()', () => {
-      const addonId = 1;
-      const baseVersionId = 2;
-      const headVersionId = 2;
-
-      let versionsState = reducer(
-        undefined,
-        actions.abortFetchDiff({ addonId, baseVersionId, headVersionId }),
-      );
-      versionsState = reducer(
-        versionsState,
-        actions.beginFetchDiff({ addonId, baseVersionId, headVersionId }),
-      );
-
-      expect(
-        getCompareInfo(versionsState, addonId, baseVersionId, headVersionId),
-      ).toEqual(undefined);
-      expect(
-        isCompareInfoLoading(
-          versionsState,
-          addonId,
-          baseVersionId,
-          headVersionId,
-        ),
-      ).toEqual(true);
-    });
-
     it('sets the VersionDiff to `null` and the loading flag to `false` on abortFetchDiffFile()', () => {
       const addonId = nextUniqueId();
       const baseVersionId = nextUniqueId();
@@ -808,13 +743,7 @@ describe(__filename, () => {
         }),
       ).toEqual(null);
       expect(
-        isDiffFileLoading(
-          versions,
-          addonId,
-          baseVersionId,
-          headVersionId,
-          path,
-        ),
+        isDiffLoading(versions, addonId, baseVersionId, headVersionId, path),
       ).toEqual(false);
     });
 
@@ -853,82 +782,8 @@ describe(__filename, () => {
         }),
       ).toEqual(undefined);
       expect(
-        isDiffFileLoading(
-          versions,
-          addonId,
-          baseVersionId,
-          headVersionId,
-          path,
-        ),
+        isDiffLoading(versions, addonId, baseVersionId, headVersionId, path),
       ).toEqual(true);
-    });
-
-    it('loads compare info', () => {
-      const addonId = nextUniqueId();
-      const baseVersionId = nextUniqueId();
-      const path = 'manifest.json';
-      const mimeType = 'mime/type';
-
-      const version = {
-        ...fakeVersionWithDiff,
-        file: {
-          ...fakeVersionWithDiff.file,
-          mimetype: mimeType,
-          // eslint-disable-next-line @typescript-eslint/camelcase
-          selected_file: path,
-        },
-      };
-      const headVersionId = version.id;
-
-      let versionsState = reducer(
-        undefined,
-        _loadVersionInfo({
-          version,
-        }),
-      );
-      versionsState = reducer(
-        versionsState,
-        actions.loadDiff({
-          addonId,
-          baseVersionId,
-          headVersionId,
-          version,
-        }),
-      );
-
-      expect(
-        getCompareInfo(versionsState, addonId, baseVersionId, headVersionId),
-      ).toEqual({
-        diff: createInternalDiff(version.file.diff),
-        mimeType,
-      });
-      expect(
-        isCompareInfoLoading(
-          versionsState,
-          addonId,
-          baseVersionId,
-          headVersionId,
-        ),
-      ).toEqual(false);
-    });
-
-    it('throws an error message when headVersion is missing on loadDiff()', () => {
-      const addonId = 1;
-      const baseVersionId = 2;
-      const version = fakeVersionWithDiff;
-      const headVersionId = version.id;
-
-      expect(() => {
-        reducer(
-          undefined,
-          actions.loadDiff({
-            addonId,
-            baseVersionId,
-            headVersionId,
-            version,
-          }),
-        );
-      }).toThrow(/Version missing for headVersionId/);
     });
   });
 
@@ -2264,8 +2119,8 @@ describe(__filename, () => {
     });
   });
 
-  describe('fetchDiff', () => {
-    const _fetchDiff = ({
+  describe('fetchVersionWithDiff', () => {
+    const _fetchVersionWithDiff = ({
       addonId = 1,
       baseVersionId = 2,
       forceReloadVersion = false,
@@ -2278,7 +2133,7 @@ describe(__filename, () => {
       return thunkTester({
         store,
         createThunk: () =>
-          fetchDiff({
+          fetchVersionWithDiff({
             _getDiff,
             addonId,
             baseVersionId,
@@ -2289,12 +2144,12 @@ describe(__filename, () => {
       });
     };
 
-    it('dispatches beginFetchDiff()', async () => {
+    it('dispatches beginFetchVersionWithDiff()', async () => {
       const addonId = 1;
       const baseVersionId = 2;
       const headVersionId = 3;
 
-      const { dispatch, thunk } = _fetchDiff({
+      const { dispatch, thunk } = _fetchVersionWithDiff({
         addonId,
         baseVersionId,
         headVersionId,
@@ -2302,7 +2157,7 @@ describe(__filename, () => {
       await thunk();
 
       expect(dispatch).toHaveBeenCalledWith(
-        actions.beginFetchDiff({
+        actions.beginFetchVersionWithDiff({
           addonId,
           baseVersionId,
           headVersionId,
@@ -2313,7 +2168,7 @@ describe(__filename, () => {
     it('dispatches setCurrentVersionId() for headVersionId', async () => {
       const headVersionId = 3;
 
-      const { dispatch, thunk } = _fetchDiff({ headVersionId });
+      const { dispatch, thunk } = _fetchVersionWithDiff({ headVersionId });
       await thunk();
 
       expect(dispatch).toHaveBeenCalledWith(
@@ -2331,7 +2186,7 @@ describe(__filename, () => {
       const baseVersionId = version.id - 1;
       const headVersionId = version.id;
 
-      const { store, thunk } = _fetchDiff({
+      const { store, thunk } = _fetchVersionWithDiff({
         _getDiff,
         addonId,
         baseVersionId,
@@ -2352,7 +2207,7 @@ describe(__filename, () => {
       const headVersionId = 2;
       const version = { ...fakeVersionWithDiff, id: headVersionId };
 
-      const { dispatch, thunk } = _fetchDiff({
+      const { dispatch, thunk } = _fetchVersionWithDiff({
         baseVersionId,
         headVersionId,
         version,
@@ -2378,7 +2233,7 @@ describe(__filename, () => {
         }),
       );
 
-      const { dispatch, thunk } = _fetchDiff({
+      const { dispatch, thunk } = _fetchVersionWithDiff({
         baseVersionId,
         headVersionId,
         version,
@@ -2405,7 +2260,7 @@ describe(__filename, () => {
         }),
       );
 
-      const { dispatch, thunk } = _fetchDiff({
+      const { dispatch, thunk } = _fetchVersionWithDiff({
         baseVersionId,
         forceReloadVersion: true,
         headVersionId,
@@ -2433,7 +2288,7 @@ describe(__filename, () => {
         }),
       );
 
-      const { dispatch, thunk } = _fetchDiff({
+      const { dispatch, thunk } = _fetchVersionWithDiff({
         baseVersionId,
         headVersionId,
         version,
@@ -2468,7 +2323,7 @@ describe(__filename, () => {
         }),
       );
 
-      const { dispatch, thunk } = _fetchDiff({
+      const { dispatch, thunk } = _fetchVersionWithDiff({
         baseVersionId,
         headVersionId,
         version,
@@ -2484,13 +2339,13 @@ describe(__filename, () => {
       );
     });
 
-    it('dispatches loadDiff() when API response is successful', async () => {
-      const version = { ...fakeVersionWithDiff, id: 3 };
-      const addonId = 1;
-      const baseVersionId = 2;
-      const headVersionId = version.id;
+    it('dispatches loadDiffFileFromVersion when API response is successful', async () => {
+      const addonId = nextUniqueId();
+      const baseVersionId = nextUniqueId();
+      const headVersionId = nextUniqueId();
+      const version = { ...fakeVersionWithDiff, id: headVersionId };
 
-      const { dispatch, thunk } = _fetchDiff({
+      const { dispatch, thunk } = _fetchVersionWithDiff({
         addonId,
         baseVersionId,
         headVersionId,
@@ -2499,16 +2354,16 @@ describe(__filename, () => {
       await thunk();
 
       expect(dispatch).toHaveBeenCalledWith(
-        actions.loadDiff({
-          addonId,
+        actions.loadDiffFileFromVersion({
           baseVersionId,
           headVersionId,
+          path: version.file.selected_file,
           version,
         }),
       );
     });
 
-    it('dispatches abortFetchDiff() when API call has failed', async () => {
+    it('dispatches  abortFetchVersionWithDiff() when API call has failed', async () => {
       const addonId = 1;
       const baseVersionId = 2;
       const headVersionId = 2;
@@ -2520,7 +2375,7 @@ describe(__filename, () => {
         ),
       );
 
-      const { dispatch, thunk } = _fetchDiff({
+      const { dispatch, thunk } = _fetchVersionWithDiff({
         _getDiff,
         addonId,
         baseVersionId,
@@ -2529,7 +2384,7 @@ describe(__filename, () => {
       await thunk();
 
       expect(dispatch).toHaveBeenCalledWith(
-        actions.abortFetchDiff({
+        actions.abortFetchVersionWithDiff({
           addonId,
           baseVersionId,
           headVersionId,
@@ -2547,7 +2402,10 @@ describe(__filename, () => {
         ),
       );
 
-      const { dispatch, thunk } = _fetchDiff({ _getDiff, headVersionId });
+      const { dispatch, thunk } = _fetchVersionWithDiff({
+        _getDiff,
+        headVersionId,
+      });
       await thunk();
 
       expect(dispatch).toHaveBeenCalledWith(
@@ -2562,14 +2420,18 @@ describe(__filename, () => {
       const baseVersionId = 2;
       const headVersionId = 3;
 
-      const { dispatch, thunk, store } = _fetchDiff({
+      const { dispatch, thunk, store } = _fetchVersionWithDiff({
         addonId,
         baseVersionId,
         headVersionId,
       });
-      // This simulates another previous call to `fetchDiff()`.
+      // This simulates another previous call to `fetchVersionWithDiff()`.
       store.dispatch(
-        actions.beginFetchDiff({ addonId, baseVersionId, headVersionId }),
+        actions.beginFetchVersionWithDiff({
+          addonId,
+          baseVersionId,
+          headVersionId,
+        }),
       );
 
       await thunk();
@@ -3459,65 +3321,6 @@ describe(__filename, () => {
     });
   });
 
-  describe('getCompareInfoKey', () => {
-    it('computes a key given an addonId, baseVersionId and headVersionId', () => {
-      const addonId = 123;
-      const baseVersionId = 1;
-      const headVersionId = 2;
-
-      expect(
-        getCompareInfoKey({ addonId, baseVersionId, headVersionId }),
-      ).toEqual(`${addonId}/${baseVersionId}/${headVersionId}/`);
-    });
-
-    it('computes a key given an addonId, baseVersionId, headVersionId and path', () => {
-      const addonId = 123;
-      const baseVersionId = 1;
-      const headVersionId = 2;
-      const path = 'path';
-
-      expect(
-        getCompareInfoKey({ addonId, baseVersionId, headVersionId, path }),
-      ).toEqual(`${addonId}/${baseVersionId}/${headVersionId}/${path}`);
-    });
-  });
-
-  describe('isCompareInfoLoading', () => {
-    it('returns false by default', () => {
-      const addonId = 123;
-      const baseVersionId = 1;
-      const headVersionId = 2;
-
-      expect(
-        isCompareInfoLoading(
-          // Nothing has been loaded in this state.
-          initialState,
-          addonId,
-          baseVersionId,
-          headVersionId,
-        ),
-      ).toEqual(false);
-    });
-
-    it('returns true when loading compare info', () => {
-      const addonId = 123;
-      const baseVersionId = 1;
-      const headVersionId = 2;
-      const state = reducer(
-        undefined,
-        actions.beginFetchDiff({
-          addonId,
-          baseVersionId,
-          headVersionId,
-        }),
-      );
-
-      expect(
-        isCompareInfoLoading(state, addonId, baseVersionId, headVersionId),
-      ).toEqual(true);
-    });
-  });
-
   describe('getDiffKey', () => {
     const addonId = nextUniqueId();
     const baseVersionId = nextUniqueId();
@@ -3530,7 +3333,7 @@ describe(__filename, () => {
     });
   });
 
-  describe('isDiffFileLoading', () => {
+  describe('isDiffLoading', () => {
     const addonId = nextUniqueId();
     const baseVersionId = nextUniqueId();
     const headVersionId = nextUniqueId();
@@ -3539,7 +3342,7 @@ describe(__filename, () => {
       const path = 'some-file.js';
 
       expect(
-        isDiffFileLoading(
+        isDiffLoading(
           // Nothing has been loaded in this state.
           initialState,
           addonId,
@@ -3578,7 +3381,7 @@ describe(__filename, () => {
       );
 
       expect(
-        isDiffFileLoading(state, addonId, baseVersionId, headVersionId, path),
+        isDiffLoading(state, addonId, baseVersionId, headVersionId, path),
       ).toEqual(true);
     });
 
@@ -3595,7 +3398,7 @@ describe(__filename, () => {
       );
 
       expect(
-        isDiffFileLoading(
+        isDiffLoading(
           state,
           addonId,
           baseVersionId,

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -235,11 +235,6 @@ export type VersionsMap = {
   unlisted: VersionsList;
 };
 
-export type CompareInfo = {
-  diff: DiffInfo | null;
-  mimeType: string;
-};
-
 export type EntryStatusMap = {
   [nodeName: string]: VersionEntryStatus | undefined;
 };
@@ -250,6 +245,17 @@ export const actions = {
     (resolve) => {
       return (payload: { path: string; version: ExternalVersionWithContent }) =>
         resolve(payload);
+    },
+  ),
+  loadDiffFileFromVersion: createAction(
+    'LOAD_DIFF_FILE_FROM_VERSION',
+    (resolve) => {
+      return (payload: {
+        baseVersionId: number;
+        headVersionId: number;
+        path: string;
+        version: ExternalVersionWithDiff;
+      }) => resolve(payload);
     },
   ),
   loadVersionFile: createAction('LOAD_VERSION_FILE', (resolve) => {
@@ -307,14 +313,17 @@ export const actions = {
     return (payload: { addonId: number; versions: ExternalVersionsList }) =>
       resolve(payload);
   }),
-  beginFetchDiff: createAction('BEGIN_FETCH_DIFF', (resolve) => {
-    return (payload: {
-      addonId: number;
-      baseVersionId: number;
-      headVersionId: number;
-      path?: string;
-    }) => resolve(payload);
-  }),
+  beginFetchVersionWithDiff: createAction(
+    'BEGIN_FETCH_VERSION_WITH_DIFF',
+    (resolve) => {
+      return (payload: {
+        addonId: number;
+        baseVersionId: number;
+        headVersionId: number;
+        path?: string;
+      }) => resolve(payload);
+    },
+  ),
   beginFetchDiffFile: createAction('BEGIN_FETCH_DIFF_FILE', (resolve) => {
     return (payload: {
       addonId: number;
@@ -326,14 +335,17 @@ export const actions = {
   beginFetchVersionFile: createAction('BEGIN_FETCH_VERSION_FILE', (resolve) => {
     return (payload: { path: string; versionId: number }) => resolve(payload);
   }),
-  abortFetchDiff: createAction('ABORT_FETCH_DIFF', (resolve) => {
-    return (payload: {
-      addonId: number;
-      baseVersionId: number;
-      headVersionId: number;
-      path?: string;
-    }) => resolve(payload);
-  }),
+  abortFetchVersionWithDiff: createAction(
+    'ABORT_FETCH__VERSION_WITH_DIFF',
+    (resolve) => {
+      return (payload: {
+        addonId: number;
+        baseVersionId: number;
+        headVersionId: number;
+        path?: string;
+      }) => resolve(payload);
+    },
+  ),
   abortFetchDiffFile: createAction('ABORT_FETCH_DIFF_FILE', (resolve) => {
     return (payload: {
       addonId: number;
@@ -345,22 +357,13 @@ export const actions = {
   abortFetchVersionFile: createAction('ABORT_FETCH_VERSION_FILE', (resolve) => {
     return (payload: { path: string; versionId: number }) => resolve(payload);
   }),
-  loadDiff: createAction('LOAD_DIFF', (resolve) => {
-    return (payload: {
-      addonId: number;
-      baseVersionId: number;
-      headVersionId: number;
-      version: ExternalVersionWithDiff;
-      path?: string;
-    }) => resolve(payload);
-  }),
   loadDiffFile: createAction('LOAD_DIFF_FILE', (resolve) => {
     return (payload: {
       addonId: number;
       baseVersionId: number;
       headVersionId: number;
-      version: ExternalVersionWithDiffFileOnly;
       path: string;
+      version: ExternalVersionWithDiffFileOnly;
     }) => resolve(payload);
   }),
   beginFetchVersion: createAction('BEGIN_FETCH_VERSION', (resolve) => {
@@ -386,15 +389,6 @@ export const actions = {
 export type VersionsState = {
   byAddonId: {
     [addonId: number]: VersionsMap;
-  };
-  compareInfo: {
-    [compareInfoKey: string]:
-      | CompareInfo // data successfully loaded
-      | null // an error has occured
-      | undefined; // data not fetched yet
-  };
-  compareInfoIsLoading: {
-    [compareInfoKey: string]: boolean;
   };
   currentBaseVersionId:
     | number // This is an existing version ID.
@@ -451,8 +445,6 @@ export type VersionsState = {
 
 export const initialState: VersionsState = {
   byAddonId: {},
-  compareInfo: {},
-  compareInfoIsLoading: {},
   currentBaseVersionId: undefined,
   currentVersionId: undefined,
   entryStatusMaps: {},
@@ -821,7 +813,7 @@ export const isFileLoading = (
   return false;
 };
 
-export const isDiffFileLoading = (
+export const isDiffLoading = (
   versions: VersionsState,
   addonId: number,
   baseVersionId: number,
@@ -1105,9 +1097,7 @@ export const fetchDiffFile = ({
   return async (dispatch, getState) => {
     const { api: apiState, versions } = getState();
 
-    if (
-      isDiffFileLoading(versions, addonId, baseVersionId, headVersionId, path)
-    ) {
+    if (isDiffLoading(versions, addonId, baseVersionId, headVersionId, path)) {
       return;
     }
 
@@ -1215,70 +1205,7 @@ type GetDiffKeyParams = {
   headVersionId: number;
 };
 
-type GetCompareInfoKeyParams = {
-  addonId: number;
-  baseVersionId: number;
-  headVersionId: number;
-  path?: string;
-};
-
-export const getCompareInfoKey = ({
-  addonId,
-  baseVersionId,
-  headVersionId,
-  path,
-}: GetCompareInfoKeyParams) => {
-  return [addonId, baseVersionId, headVersionId, path].join('/');
-};
-
-export const createInternalCompareInfo = ({
-  version,
-}: {
-  baseVersionId: number;
-  headVersionId: number;
-  version: ExternalVersionWithDiff;
-}): CompareInfo => {
-  return {
-    diff: createInternalDiff(version.file.diff),
-    mimeType: version.file.mimetype,
-  };
-};
-
-export const getCompareInfo = (
-  versions: VersionsState,
-  addonId: number,
-  baseVersionId: number,
-  headVersionId: number,
-  path?: string,
-) => {
-  const compareInfoKey = getCompareInfoKey({
-    addonId,
-    baseVersionId,
-    headVersionId,
-    path,
-  });
-
-  return versions.compareInfo[compareInfoKey];
-};
-
-export const isCompareInfoLoading = (
-  versions: VersionsState,
-  addonId: number,
-  baseVersionId: number,
-  headVersionId: number,
-  path?: string,
-) => {
-  const compareInfoKey = getCompareInfoKey({
-    addonId,
-    baseVersionId,
-    headVersionId,
-    path,
-  });
-
-  return versions.compareInfoIsLoading[compareInfoKey] || false;
-};
-
-export const fetchDiff = ({
+export const fetchVersionWithDiff = ({
   _getDiff = getDiff,
   addonId,
   baseVersionId,
@@ -1289,20 +1216,19 @@ export const fetchDiff = ({
   return async (dispatch, getState) => {
     const { api: apiState, versions: versionsState } = getState();
     if (
-      isCompareInfoLoading(
-        versionsState,
-        addonId,
-        baseVersionId,
-        headVersionId,
-        path,
-      )
+      isDiffLoading(versionsState, addonId, baseVersionId, headVersionId, path)
     ) {
       log.debug('Aborting because the diff is already being fetched');
       return;
     }
 
     dispatch(
-      actions.beginFetchDiff({ addonId, baseVersionId, headVersionId, path }),
+      actions.beginFetchVersionWithDiff({
+        addonId,
+        baseVersionId,
+        headVersionId,
+        path,
+      }),
     );
     // Set the current version to the newer one (the head vesion) so that
     // components can track its loading progress.
@@ -1318,13 +1244,20 @@ export const fetchDiff = ({
 
     if (isErrorResponse(response)) {
       dispatch(
-        actions.abortFetchDiff({ addonId, baseVersionId, headVersionId, path }),
+        actions.abortFetchVersionWithDiff({
+          addonId,
+          baseVersionId,
+          headVersionId,
+          path,
+        }),
       );
       // Since the diff response loads a version, we also need to simulate
       // aborting a version fetch.
       dispatch(actions.abortFetchVersion({ versionId: headVersionId }));
       dispatch(errorsActions.addError({ error: response.error }));
     } else {
+      const { selected_file } = response.file;
+
       if (forceReloadVersion || !getVersionInfo(versionsState, response.id)) {
         dispatch(
           actions.loadVersionInfo({
@@ -1348,11 +1281,10 @@ export const fetchDiff = ({
         );
       }
       dispatch(
-        actions.loadDiff({
-          addonId,
+        actions.loadDiffFileFromVersion({
           baseVersionId,
           headVersionId,
-          path,
+          path: selected_file,
           version: response,
         }),
       );
@@ -1592,6 +1524,70 @@ export const createReducer = ({
           },
         };
       }
+      case getType(actions.loadDiffFileFromVersion): {
+        const { baseVersionId, headVersionId, version } = action.payload;
+        const path = action.payload.path || '';
+        const key = getDiffKey({
+          addonId: version.addon.id,
+          baseVersionId,
+          headVersionId,
+        });
+
+        return {
+          ...state,
+          versionDiffs: {
+            ...state.versionDiffs,
+            [key]: {
+              ...state.versionDiffs[key],
+              [path]: createInternalVersionFile(
+                version.file,
+              ) as VersionFileWithDiff,
+            },
+          },
+          versionDiffsLoading: {
+            ...state.versionDiffsLoading,
+            [key]: {
+              ...state.versionDiffsLoading[key],
+              [path]: false,
+            },
+          },
+        };
+      }
+      case getType(actions.loadDiffFile): {
+        const {
+          addonId,
+          baseVersionId,
+          headVersionId,
+          path,
+          version,
+        } = action.payload;
+
+        const key = getDiffKey({
+          addonId,
+          baseVersionId,
+          headVersionId,
+        });
+
+        return {
+          ...state,
+          versionDiffs: {
+            ...state.versionDiffs,
+            [key]: {
+              ...state.versionDiffs[key],
+              [path]: createInternalVersionFile(
+                version.file,
+              ) as VersionFileWithDiff,
+            },
+          },
+          versionDiffsLoading: {
+            ...state.versionDiffsLoading,
+            [key]: {
+              ...state.versionDiffsLoading[key],
+              [path]: false,
+            },
+          },
+        };
+      }
       case getType(actions.loadVersionFile): {
         const { path, version } = action.payload;
 
@@ -1806,18 +1802,27 @@ export const createReducer = ({
           },
         };
       }
-      case getType(actions.beginFetchDiff): {
-        const key = getCompareInfoKey(action.payload);
+      case getType(actions.beginFetchVersionWithDiff): {
+        const path = action.payload.path || '';
+        const versionId = action.payload.headVersionId;
+        const key = getDiffKey(action.payload);
 
         return {
           ...state,
-          compareInfo: {
-            ...state.compareInfo,
-            [key]: undefined,
+          versionInfo: {
+            ...state.versionInfo,
+            [versionId]: undefined,
           },
-          compareInfoIsLoading: {
-            ...state.compareInfoIsLoading,
-            [key]: true,
+          versionInfoLoading: {
+            ...state.versionInfoLoading,
+            [versionId]: true,
+          },
+          versionDiffsLoading: {
+            ...state.versionDiffsLoading,
+            [key]: {
+              ...state.versionDiffsLoading[key],
+              [path]: true,
+            },
           },
         };
       }
@@ -1843,27 +1848,21 @@ export const createReducer = ({
           },
         };
       }
-      case getType(actions.abortFetchDiff): {
-        const key = getCompareInfoKey(action.payload);
-
-        return {
-          ...state,
-          compareInfo: {
-            ...state.compareInfo,
-            [key]: null,
-          },
-          compareInfoIsLoading: {
-            ...state.compareInfoIsLoading,
-            [key]: false,
-          },
-        };
-      }
-      case getType(actions.abortFetchDiffFile): {
-        const { path } = action.payload;
+      case getType(actions.abortFetchVersionWithDiff): {
+        const path = action.payload.path || '';
+        const versionId = action.payload.headVersionId;
         const key = getDiffKey(action.payload);
 
         return {
           ...state,
+          versionInfo: {
+            ...state.versionInfo,
+            [versionId]: null,
+          },
+          versionInfoLoading: {
+            ...state.versionInfoLoading,
+            [versionId]: false,
+          },
           versionDiffs: {
             ...state.versionDiffs,
             [key]: {
@@ -1880,59 +1879,9 @@ export const createReducer = ({
           },
         };
       }
-      case getType(actions.loadDiff): {
-        const {
-          addonId,
-          baseVersionId,
-          headVersionId,
-          path,
-          version,
-        } = action.payload;
-
-        const compareInfoKey = getCompareInfoKey({
-          addonId,
-          baseVersionId,
-          headVersionId,
-          path,
-        });
-
-        const headVersion = getVersionInfo(state, headVersionId);
-        if (!headVersion) {
-          throw new Error(
-            `Version missing for headVersionId: ${headVersionId}`,
-          );
-        }
-
-        return {
-          ...state,
-          compareInfo: {
-            ...state.compareInfo,
-            [compareInfoKey]: createInternalCompareInfo({
-              baseVersionId,
-              headVersionId,
-              version,
-            }),
-          },
-          compareInfoIsLoading: {
-            ...state.compareInfoIsLoading,
-            [compareInfoKey]: false,
-          },
-        };
-      }
-      case getType(actions.loadDiffFile): {
-        const {
-          addonId,
-          baseVersionId,
-          headVersionId,
-          path,
-          version,
-        } = action.payload;
-
-        const key = getDiffKey({
-          addonId,
-          baseVersionId,
-          headVersionId,
-        });
+      case getType(actions.abortFetchDiffFile): {
+        const { path } = action.payload;
+        const key = getDiffKey(action.payload);
 
         return {
           ...state,
@@ -1940,9 +1889,7 @@ export const createReducer = ({
             ...state.versionDiffs,
             [key]: {
               ...state.versionDiffs[key],
-              [path]: createInternalVersionFile(
-                version.file,
-              ) as VersionFileWithDiff,
+              [path]: null,
             },
           },
           versionDiffsLoading: {

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -336,7 +336,7 @@ export const actions = {
     return (payload: { path: string; versionId: number }) => resolve(payload);
   }),
   abortFetchVersionWithDiff: createAction(
-    'ABORT_FETCH__VERSION_WITH_DIFF',
+    'ABORT_FETCH_VERSION_WITH_DIFF',
     (resolve) => {
       return (payload: {
         addonId: number;

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -39,7 +39,6 @@ import {
   ExternalVersionFileWithContent,
   ExternalVersionFileWithDiff,
   ExternalVersionWithContent,
-  ExternalVersionWithContentFileOnly,
   ExternalVersionWithDiff,
   ExternalVersionWithDiffFileOnly,
   ExternalVersionsList,
@@ -225,13 +224,6 @@ export const fakeVersionWithContent: ExternalVersionWithContent = Object.freeze(
   {
     ...partialFakeVersion,
     file: fakeVersionFileWithContent,
-  },
-);
-
-export const fakeVersionWithContentFileOnly: ExternalVersionWithContentFileOnly = Object.freeze(
-  {
-    id: fakeVersionWithContent.id,
-    file: fakeVersionWithContent.file,
   },
 );
 

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -50,7 +50,6 @@ import {
   VersionEntryType,
   actions as versionsActions,
   createEntryStatusMap,
-  createInternalCompareInfo,
   createInternalVersion,
 } from './reducers/versions';
 import Commentable, {
@@ -457,22 +456,6 @@ export const createFakeLinterMessagesByPath = ({
     throw new Error(`Somehow no messages were mapped to path "${path}"`);
   }
   return map.byPath[path];
-};
-
-export const createFakeCompareInfo = ({
-  baseVersionId = 1,
-  headVersionId = 2,
-  version = fakeVersionWithDiff,
-}: {
-  baseVersionId?: number;
-  headVersionId?: number;
-  version?: ExternalVersionWithDiff;
-} = {}) => {
-  return createInternalCompareInfo({
-    baseVersionId,
-    headVersionId,
-    version,
-  });
 };
 
 export const createFakeLocation = ({

--- a/src/utils.spec.tsx
+++ b/src/utils.spec.tsx
@@ -8,6 +8,8 @@ import {
   ExternalChange,
   ExternalHunk,
   createInternalDiff,
+  createInternalVersionFile,
+  VersionFileWithDiff,
 } from './reducers/versions';
 import { getCodeLineAnchor } from './components/CodeView/utils';
 import {
@@ -31,12 +33,11 @@ import {
   shouldAllowSlowPages,
 } from './utils';
 import {
-  createFakeCompareInfo,
   createFakeHistory,
   createFakeLocation,
   fakeChange,
   fakeExternalDiff,
-  fakeVersionWithDiff,
+  fakeVersionFileWithDiff,
 } from './test-helpers';
 
 describe(__filename, () => {
@@ -297,50 +298,44 @@ describe(__filename, () => {
   });
 
   describe('createCodeLineAnchorGetter', () => {
-    it('returns getCodeLineAnchor if compareInfo is null', () => {
-      expect(createCodeLineAnchorGetter({ compareInfo: null })).toEqual(
-        getCodeLineAnchor,
-      );
+    it('returns getCodeLineAnchor if file is null', () => {
+      expect(createCodeLineAnchorGetter(null)).toEqual(getCodeLineAnchor);
     });
 
-    it('returns getCodeLineAnchor if compareInfo is undefined', () => {
-      expect(createCodeLineAnchorGetter({ compareInfo: undefined })).toEqual(
-        getCodeLineAnchor,
-      );
+    it('returns getCodeLineAnchor if file is undefined', () => {
+      expect(createCodeLineAnchorGetter(undefined)).toEqual(getCodeLineAnchor);
     });
 
-    it('returns getCodeLineAnchor if compareInfo.diff is falsey', () => {
+    it('returns getCodeLineAnchor if file.diff is falsey', () => {
       expect(
-        createCodeLineAnchorGetter({
-          compareInfo: createFakeCompareInfo({
-            version: {
-              ...fakeVersionWithDiff,
-              file: {
-                ...fakeVersionWithDiff.file,
-                diff: null,
-              },
-            },
-          }),
-        }),
+        createCodeLineAnchorGetter(
+          createInternalVersionFile({
+            ...fakeVersionFileWithDiff,
+            diff: null,
+          }) as VersionFileWithDiff,
+        ),
       ).toEqual(getCodeLineAnchor);
     });
 
-    it('returns getCodeLineAnchor from ForwardComparisonMap if compareInfo.diff exists', () => {
-      const compareInfo = createFakeCompareInfo();
-      if (!compareInfo.diff) {
-        throw new Error('compareInfo.diff was unexpectedly empty');
+    it('returns getCodeLineAnchor from ForwardComparisonMap if file.diff exists', () => {
+      const file = createInternalVersionFile(
+        fakeVersionFileWithDiff,
+      ) as VersionFileWithDiff;
+      if (!file.diff) {
+        throw new Error('file.diff was unexpectedly empty');
       }
 
-      const getterFromFactory = createCodeLineAnchorGetter({ compareInfo });
+      const getterFromFactory = createCodeLineAnchorGetter(file);
 
-      // Generate a getter without compareInfo to verify that it is different.
-      const getterFromFactoryWithoutCompareInfo = createCodeLineAnchorGetter({
-        compareInfo: null,
-      });
-
-      expect(getterFromFactory).not.toEqual(
-        getterFromFactoryWithoutCompareInfo,
+      // Generate a getter without a diff to verify that it is different.
+      const getterFromFactoryWithoutDiff = createCodeLineAnchorGetter(
+        createInternalVersionFile({
+          ...fakeVersionFileWithDiff,
+          diff: null,
+        }) as VersionFileWithDiff,
       );
+
+      expect(getterFromFactory).not.toEqual(getterFromFactoryWithoutDiff);
     });
   });
 

--- a/src/utils.spec.tsx
+++ b/src/utils.spec.tsx
@@ -312,7 +312,7 @@ describe(__filename, () => {
           createInternalVersionFile({
             ...fakeVersionFileWithDiff,
             diff: null,
-          }) as VersionFileWithDiff,
+          }),
         ),
       ).toEqual(getCodeLineAnchor);
     });
@@ -332,7 +332,7 @@ describe(__filename, () => {
         createInternalVersionFile({
           ...fakeVersionFileWithDiff,
           diff: null,
-        }) as VersionFileWithDiff,
+        }),
       );
 
       expect(getterFromFactory).not.toEqual(getterFromFactoryWithoutDiff);

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -7,7 +7,12 @@ import queryString from 'query-string';
 import log from 'loglevel';
 import { Hunks, ChangeInfo, DiffInfo, getChangeKey } from 'react-diff-view';
 
-import { changeTypes, CompareInfo } from './reducers/versions';
+import {
+  VersionFileWithContent,
+  VersionFileWithDiff,
+  changeTypes,
+  isFileWithDiff,
+} from './reducers/versions';
 import { getCodeLineAnchor } from './components/CodeView/utils';
 import tracking from './tracking';
 
@@ -259,13 +264,11 @@ export class ForwardComparisonMap {
   }
 }
 
-export const createCodeLineAnchorGetter = ({
-  compareInfo,
-}: {
-  compareInfo: CompareInfo | null | undefined;
-}) => {
-  if (compareInfo && compareInfo.diff) {
-    const map = new ForwardComparisonMap(compareInfo.diff);
+export const createCodeLineAnchorGetter = (
+  file: VersionFileWithContent | VersionFileWithDiff | null | undefined,
+) => {
+  if (file && isFileWithDiff(file) && file.diff) {
+    const map = new ForwardComparisonMap(file.diff);
     return map.createCodeLineAnchorGetter();
   }
   return getCodeLineAnchor;


### PR DESCRIPTION
Fixes #1599 
Fixes #1574 
Fixes #1327 

~~Depends on #1646~~

I realize that this is still a huge patch, but I have already spent a lot of time breaking a larger patch into smaller pieces, and I'm not sure I can reduce this one much more, as making the change impacts a lot of other areas. Probably the majority of the changes in this patch are to tests, but I know that doesn't make it any easier to review.

This patch finishes implementing everything we need to do the following:
1. Once a version is loaded, we will only retrieve the diff info for each subsequent file, rather than retrieving the entire version each time.
2. As a side effect of this change, we no longer need to also retrieve the contents of the file for the current version - we can get away with only retrieving the diff.

The site should continue to function exactly as it did before. There will just be fewer requests generated, and less data returned to the client.
 