### PR TITLE
Call validation endpoint the same way we call other APIs

### DIFF
--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -1145,11 +1145,21 @@ describe(__filename, () => {
 
   describe('getValidation', () => {
     it('calls the API to retrieve validation information', async () => {
-      const url = 'some-url';
+      const addonId = nextUniqueId();
+      const fileId = nextUniqueId();
 
-      await getValidation({ apiState: defaultApiState, url });
+      await getValidation({
+        apiState: defaultApiState,
+        addonId,
+        fileId,
+      });
 
-      expect(fetch).toHaveBeenCalledWith(url, expect.any(Object));
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(
+          `/api/${defaultVersion}/reviewers/addon/${addonId}/file/${fileId}/validation/`,
+        ),
+        expect.any(Object),
+      );
     });
   });
 });

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -545,13 +545,18 @@ export const deleteComment = async ({
 };
 
 type GetValidationParams = {
+  addonId: number;
   apiState: ApiState;
-  url: string;
+  fileId: number;
 };
 
-export const getValidation = async ({ apiState, url }: GetValidationParams) => {
+export const getValidation = async ({
+  addonId,
+  apiState,
+  fileId,
+}: GetValidationParams) => {
   return callApi<ResponseOnly<ExternalLinterResult>>({
     apiState,
-    endpointUrl: url,
+    endpoint: `reviewers/addon/${addonId}/file/${fileId}/validation/`,
   });
 };

--- a/src/components/CodeOverview/index.spec.tsx
+++ b/src/components/CodeOverview/index.spec.tsx
@@ -163,8 +163,7 @@ describe(__filename, () => {
     const root = render({ version });
 
     const provider = root.find(LinterProvider);
-    expect(provider).toHaveProp('versionId', version.id);
-    expect(provider).toHaveProp('validationURL', version.validationURL);
+    expect(provider).toHaveProp('version', version);
     expect(provider).toHaveProp('selectedPath', version.selectedPath);
   });
 

--- a/src/components/CodeOverview/index.tsx
+++ b/src/components/CodeOverview/index.tsx
@@ -337,8 +337,7 @@ export class CodeOverviewBase extends React.Component<Props, State> {
     return (
       <LinterProvider
         key={overviewHeight ? String(overviewHeight) : ''}
-        versionId={version.id}
-        validationURL={version.validationURL}
+        version={version}
         selectedPath={version.selectedPath}
       >
         {

--- a/src/components/CodeView/index.spec.tsx
+++ b/src/components/CodeView/index.spec.tsx
@@ -381,8 +381,7 @@ describe(__filename, () => {
     const root = render({ version });
 
     const provider = root.find(LinterProvider);
-    expect(provider).toHaveProp('versionId', version.id);
-    expect(provider).toHaveProp('validationURL', version.validationURL);
+    expect(provider).toHaveProp('version', version);
     expect(provider).toHaveProp('selectedPath', version.selectedPath);
   });
 

--- a/src/components/CodeView/index.tsx
+++ b/src/components/CodeView/index.tsx
@@ -273,11 +273,7 @@ export class CodeViewBase extends React.Component<Props> {
 
     return (
       <React.Profiler id="CodeView-Render" onRender={this.onRenderProfiler}>
-        <LinterProvider
-          versionId={version.id}
-          validationURL={version.validationURL}
-          selectedPath={version.selectedPath}
-        >
+        <LinterProvider version={version} selectedPath={version.selectedPath}>
           {
             // This needs to be an anonymous function (which defeats memoization)
             // so that the component gets re-rendered in the case of adding

--- a/src/components/DiffView/index.spec.tsx
+++ b/src/components/DiffView/index.spec.tsx
@@ -597,8 +597,7 @@ describe(__filename, () => {
     const root = render({ version });
 
     const provider = root.find(LinterProvider);
-    expect(provider).toHaveProp('versionId', version.id);
-    expect(provider).toHaveProp('validationURL', version.validationURL);
+    expect(provider).toHaveProp('version', version);
     expect(provider).toHaveProp('selectedPath', version.selectedPath);
   });
 

--- a/src/components/DiffView/index.tsx
+++ b/src/components/DiffView/index.tsx
@@ -515,11 +515,7 @@ export class DiffViewBase extends React.Component<Props> {
 
     return (
       <Profiler id="DiffView-Render" onRender={this.onRenderProfiler}>
-        <LinterProvider
-          versionId={version.id}
-          validationURL={version.validationURL}
-          selectedPath={version.selectedPath}
-        >
+        <LinterProvider version={version} selectedPath={version.selectedPath}>
           {this.renderWithMessages}
         </LinterProvider>
       </Profiler>

--- a/src/components/FileTreeNode/index.spec.tsx
+++ b/src/components/FileTreeNode/index.spec.tsx
@@ -13,8 +13,9 @@ import {
 } from '../../reducers/linter';
 import LinterProvider, { LinterProviderInfo } from '../LinterProvider';
 import {
-  actions as versionsActions,
   VersionEntryStatus,
+  actions as versionsActions,
+  createInternalVersion,
 } from '../../reducers/versions';
 import {
   createExternalVersionWithEntries,
@@ -820,10 +821,9 @@ describe(__filename, () => {
     const root = render({ store, versionId: externalVersion.id });
 
     const provider = root.find(LinterProvider);
-    expect(provider).toHaveProp('versionId', externalVersion.id);
     expect(provider).toHaveProp(
-      'validationURL',
-      externalVersion.validation_url_json,
+      'version',
+      createInternalVersion(externalVersion),
     );
     expect(provider).toHaveProp(
       'selectedPath',

--- a/src/components/FileTreeNode/index.tsx
+++ b/src/components/FileTreeNode/index.tsx
@@ -329,11 +329,7 @@ export class FileTreeNodeBase<TreeNodeType> extends React.Component<Props> {
     const { version } = this.props;
 
     return (
-      <LinterProvider
-        versionId={version.id}
-        validationURL={version.validationURL}
-        selectedPath={version.selectedPath}
-      >
+      <LinterProvider version={version} selectedPath={version.selectedPath}>
         {(info: LinterProviderInfo) => this.renderWithLinterInfo(info)}
       </LinterProvider>
     );

--- a/src/components/LinterProvider/index.spec.tsx
+++ b/src/components/LinterProvider/index.spec.tsx
@@ -42,8 +42,7 @@ describe(__filename, () => {
   }: RenderParams = {}) => {
     const props = {
       children,
-      versionId: version.id,
-      validationURL: version.validationURL,
+      version,
       selectedPath: version.selectedPath,
       ...moreProps,
     };
@@ -134,12 +133,7 @@ describe(__filename, () => {
   });
 
   it('dispatches fetchLinterMessagesIfNeeded when linterMessages is undefined', () => {
-    const url = '/path/to/validation.json';
-    const version = createInternalVersion({
-      ...fakeVersionWithContent,
-      id: fakeVersionWithContent.id + 1,
-      validation_url_json: url,
-    });
+    const version = createInternalVersion(fakeVersionWithContent);
 
     const {
       _fetchLinterMessagesIfNeeded,
@@ -151,8 +145,7 @@ describe(__filename, () => {
 
     expect(dispatch).toHaveBeenCalledWith(fakeThunk.thunk);
     expect(_fetchLinterMessagesIfNeeded).toHaveBeenCalledWith({
-      versionId: version.id,
-      url,
+      version,
     });
   });
 

--- a/src/components/LinterProvider/index.tsx
+++ b/src/components/LinterProvider/index.tsx
@@ -10,6 +10,7 @@ import {
   fetchLinterMessagesIfNeeded,
   selectMessageMap,
 } from '../../reducers/linter';
+import { Version } from '../../reducers/versions';
 
 export type LinterProviderInfo = {
   messageMap: LinterMessageMap | undefined;
@@ -24,8 +25,7 @@ export type RenderWithMessages = (info: LinterProviderInfo) => React.ReactNode;
 export type PublicProps = {
   _loadData?: LoadData;
   children: RenderWithMessages;
-  versionId: number;
-  validationURL: string;
+  version: Version;
   selectedPath: string;
 };
 
@@ -67,15 +67,13 @@ export class LinterProviderBase extends React.Component<Props> {
       _fetchLinterMessagesIfNeeded,
       dispatch,
       messageMap,
-      validationURL,
-      versionId,
+      version,
     } = this.props;
 
     if (messageMap === undefined) {
       dispatch(
         _fetchLinterMessagesIfNeeded({
-          versionId,
-          url: validationURL,
+          version,
         }),
       );
     }
@@ -98,10 +96,10 @@ const mapStateToProps = (
   // ownProps.location via withRouter(). See the comment below for details.
   ownProps: PublicProps & RouteComponentProps,
 ): PropsFromState => {
-  const { selectedPath, versionId } = ownProps;
+  const { selectedPath, version } = ownProps;
 
   let selectedMessageMap;
-  const map = selectMessageMap(state.linter, versionId);
+  const map = selectMessageMap(state.linter, version.id);
   if (map) {
     selectedMessageMap = map.byPath[selectedPath]
       ? map.byPath[selectedPath]

--- a/src/components/VersionFileViewer/index.spec.tsx
+++ b/src/components/VersionFileViewer/index.spec.tsx
@@ -265,8 +265,7 @@ describe(__filename, () => {
     const root = render({ compareInfo, version });
 
     const provider = root.find(LinterProvider);
-    expect(provider).toHaveProp('versionId', version.id);
-    expect(provider).toHaveProp('validationURL', version.validationURL);
+    expect(provider).toHaveProp('version', version);
     expect(provider).toHaveProp('selectedPath', version.selectedPath);
   });
 

--- a/src/components/VersionFileViewer/index.tsx
+++ b/src/components/VersionFileViewer/index.tsx
@@ -152,11 +152,7 @@ const VersionFileViewer = ({
   };
 
   return (
-    <LinterProvider
-      versionId={version.id}
-      validationURL={version.validationURL}
-      selectedPath={version.selectedPath}
-    >
+    <LinterProvider version={version} selectedPath={version.selectedPath}>
       {renderWithLinterProvider}
     </LinterProvider>
   );

--- a/src/reducers/linter.tsx
+++ b/src/reducers/linter.tsx
@@ -5,6 +5,7 @@ import { ActionType, deprecated, getType } from 'typesafe-actions';
 import { ThunkActionCreator } from '../configureStore';
 import { actions as errorsActions } from './errors';
 import { getValidation, isErrorResponse } from '../api';
+import { Version } from './versions';
 
 // See: https://github.com/piotrwitek/typesafe-actions/issues/143
 const { createAction } = deprecated;
@@ -195,17 +196,16 @@ export const actions = {
 
 export const fetchLinterMessagesIfNeeded = ({
   _getValidation = getValidation,
-  url,
-  versionId,
+  version,
 }: {
   _getValidation?: typeof getValidation;
-  url: string;
-  versionId: number;
+  version: Version;
 }): ThunkActionCreator => {
   return async (dispatch, getState) => {
     const { api: apiState, linter } = getState();
+    const versionId = version.id;
     // See: https://github.com/mozilla/addons-code-manager/issues/591
-    if (linter.isLoading && linter.forVersionId === versionId) {
+    if (linter.isLoading && linter.forVersionId === version.id) {
       log.debug('Aborting because linter messages are already being fetched');
       return;
     }
@@ -214,7 +214,8 @@ export const fetchLinterMessagesIfNeeded = ({
 
     const response = await _getValidation({
       apiState,
-      url,
+      addonId: version.addon.id,
+      fileId: version.fileId,
     });
 
     if (isErrorResponse(response)) {

--- a/src/reducers/versions.spec.tsx
+++ b/src/reducers/versions.spec.tsx
@@ -863,12 +863,12 @@ describe(__filename, () => {
         addon: createInternalVersionAddon(version.addon),
         entries: [createInternalVersionEntry(entry)],
         expandedPaths: getParentFolders(version.file.selected_file),
+        fileId: version.file.id,
         id: version.id,
         initialPath: version.file.selected_file,
         reviewed: version.reviewed,
         versionString: version.version,
         selectedPath: version.file.selected_file,
-        validationURL: fakeVersionWithContent.validation_url_json,
         visibleSelectedPath: null,
       });
     });

--- a/src/reducers/versions.tsx
+++ b/src/reducers/versions.tsx
@@ -201,9 +201,9 @@ export type Version = {
   addon: VersionAddon;
   initialPath: string;
   entries: VersionEntry[];
+  fileId: number;
   id: number;
   reviewed: string;
-  validationURL: string;
   versionString: string;
   // TODO: remove `expandedPaths`, `selectedPath` and `visibleSelectedPath`
   // from `version` object once no code depends on these
@@ -598,11 +598,11 @@ export const createInternalVersion = (
       return createInternalVersionEntry(version.file_entries[nodeName]);
     }),
     expandedPaths: getParentFolders(version.file.selected_file),
+    fileId: version.file.id,
     id: version.id,
     reviewed: version.reviewed,
     selectedPath: version.file.selected_file,
     versionString: version.version,
-    validationURL: version.validation_url_json,
     visibleSelectedPath: null,
   };
 };


### PR DESCRIPTION
Fixes #1631 

Note that in order to make the changes desired for #1631, the following additional changes were made, which make up the bulk of this patch:
- Change `LinterProvider` so that it accepts a `version` property, rather than `versionId` and `validationURL`.
- Change the `fetchLinterMessagesIfNeeded` reducer function so that it accepts a `version` argument, rather than `versionId` and `url`.
- Store a `fileId` as part of the internal `Version` type.

Note that this will need to be rebased after #1646 and #1647 land, and that will be much easier to do that the opposite (land this first and rebase those), so it probably makes sense to hold off on this one until those land.