### PR TITLE
Print node version when we build the docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,7 @@ jobs:
             docker login -u $DOCKER_USER -p $DOCKER_PASS
             docker build --pull -t addons-code-manager .
       - run: docker images
+      - run: docker run --rm addons-code-manager node --version
       - run:
           name: Write the sha256 sum to an artifact for verification
           command: |
@@ -187,6 +188,7 @@ jobs:
             docker login -u $DOCKER_USER -p $DOCKER_PASS
             docker build --pull -t addons-code-manager .
       - run: docker images
+      - run: docker run --rm addons-code-manager node --version
       - run:
           name: Write the sha256 sum to an artifact for verification
           command: |


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-code-manager/issues/2150