### PR TITLE
Use specific non-root user to run the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
-FROM node:16 AS builder
+FROM node:16-slim AS builder
 
 WORKDIR /app
 
 # Install the project's dependencies, including dev dependencies.
 COPY package.json yarn.lock ./
+
+# python and build-essential are needed or the `yarn install --pure-lockfile`
+# fails while trying to invoke `/app/node_modules/node-pty`.
+RUN apt-get update -y && apt-get install -y python3 build-essential 
 RUN yarn install --pure-lockfile --production=false
 
-FROM node:16
+FROM node:16-slim
 
 ARG olympia_uid=9500
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+#
+# Build
+#
 FROM node:16-slim AS builder
 
 WORKDIR /app
@@ -7,24 +10,33 @@ COPY package.json yarn.lock ./
 
 # python and build-essential are needed or the `yarn install --pure-lockfile`
 # fails while trying to invoke `/app/node_modules/node-pty`.
-RUN apt-get update -y && apt-get install -y python3 build-essential 
+RUN apt-get update -y && apt-get install -y python3 build-essential
 RUN yarn install --pure-lockfile --production=false
 
+#
+# Install
+#
 FROM node:16-slim
 
 ARG olympia_uid=9500
+ARG work_dir=/app
 
 ENV NODE_ENV production
 ENV SERVER_HOST 0.0.0.0
 ENV PORT 4000
 
 RUN useradd -u ${olympia_uid} -d /home/olympia -m -s /sbin/nologin olympia
+# The WORKDIR directive set the ownership of the work directory to root instead
+# of USER unless the "buildkit" feature is enabled. To make sure the work
+# directory is owned by the proper user for everybody, we manually set the
+# ownership.
+RUN mkdir -p ${work_dir} && chown ${olympia_uid}:${olympia_uid} ${work_dir}
+
+WORKDIR ${work_dir}
 
 USER ${olympia_uid}:${olympia_uid}
 
-WORKDIR /app
-
-COPY --from=builder --chown=${olympia_uid}:${olympia_uid} /app/ .
+COPY --from=builder --chown=${olympia_uid}:${olympia_uid} ${work_dir}/ .
 COPY --chown=${olympia_uid}:${olympia_uid} . .
 
 CMD yarn start

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
+FROM node:16 AS builder
+
+WORKDIR /app
+
+# Install the project's dependencies, including dev dependencies.
+COPY package.json yarn.lock ./
+RUN yarn install --pure-lockfile --production=false
+
 FROM node:16
 
 ARG olympia_uid=9500
@@ -6,16 +14,13 @@ ENV NODE_ENV production
 ENV SERVER_HOST 0.0.0.0
 ENV PORT 4000
 
-RUN useradd -u ${olympia_uid} -s /sbin/nologin olympia
+RUN useradd -u ${olympia_uid} -d /home/olympia -m -s /sbin/nologin olympia
 
 USER ${olympia_uid}:${olympia_uid}
 
 WORKDIR /app
 
-# Install the project's dependencies, including dev dependencies.
-COPY package.json yarn.lock ./
-RUN yarn install --pure-lockfile --production=false
-
+COPY --from=builder --chown=${olympia_uid}:${olympia_uid} /app/ .
 COPY --chown=${olympia_uid}:${olympia_uid} . .
 
 CMD yarn start

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN yarn install --pure-lockfile --production=false
 FROM node:16-slim
 
 ARG olympia_uid=9500
-ARG work_dir=/app
+ARG app_dir=/app
 
 ENV NODE_ENV production
 ENV SERVER_HOST 0.0.0.0
@@ -30,13 +30,13 @@ RUN useradd -u ${olympia_uid} -d /home/olympia -m -s /sbin/nologin olympia
 # of USER unless the "buildkit" feature is enabled. To make sure the work
 # directory is owned by the proper user for everybody, we manually set the
 # ownership.
-RUN mkdir -p ${work_dir} && chown ${olympia_uid}:${olympia_uid} ${work_dir}
+RUN mkdir -p ${app_dir} && chown ${olympia_uid}:${olympia_uid} ${app_dir}
 
-WORKDIR ${work_dir}
+WORKDIR ${app_dir}
 
 USER ${olympia_uid}:${olympia_uid}
 
-COPY --from=builder --chown=${olympia_uid}:${olympia_uid} ${work_dir}/ .
+COPY --from=builder --chown=${olympia_uid}:${olympia_uid} ${app_dir}/ .
 COPY --chown=${olympia_uid}:${olympia_uid} . .
 
 CMD yarn start

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,25 +18,25 @@ RUN yarn install --pure-lockfile --production=false
 #
 FROM node:16-slim
 
-ARG olympia_uid=9500
+ARG runas_id=9500
 ARG app_dir=/app
 
 ENV NODE_ENV production
 ENV SERVER_HOST 0.0.0.0
 ENV PORT 4000
 
-RUN useradd -u ${olympia_uid} -d /home/olympia -m -s /sbin/nologin olympia
+RUN useradd -u ${runas_id} -d /home/olympia -m -s /sbin/nologin olympia
 # The WORKDIR directive set the ownership of the work directory to root instead
 # of USER unless the "buildkit" feature is enabled. To make sure the work
 # directory is owned by the proper user for everybody, we manually set the
 # ownership.
-RUN mkdir -p ${app_dir} && chown ${olympia_uid}:${olympia_uid} ${app_dir}
+RUN mkdir -p ${app_dir} && chown ${runas_id}:${runas_id} ${app_dir}
 
 WORKDIR ${app_dir}
 
-USER ${olympia_uid}:${olympia_uid}
+USER ${runas_id}:${runas_id}
 
-COPY --from=builder --chown=${olympia_uid}:${olympia_uid} ${app_dir}/ .
-COPY --chown=${olympia_uid}:${olympia_uid} . .
+COPY --from=builder --chown=${runas_id}:${runas_id} ${app_dir}/ .
+COPY --chown=${runas_id}:${runas_id} . .
 
 CMD yarn start

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,25 +18,25 @@ RUN yarn install --pure-lockfile --production=false
 #
 FROM node:16-slim
 
-ARG runas_id=9500
+ARG app_uid=9500
 ARG app_dir=/app
 
 ENV NODE_ENV production
 ENV SERVER_HOST 0.0.0.0
 ENV PORT 4000
 
-RUN useradd -u ${runas_id} -d /home/olympia -m -s /sbin/nologin olympia
+RUN useradd -u ${app_uid} -d /home/app -m -s /sbin/nologin app
 # The WORKDIR directive set the ownership of the work directory to root instead
 # of USER unless the "buildkit" feature is enabled. To make sure the work
 # directory is owned by the proper user for everybody, we manually set the
 # ownership.
-RUN mkdir -p ${app_dir} && chown ${runas_id}:${runas_id} ${app_dir}
+RUN mkdir -p ${app_dir} && chown ${app_uid}:${app_uid} ${app_dir}
 
 WORKDIR ${app_dir}
 
-USER ${runas_id}:${runas_id}
+USER ${app_uid}:${app_uid}
 
-COPY --from=builder --chown=${runas_id}:${runas_id} ${app_dir}/ .
-COPY --chown=${runas_id}:${runas_id} . .
+COPY --from=builder --chown=${app_uid}:${app_uid} ${app_dir}/ .
+COPY --chown=${app_uid}:${app_uid} . .
 
 CMD yarn start

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM node:16
 
+ARG olympia_uid=9500
+
 ENV NODE_ENV production
 ENV SERVER_HOST 0.0.0.0
 ENV PORT 4000
+
+RUN useradd -u ${olympia_uid} -s /sbin/nologin olympia
+
+USER ${olympia_uid}:${olympia_uid}
 
 WORKDIR /app
 
@@ -10,6 +16,6 @@ WORKDIR /app
 COPY package.json yarn.lock ./
 RUN yarn install --pure-lockfile --production=false
 
-COPY . .
+COPY --chown=${olympia_uid}:${olympia_uid} . .
 
 CMD yarn start


### PR DESCRIPTION
The purpose of this PR is to make it possible to run the docker image as a non-root user.

- [X] This PR relates to an existing open issue and there are no existing PRs open for the same issue.
- [X] Add a description of the changes introduced in this PR.
- [X] The change has been successfully run locally.

Fixes #2181