### PR TITLE
Generate assets at the image build time #2212

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ COPY package.json yarn.lock ./
 RUN apt-get update -y && apt-get install -y python3 build-essential
 RUN yarn install --pure-lockfile --production=false
 
+# Build the application
+RUN yarn build
+
 #
 # Install
 #


### PR DESCRIPTION
- No open PR for this issue
- Fixed the docker file to modified the builder stage to include a yarn build command. This way, the application will be built 
-  during the image build process.
- I have run this locally

Fixes  #2212
