### PR TITLE
Switch ubuntu image to 2004:current (ubuntu-2004:202201-02 is deprecated)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ references:
 
   defaults-release: &defaults-release
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2004:current
     working_directory: ~/addons-code-manager
 
   restore_build_cache: &restore_build_cache


### PR DESCRIPTION
Relates to https://github.com/mozilla/addons/issues/1565

We don't currently actively maintain this repos but it's best to ensure future builds will work...

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/ADDCDMGR-508)
